### PR TITLE
Fix some memory leaks and errors

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -195,6 +195,8 @@ int main(int argc, char *argv[])
     exitCode = trg_gtkapp_init(client, argc, argv);
 #endif
 
+    g_object_unref(client);
+
     trg_cleanup();
 
     return exitCode;

--- a/src/trg-json-widgets.c
+++ b/src/trg-json-widgets.c
@@ -53,11 +53,7 @@ void trg_json_widget_desc_free(trg_json_widget_desc * wd)
 
 void trg_json_widget_desc_list_free(GList * list)
 {
-    GList *li;
-    for (li = list; li; li = g_list_next(li))
-        trg_json_widget_desc_free((trg_json_widget_desc *) li->data);
-
-    g_list_free(list);
+    g_list_free_full(list, (GDestroyNotify)trg_json_widget_desc_free);
 }
 
 void toggle_active_arg_is_sensitive(GtkToggleButton * b, gpointer data)

--- a/src/trg-main-window.c
+++ b/src/trg-main-window.c
@@ -847,8 +847,7 @@ confirm_action_dialog(GtkWindow * gtk_win,
                                 firstNode->data);
         gtk_tree_model_get(GTK_TREE_MODEL(priv->filteredTorrentModel),
                            &firstIter, TORRENT_COLUMN_NAME, &name, -1);
-        g_list_foreach(list, (GFunc) gtk_tree_path_free, NULL);
-        g_list_free(list);
+        g_list_free_full(list, (GDestroyNotify) gtk_tree_path_free);
 
         dialog = gtk_message_dialog_new_with_markup(GTK_WINDOW(win),
                                                     GTK_DIALOG_DESTROY_WITH_PARENT,
@@ -1603,8 +1602,7 @@ torrent_selection_changed(GtkTreeSelection * selection,
         }
     }
 
-    g_list_foreach(selectionList, (GFunc) gtk_tree_path_free, NULL);
-    g_list_free(selectionList);
+    g_list_free_full(selectionList, (GDestroyNotify) gtk_tree_path_free);
 
     update_selected_torrent_notebook(win, TORRENT_GET_MODE_FIRST, id);
 
@@ -2202,8 +2200,7 @@ static void exec_cmd_cb(GtkWidget * w, TrgMainWindow * win)
     g_spawn_async(NULL, argv, NULL, G_SPAWN_SEARCH_PATH, NULL, NULL, NULL,
                   &cmd_error);
 
-    g_list_foreach(selectedRows, (GFunc) gtk_tree_path_free, NULL);
-    g_list_free(selectedRows);
+    g_list_free_full(selectedRows, (GDestroyNotify) gtk_tree_path_free);
 
     if (argv)
         g_strfreev(argv);

