### PR TITLE
Parse headers case insensitively

### DIFF
--- a/src/trg-client.c
+++ b/src/trg-client.c
@@ -478,7 +478,8 @@ header_callback(void *ptr, size_t size, size_t nmemb, void *data)
     TrgClient *tc = TRG_CLIENT(data);
     gchar *session_id;
 
-    if (g_str_has_prefix(header, X_TRANSMISSION_SESSION_ID_HEADER_PREFIX)) {
+    if (g_ascii_strncasecmp(header, X_TRANSMISSION_SESSION_ID_HEADER_PREFIX,
+            strlen(X_TRANSMISSION_SESSION_ID_HEADER_PREFIX)) == 0) {
         char *nl;
 
         session_id = g_strdup(header);


### PR DESCRIPTION
if a reverse proxy lowers header names, TRG will not parse them properly and return a 409 conflict. So I attempted to fix this by first lowering the header, and then comparing it to a lowercase x-transmission-session-id. 

I got some feedback to make sure this looked safe as well as not leaking any memory, but I am not a C programmer so I could have easily done something wrong.

