### PR TITLE
Change links from google code to github

### DIFF
--- a/src/transmission-remote-gtk.pod
+++ b/src/transmission-remote-gtk.pod
@@ -40,7 +40,7 @@ Written by Alan Fitton.
 
 =head1 BUGS
 
-Please see L<http://code.google.com/p/transmission-remote-gtk/issues>
+Please see L<https://github.com/transmission-remote-gtk/transmission-remote-gtk/issues>
 
 =head1 COPYRIGHT
 
@@ -51,7 +51,7 @@ permitted by law.
 
 =head1 SEE ALSO
 
-C<transmission-daemon(1)>, C<transmission-gtk(1)>, the project website C<http://code.google.com/p/transmission-remote-gtk/>
+C<transmission-daemon(1)>, C<transmission-gtk(1)>, the project website C<https://github.com/transmission-remote-gtk/transmission-remote-gtk>
 
 =cut
 

--- a/src/trg-about-window.c
+++ b/src/trg-about-window.c
@@ -59,9 +59,9 @@ GtkWidget *trg_about_window_new(GtkWindow * parent)
                                   ("A remote client to transmission-daemon."));
 
     gtk_about_dialog_set_website(GTK_ABOUT_DIALOG(dialog),
-                                 "http://code.google.com/p/transmission-remote-gtk/");
+                                 "https://github.com/transmission-remote-gtk/transmission-remote-gtk");
     gtk_about_dialog_set_website_label(GTK_ABOUT_DIALOG(dialog),
-                                       "http://code.google.com/p/transmission-remote-gtk/");
+                                       "https://github.com/transmission-remote-gtk/transmission-remote-gtk");
 
     gtk_about_dialog_set_authors(GTK_ABOUT_DIALOG(dialog), trgAuthors);
     /*gtk_about_dialog_set_documenters(GTK_ABOUT_DIALOG(dialog), documenters); */


### PR DESCRIPTION
Trivial thing but still: "About" dialog shows links to Google Code that seized to exist. It redirects to Github but it probably won't do it forever :)