### PR TITLE
Fix for General download/upload speed cannot be set in preferences #56.

### DIFF
--- a/src/trg-json-widgets.c
+++ b/src/trg-json-widgets.c
@@ -128,9 +128,8 @@ GtkWidget *trg_json_widget_spin_new(GList ** wl, JsonObject * obj,
 {
     GtkWidget *w = gtk_spin_button_new_with_range(min, max, step);
     trg_json_widget_desc *wd = g_new0(trg_json_widget_desc, 1);
-    JsonNode *node = json_object_get_member(obj, key);
 
-    wd->saveFunc = trg_json_widget_spin_save_double;
+    wd->saveFunc = trg_json_widget_spin_save_int;
     wd->key = g_strdup(key);
     wd->widget = w;
 
@@ -143,7 +142,7 @@ GtkWidget *trg_json_widget_spin_new(GList ** wl, JsonObject * obj,
     }
 
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(w),
-                              json_node_really_get_double(node));
+                              (double)json_object_get_int_member(obj, key));
 
     *wl = g_list_append(*wl, wd);
 
@@ -168,10 +167,10 @@ trg_json_widget_entry_save(GtkWidget * widget, JsonObject * obj,
 }
 
 void
-trg_json_widget_spin_save_double(GtkWidget * widget, JsonObject * obj,
+trg_json_widget_spin_save_int(GtkWidget * widget, JsonObject * obj,
                                  gchar * key)
 {
-    json_object_set_double_member(obj, key,
-                                  gtk_spin_button_get_value(GTK_SPIN_BUTTON
+    json_object_set_int_member(obj, key,
+                                  gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON
                                                             (widget)));
 }

--- a/src/trg-json-widgets.c
+++ b/src/trg-json-widgets.c
@@ -28,6 +28,8 @@
 #include "json.h"
 #include "util.h"
 
+#define TRG_JSON_WIDGET_SPIN_DOUBLE_DIGITS 2
+
 /* Functions for creating widgets that load/save their state from/to a JSON
  * object. This is used by the torrent properties and remote settings dialogs.
  * The pattern here is farily similar to that used in local configuration,
@@ -121,15 +123,20 @@ GtkWidget *trg_json_widget_entry_new(GList ** wl, JsonObject * obj,
     return w;
 }
 
-GtkWidget *trg_json_widget_spin_new(GList ** wl, JsonObject * obj,
+GtkWidget *trg_json_widget_spin_int_new(GList ** wl, JsonObject * obj,
                                     const gchar * key,
-                                    GtkWidget * toggleDep, gdouble min,
-                                    gdouble max, gdouble step)
+                                    GtkWidget * toggleDep, gint min,
+                                    gint max, gint step)
 {
-    GtkWidget *w = gtk_spin_button_new_with_range(min, max, step);
+    GtkWidget *w = gtk_spin_button_new_with_range((gdouble)min,
+                                                  (gdouble)max,
+                                                  (gdouble)step);
+
+    gtk_spin_button_set_digits(GTK_SPIN_BUTTON(w), 0);
+
     trg_json_widget_desc *wd = g_new0(trg_json_widget_desc, 1);
 
-    wd->saveFunc = trg_json_widget_spin_save_int;
+    wd->saveFunc = trg_json_widget_spin_int_save;
     wd->key = g_strdup(key);
     wd->widget = w;
 
@@ -143,6 +150,38 @@ GtkWidget *trg_json_widget_spin_new(GList ** wl, JsonObject * obj,
 
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(w),
                               (double)json_object_get_int_member(obj, key));
+
+    *wl = g_list_append(*wl, wd);
+
+    return w;
+}
+
+GtkWidget *trg_json_widget_spin_double_new(GList ** wl, JsonObject * obj,
+                                    const gchar * key,
+                                    GtkWidget * toggleDep, gdouble min,
+                                    gdouble max, gdouble step)
+{
+    GtkWidget *w = gtk_spin_button_new_with_range(min, max, step);
+
+    gtk_spin_button_set_digits(GTK_SPIN_BUTTON(w),
+                               TRG_JSON_WIDGET_SPIN_DOUBLE_DIGITS);
+
+    trg_json_widget_desc *wd = g_new0(trg_json_widget_desc, 1);
+
+    wd->saveFunc = trg_json_widget_spin_double_save;
+    wd->key = g_strdup(key);
+    wd->widget = w;
+
+    if (toggleDep) {
+        gtk_widget_set_sensitive(w,
+                                 gtk_toggle_button_get_active
+                                 (GTK_TOGGLE_BUTTON(toggleDep)));
+        g_signal_connect(G_OBJECT(toggleDep), "toggled",
+                         G_CALLBACK(toggle_active_arg_is_sensitive), w);
+    }
+
+    gtk_spin_button_set_value(GTK_SPIN_BUTTON(w),
+                              json_object_get_double_member(obj, key));
 
     *wl = g_list_append(*wl, wd);
 
@@ -167,10 +206,19 @@ trg_json_widget_entry_save(GtkWidget * widget, JsonObject * obj,
 }
 
 void
-trg_json_widget_spin_save_int(GtkWidget * widget, JsonObject * obj,
+trg_json_widget_spin_int_save(GtkWidget * widget, JsonObject * obj,
                                  gchar * key)
 {
     json_object_set_int_member(obj, key,
-                                  gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON
+                               gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON
+                                                                (widget)));
+}
+
+void
+trg_json_widget_spin_double_save(GtkWidget * widget, JsonObject * obj,
+                                 gchar * key)
+{
+    json_object_set_double_member(obj, key,
+                                  gtk_spin_button_get_value(GTK_SPIN_BUTTON
                                                             (widget)));
 }

--- a/src/trg-json-widgets.c
+++ b/src/trg-json-widgets.c
@@ -28,8 +28,6 @@
 #include "json.h"
 #include "util.h"
 
-#define TRG_JSON_WIDGET_SPIN_DOUBLE_DIGITS 2
-
 /* Functions for creating widgets that load/save their state from/to a JSON
  * object. This is used by the torrent properties and remote settings dialogs.
  * The pattern here is farily similar to that used in local configuration,
@@ -162,9 +160,6 @@ GtkWidget *trg_json_widget_spin_double_new(GList ** wl, JsonObject * obj,
                                     gdouble max, gdouble step)
 {
     GtkWidget *w = gtk_spin_button_new_with_range(min, max, step);
-
-    gtk_spin_button_set_digits(GTK_SPIN_BUTTON(w),
-                               TRG_JSON_WIDGET_SPIN_DOUBLE_DIGITS);
 
     trg_json_widget_desc *wd = g_new0(trg_json_widget_desc, 1);
 

--- a/src/trg-json-widgets.h
+++ b/src/trg-json-widgets.h
@@ -38,17 +38,21 @@ GtkWidget *trg_json_widget_check_new(GList ** wl, JsonObject * obj,
 GtkWidget *trg_json_widget_entry_new(GList ** wl, JsonObject * obj,
                                      const gchar * key,
                                      GtkWidget * toggleDep);
-GtkWidget *trg_json_widget_spin_new(GList ** wl, JsonObject * obj,
-                                    const gchar * key,
-                                    GtkWidget * toggleDep, gdouble min,
-                                    gdouble max, gdouble step);
+GtkWidget *trg_json_widget_spin_int_new(GList ** wl, JsonObject * obj,
+                                        const gchar * key,
+                                        GtkWidget * toggleDep, gint min,
+                                        gint max, gint step);
+GtkWidget *trg_json_widget_spin_double_new(GList ** wl, JsonObject * obj,
+                                           const gchar * key,
+                                           GtkWidget * toggleDep, gdouble min,
+                                           gdouble max, gdouble step);
 void trg_json_widget_check_save(GtkWidget * widget, JsonObject * obj,
                                 gchar * key);
 void trg_json_widget_entry_save(GtkWidget * widget, JsonObject * obj,
                                 gchar * key);
-void trg_json_widget_spin_save_int(GtkWidget * widget, JsonObject * obj,
+void trg_json_widget_spin_int_save(GtkWidget * widget, JsonObject * obj,
                                    gchar * key);
-void trg_json_widget_spin_save_double(GtkWidget * widget, JsonObject * obj,
+void trg_json_widget_spin_double_save(GtkWidget * widget, JsonObject * obj,
                                       gchar * key);
 
 void trg_json_widget_desc_free(trg_json_widget_desc * wd);

--- a/src/trg-remote-prefs-dialog.c
+++ b/src/trg-remote-prefs-dialog.c
@@ -279,8 +279,8 @@ static GtkWidget *trg_rprefs_alt_speed_spin_new(GList ** wl,
                                                 GtkWidget * alt_check,
                                                 GtkWidget * alt_time_check)
 {
-    GtkWidget *w = trg_json_widget_spin_new(wl, obj, key,
-                                            NULL, 0, INT_MAX, 5);
+    GtkWidget *w = trg_json_widget_spin_int_new(wl, obj, key,
+                                                NULL, 0, INT_MAX, 5);
     gtk_widget_set_sensitive(w,
                              gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON
                                                           (alt_check))
@@ -311,15 +311,15 @@ static GtkWidget *trg_rprefs_bandwidthPage(TrgRemotePrefsDialog * win,
     tb = trg_json_widget_check_new(&priv->widgets, json,
                                    SGET_SPEED_LIMIT_DOWN_ENABLED,
                                    _("Down Limit (KiB/s)"), NULL);
-    w = trg_json_widget_spin_new(&priv->widgets, json,
-                                 SGET_SPEED_LIMIT_DOWN, tb, 0, INT_MAX, 5);
+    w = trg_json_widget_spin_int_new(&priv->widgets, json,
+                                     SGET_SPEED_LIMIT_DOWN, tb, 0, INT_MAX, 5);
     hig_workarea_add_row_w(t, &row, tb, w, NULL);
 
     tb = trg_json_widget_check_new(&priv->widgets, json,
                                    SGET_SPEED_LIMIT_UP_ENABLED,
                                    _("Up Limit (KiB/s)"), NULL);
-    w = trg_json_widget_spin_new(&priv->widgets, json, SGET_SPEED_LIMIT_UP,
-                                 tb, 0, INT_MAX, 5);
+    w = trg_json_widget_spin_int_new(&priv->widgets, json, SGET_SPEED_LIMIT_UP,
+                                     tb, 0, INT_MAX, 5);
     hig_workarea_add_row_w(t, &row, tb, w, NULL);
 
     hig_workarea_add_section_title(t, &row, _("Alternate limits"));
@@ -366,9 +366,9 @@ static GtkWidget *trg_rprefs_limitsPage(TrgRemotePrefsDialog * win,
     tb = trg_json_widget_check_new(&priv->widgets, json,
                                    SGET_SEED_RATIO_LIMITED,
                                    _("Seed ratio limit"), NULL);
-    w = trg_json_widget_spin_new(&priv->widgets, json,
-                                 SGET_SEED_RATIO_LIMIT, tb, 0, INT_MAX,
-                                 0.1);
+    w = trg_json_widget_spin_double_new(&priv->widgets, json,
+                                        SGET_SEED_RATIO_LIMIT, tb,
+                                        0, INT_MAX, 0.1);
     hig_workarea_add_row_w(t, &row, tb, w, NULL);
 
     if (json_object_has_member(json, SGET_DOWNLOAD_QUEUE_ENABLED)) {
@@ -377,39 +377,39 @@ static GtkWidget *trg_rprefs_limitsPage(TrgRemotePrefsDialog * win,
         tb = trg_json_widget_check_new(&priv->widgets, json,
                                        SGET_DOWNLOAD_QUEUE_ENABLED,
                                        _("Download queue size"), NULL);
-        w = trg_json_widget_spin_new(&priv->widgets, json,
-                                     SGET_DOWNLOAD_QUEUE_SIZE, tb, 0,
-                                     INT_MAX, 1);
+        w = trg_json_widget_spin_int_new(&priv->widgets, json,
+                                         SGET_DOWNLOAD_QUEUE_SIZE, tb, 0,
+                                         INT_MAX, 1);
         hig_workarea_add_row_w(t, &row, tb, w, NULL);
 
         tb = trg_json_widget_check_new(&priv->widgets, json,
                                        SGET_SEED_QUEUE_ENABLED,
                                        _("Seed queue size"), NULL);
-        w = trg_json_widget_spin_new(&priv->widgets, json,
-                                     SGET_SEED_QUEUE_SIZE, tb, 0, INT_MAX,
-                                     1);
+        w = trg_json_widget_spin_int_new(&priv->widgets, json,
+                                         SGET_SEED_QUEUE_SIZE, tb, 0,
+                                         INT_MAX, 1);
         hig_workarea_add_row_w(t, &row, tb, w, NULL);
 
         tb = trg_json_widget_check_new(&priv->widgets, json,
                                        SGET_QUEUE_STALLED_ENABLED,
                                        _("Ignore stalled (minutes)"),
                                        NULL);
-        w = trg_json_widget_spin_new(&priv->widgets, json,
-                                     SGET_QUEUE_STALLED_MINUTES, tb, 0,
-                                     INT_MAX, 1);
+        w = trg_json_widget_spin_int_new(&priv->widgets, json,
+                                         SGET_QUEUE_STALLED_MINUTES, tb,
+                                          0, INT_MAX, 1);
         hig_workarea_add_row_w(t, &row, tb, w, NULL);
     }
 
     hig_workarea_add_section_title(t, &row, _("Peers"));
 
-    w = trg_json_widget_spin_new(&priv->widgets, json,
-                                 SGET_PEER_LIMIT_GLOBAL, NULL, 0, INT_MAX,
-                                 5);
+    w = trg_json_widget_spin_int_new(&priv->widgets, json,
+                                     SGET_PEER_LIMIT_GLOBAL, NULL, 0,
+                                     INT_MAX, 5);
     hig_workarea_add_row(t, &row, _("Global peer limit"), w, w);
 
-    w = trg_json_widget_spin_new(&priv->widgets, json,
-                                 SGET_PEER_LIMIT_PER_TORRENT, NULL, 0,
-                                 INT_MAX, 5);
+    w = trg_json_widget_spin_int_new(&priv->widgets, json,
+                                     SGET_PEER_LIMIT_PER_TORRENT, NULL,
+                                     0, INT_MAX, 5);
     hig_workarea_add_row(t, &row, _("Per torrent peer limit"), w, w);
 
     return t;
@@ -519,8 +519,8 @@ static GtkWidget *trg_rprefs_connPage(TrgRemotePrefsDialog * win,
 
     hig_workarea_add_section_title(t, &row, _("Connections"));
 
-    w = trg_json_widget_spin_new(&priv->widgets, s, SGET_PEER_PORT, NULL,
-                                 0, 65535, 1);
+    w = trg_json_widget_spin_int_new(&priv->widgets, s, SGET_PEER_PORT,
+                                     NULL, 0, 65535, 1);
     hig_workarea_add_row(t, &row, _("Peer port"), w, w);
 
     priv->port_test_label = gtk_label_new(_("Port test"));
@@ -627,8 +627,8 @@ static GtkWidget *trg_rprefs_generalPage(TrgRemotePrefsDialog * win,
 
     cache_size_mb = session_get_cache_size_mb(s);
     if (cache_size_mb >= 0) {
-        w = trg_json_widget_spin_new(&priv->widgets, s, SGET_CACHE_SIZE_MB,
-                                     NULL, 0, INT_MAX, 1);
+        w = trg_json_widget_spin_int_new(&priv->widgets, s, SGET_CACHE_SIZE_MB,
+                                         NULL, 0, INT_MAX, 1);
         hig_workarea_add_row(t, &row, _("Cache size (MiB)"), w, w);
     }
 

--- a/src/trg-remote-prefs-dialog.c
+++ b/src/trg-remote-prefs-dialog.c
@@ -180,13 +180,13 @@ trg_rprefs_time_widget_savefunc(GtkWidget * w, JsonObject * obj,
 {
     GtkWidget *hourSpin = g_object_get_data(G_OBJECT(w), "hours-spin");
     GtkWidget *minutesSpin = g_object_get_data(G_OBJECT(w), "mins-spin");
-    gdouble hoursValue =
-        gtk_spin_button_get_value(GTK_SPIN_BUTTON(hourSpin));
-    gdouble minutesValue =
-        gtk_spin_button_get_value(GTK_SPIN_BUTTON(minutesSpin));
+    gint hoursValue =
+        gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON(hourSpin));
+    gint minutesValue =
+        gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON(minutesSpin));
 
     json_object_set_int_member(obj, key,
-                               (gint64) ((hoursValue * 60.0) +
+                               (gint64) ((hoursValue * 60) +
                                          minutesValue));
 
 }

--- a/src/trg-torrent-props-dialog.c
+++ b/src/trg-torrent-props-dialog.c
@@ -422,9 +422,9 @@ static GtkWidget *trg_props_limits_page_new(TrgTorrentPropsDialog * win,
     hig_workarea_add_row(t, &row, _("Torrent priority:"), w, NULL);
 
     if (json_object_has_member(json, FIELD_QUEUE_POSITION)) {
-        w = trg_json_widget_spin_new(&priv->widgets, json,
-                                     FIELD_QUEUE_POSITION, NULL, 0,
-                                     INT_MAX, 1);
+        w = trg_json_widget_spin_int_new(&priv->widgets, json,
+                                         FIELD_QUEUE_POSITION, NULL, 0,
+                                         INT_MAX, 1);
         hig_workarea_add_row(t, &row, _("Queue Position:"), w, w);
     }
 
@@ -432,15 +432,15 @@ static GtkWidget *trg_props_limits_page_new(TrgTorrentPropsDialog * win,
                                    FIELD_DOWNLOAD_LIMITED,
                                    _("Limit download speed (KiB/s)"),
                                    NULL);
-    w = trg_json_widget_spin_new(&priv->widgets, json,
-                                 FIELD_DOWNLOAD_LIMIT, tb, 0, INT_MAX, 1);
+    w = trg_json_widget_spin_int_new(&priv->widgets, json,
+                                     FIELD_DOWNLOAD_LIMIT, tb, 0, INT_MAX, 1);
     hig_workarea_add_row_w(t, &row, tb, w, NULL);
 
     tb = trg_json_widget_check_new(&priv->widgets, json,
                                    FIELD_UPLOAD_LIMITED,
                                    _("Limit upload speed (KiB/s)"), NULL);
-    w = trg_json_widget_spin_new(&priv->widgets, json, FIELD_UPLOAD_LIMIT,
-                                 tb, 0, INT_MAX, 1);
+    w = trg_json_widget_spin_int_new(&priv->widgets, json, FIELD_UPLOAD_LIMIT,
+                                     tb, 0, INT_MAX, 1);
     hig_workarea_add_row_w(t, &row, tb, w, NULL);
 
     hig_workarea_add_section_title(t, &row, _("Seeding"));
@@ -453,9 +453,9 @@ static GtkWidget *trg_props_limits_page_new(TrgTorrentPropsDialog * win,
                              torrent_get_seed_ratio_mode(json));
     hig_workarea_add_row(t, &row, _("Seed ratio mode:"), w, NULL);
 
-    w = trg_json_widget_spin_new(&priv->widgets, json,
-                                 FIELD_SEED_RATIO_LIMIT, NULL, 0, INT_MAX,
-                                 0.2);
+    w = trg_json_widget_spin_double_new(&priv->widgets, json,
+                                        FIELD_SEED_RATIO_LIMIT, NULL, 0,
+                                        INT_MAX, 0.2);
     seed_ratio_mode_changed_cb(priv->seedRatioMode, w);
     g_signal_connect(G_OBJECT(priv->seedRatioMode), "changed",
                      G_CALLBACK(seed_ratio_mode_changed_cb), w);
@@ -463,8 +463,8 @@ static GtkWidget *trg_props_limits_page_new(TrgTorrentPropsDialog * win,
 
     hig_workarea_add_section_title(t, &row, _("Peers"));
 
-    w = trg_json_widget_spin_new(&priv->widgets, json, FIELD_PEER_LIMIT,
-                                 NULL, 0, INT_MAX, 5);
+    w = trg_json_widget_spin_int_new(&priv->widgets, json, FIELD_PEER_LIMIT,
+                                     NULL, 0, INT_MAX, 5);
     hig_workarea_add_row(t, &row, _("Peer limit:"), w, w);
 
     return t;


### PR DESCRIPTION
#56.

I can't find any spinners that actually represent doubles, so just changed it to use ints instead

Have not found any side effects.