--- a/src/trg-model.c
+++ b/src/trg-model.c
@@ -82,7 +82,7 @@ trg_model_remove_removed(GtkListStore * model, gint serial_column,
 struct find_existing_item_foreach_args {
     gint64 id;
     gint search_column;
-    GtkTreeIter *iter;
+    GtkTreeIter iter;
     gboolean found;
 };
 
@@ -97,7 +97,7 @@ find_existing_item_foreachfunc(GtkTreeModel * model,
 
     gtk_tree_model_get(model, iter, args->search_column, &currentId, -1);
     if (currentId == args->id) {
-        args->iter = iter;
+        args->iter = *iter;
         return args->found = TRUE;
     }
 
@@ -114,6 +114,6 @@ find_existing_model_item(GtkTreeModel * model, gint search_column,
     args.search_column = search_column;
     gtk_tree_model_foreach(model, find_existing_item_foreachfunc, &args);
     if (args.found == TRUE)
-        *iter = *(args.iter);
+        *iter = args.iter;
     return args.found;
 }

--- a/src/trg-torrent-model.c
+++ b/src/trg-torrent-model.c
@@ -644,11 +644,9 @@ update_torrent_iter(TrgTorrentModel * model,
 
     trg_torrent_model_count_peers(model, iter, t);
 
-    if (firstTrackerHost)
-        g_free(firstTrackerHost);
+    g_free(firstTrackerHost);
 
-    if (peerSources)
-        g_free(peerSources);
+    g_free(peerSources);
 
     g_free(lastDownloadDir);
     g_free(statusString);

--- a/src/trg-torrent-move-dialog.c
+++ b/src/trg-torrent-move-dialog.c
@@ -176,6 +176,8 @@ static GObject *trg_torrent_move_dialog_constructor(GType type,
                      "response",
                      G_CALLBACK(trg_torrent_move_response_cb), priv->win);
 
+    g_free(msg);
+
     return object;
 }
 

--- a/src/trg-torrent-props-dialog.c
+++ b/src/trg-torrent-props-dialog.c
@@ -174,7 +174,6 @@ static void trg_torrent_props_response_cb(GtkDialog * dialog, gint res_id,
                 (priv->bandwidthPriorityCombo) ) - 1);
 
         trg_json_widgets_save(priv->widgets, args);
-        trg_json_widget_desc_list_free(priv->widgets);
 
         dispatch_async(priv->client, request, on_generic_interactive_action_response,
                 priv->parent);
@@ -659,6 +658,20 @@ static GObject *trg_torrent_props_dialog_constructor(GType type,
     return object;
 }
 
+static void trg_torrent_props_dialog_dispose(GObject * object)
+{
+    G_OBJECT_CLASS(trg_torrent_props_dialog_parent_class)->dispose(object);
+}
+
+static void trg_torrent_props_dialog_finalize(GObject * object)
+{
+    TrgTorrentPropsDialogPrivate *priv = GET_PRIVATE(object);
+
+    trg_json_widget_desc_list_free(priv->widgets);
+
+    G_OBJECT_CLASS(trg_torrent_props_dialog_parent_class)->finalize(object);
+}
+
 static void trg_torrent_props_dialog_class_init(TrgTorrentPropsDialogClass
                                                 * klass)
 {
@@ -667,6 +680,8 @@ static void trg_torrent_props_dialog_class_init(TrgTorrentPropsDialogClass
     object_class->constructor = trg_torrent_props_dialog_constructor;
     object_class->set_property = trg_torrent_props_dialog_set_property;
     object_class->get_property = trg_torrent_props_dialog_get_property;
+    object_class->dispose = trg_torrent_props_dialog_dispose;
+    object_class->finalize = trg_torrent_props_dialog_finalize;
 
     g_type_class_add_private(klass, sizeof(TrgTorrentPropsDialogPrivate));
 

--- a/src/trg-trackers-model.c
+++ b/src/trg-trackers-model.c
@@ -151,6 +151,7 @@ trg_trackers_model_update(TrgTrackersModel * model,
     }
 
     g_list_free(trackers);
+
     trg_model_remove_removed(GTK_LIST_STORE(model),
                              TRACKERCOL_UPDATESERIAL, updateSerial);
 }

--- a/src/trg-tree-view.c
+++ b/src/trg-tree-view.c
@@ -91,6 +91,16 @@ gboolean trg_tree_view_is_column_showing(TrgTreeView * tv, gint index)
 }
 
 static void
+trg_column_description_free(trg_column_description * desc)
+{
+    if (desc) {
+        g_free(desc->header);
+        g_free(desc->id);
+        g_free(desc);
+    }
+}
+
+static void
 trg_tree_view_get_property(GObject * object, guint property_id,
                            GValue * value, GParamSpec * pspec)
 {
@@ -766,6 +776,21 @@ GList *trg_tree_view_get_selected_refs_list(GtkTreeView * tv)
     return refList;
 }
 
+static void trg_tree_view_dispose(GObject * object)
+{
+    G_OBJECT_CLASS(trg_tree_view_parent_class)->dispose(object);
+}
+
+static void trg_tree_view_finalize(GObject * object)
+{
+    TrgTreeViewPrivate *priv = TRG_TREE_VIEW_GET_PRIVATE(object);
+
+    g_list_free_full(priv->columns, (GDestroyNotify) trg_column_description_free);
+    g_free(priv->configId);
+
+    G_OBJECT_CLASS(trg_tree_view_parent_class)->finalize(object);
+}
+
 static void trg_tree_view_class_init(TrgTreeViewClass * klass)
 {
     GObjectClass *object_class = G_OBJECT_CLASS(klass);
@@ -775,6 +800,8 @@ static void trg_tree_view_class_init(TrgTreeViewClass * klass)
     object_class->get_property = trg_tree_view_get_property;
     object_class->set_property = trg_tree_view_set_property;
     object_class->constructor = trg_tree_view_constructor;
+    object_class->dispose = trg_tree_view_dispose;
+    object_class->finalize = trg_tree_view_finalize;
 
     g_object_class_install_property(object_class,
                                     PROP_PREFS,


### PR DESCRIPTION
I think this fixes the most severe memory leak related to requests not freeing all data. I noticed no increase in memory use after leaving the client open for some hours, but there might be more cases of incomplete cleanup after dialogs/widgets. The gtk.suppression file seems to be hiding real memory leaks so maybe it ought to be modified.