### PR TITLE
Enable curl gzip compression

### DIFF
--- a/src/trg-client.c
+++ b/src/trg-client.c
@@ -575,6 +575,7 @@ static CURL* get_curl(TrgClient *tc, guint http_class)
 	curl_easy_setopt(curl, CURLOPT_TIMEOUT,
 					 (long) trg_prefs_get_int(prefs, TRG_PREFS_KEY_TIMEOUT,
 											  TRG_PREFS_CONNECTION));
+    curl_easy_setopt(curl, CURLOPT_ACCEPT_ENCODING, "gzip");
 
     g_mutex_unlock(&priv->configMutex);
 


### PR DESCRIPTION
Since the Transmission RPC server supports it, allowing curl to use gzip compression for HTTP requests can save significant bandwidth, especially when managing a lot of torrents.