### PR TITLE
link window name to an icon in app menu

### DIFF
--- a/data/io.github.TransmissionRemoteGtk.desktop.in
+++ b/data/io.github.TransmissionRemoteGtk.desktop.in
@@ -8,3 +8,4 @@ Type=Application
 MimeType=application/x-bittorrent;x-scheme-handler/magnet;
 Categories=Network;FileTransfer;P2P;GTK;
 Keywords=p2p;bittorrent;transmission;rpc;
+StartupWMClass=transmission-remote-gtk


### PR DESCRIPTION
When I launch the transmission-remote-gtk app from gnome and transmission-remote-gtk is also added to favorites, it creates a duplicate icon on running tasks bar, instead of linking one to the favorite. This modification of desktop file fixes the issue.