### PR TITLE
Fix building under GCC 10 / -fno-common

### DIFF
--- a/src/trg-tree-view.h
+++ b/src/trg-tree-view.h
@@ -51,7 +51,7 @@ GtkWidget *trg_tree_view_new(void);
 
 G_END_DECLS GList *trg_tree_view_get_selected_refs_list(GtkTreeView * tv);
 
-enum {
+typedef enum {
     TRG_COLTYPE_ICONTEXT,
     TRG_COLTYPE_FILEICONTEXT,
     TRG_COLTYPE_WANTED,


### PR DESCRIPTION
Fix building under GCC 10 / -fno-common

* Add a `typedef` to avoid defining a variable.

Bug: https://bugs.gentoo.org/706980