### PR TITLE
Add define to enable GeoIP

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -84,6 +84,7 @@ have_geoip=no
 AS_IF([test x$with_libgeoip != xno], [
 	PKG_CHECK_MODULES([GEOIP], [geoip], [
 		have_geoip="yes"
+		AC_DEFINE(HAVE_GEOIP, 1, [Define if GeoIP is available])
 	], [
 		AC_MSG_WARN([libgeoip not found])
 	])


### PR DESCRIPTION
Fixes #57

When trying to understand why it happens, I noticed that `ldd` doesn't report that libGeoIP is linked to a resulting binary and transmission-remote-gtk behaves as if HAVE_GEOIP isn't defined. Well, this is my best guess of how to fix it (not sure if it's right as I have little to no experience in C and its tools).