### PR TITLE
Bump version to 1.4.1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -19,7 +19,7 @@ dnl
 
 AC_PREREQ([2.69])
 
-AC_INIT([transmission-remote-gtk], [1.4.0],
+AC_INIT([transmission-remote-gtk], [1.4.1],
         [https://github.com/transmission-remote-gtk/transmission-remote-gtk/issues])
 AC_CONFIG_SRCDIR([src/main.c])
 AC_CONFIG_HEADERS([config.h])

--- a/data/io.github.TransmissionRemoteGtk.appdata.xml.in
+++ b/data/io.github.TransmissionRemoteGtk.appdata.xml.in
@@ -28,6 +28,14 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="1.4.1" date="2018-12-29">
+      <description>
+        <p>This is a minor release with one bugfix:</p>
+        <ul>
+          <li>Fix error when connecting to daemon behind a proxy, specifically nginx</li>
+        </ul>
+      </description>
+    </release>
     <release version="1.4.0" date="2018-11-02">
       <description>
         <p>This is a minor release with some improvements:</p>


### PR DESCRIPTION
Please bump the version to push latest bugfix to the debian repo. Currently it is impossible to use unpatched transmission-remote-gtk against nginx-fronted transmission.