### PR TITLE
fix passing NULL to json_object_unref

### DIFF
--- a/src/trg-client.c
+++ b/src/trg-client.c
@@ -129,7 +129,7 @@ static void trg_client_finalize(GObject * object)
     TrgClientPrivate *priv = tc->priv;
 
     g_free(priv->session_id);
-    json_object_unref(priv->session);
+    g_clear_pointer(&priv->session, json_object_unref);
     g_free(priv->url);
     g_free(priv->username);
     g_free(priv->password);
@@ -370,10 +370,7 @@ void trg_client_status_change(TrgClient * tc, gboolean connected)
     TrgClientPrivate *priv = tc->priv;
 
     if (!connected) {
-        if (priv->session) {
-            json_object_unref(priv->session);
-            priv->session = NULL;
-        }
+        g_clear_pointer(&priv->session, json_object_unref);
         g_mutex_lock(&priv->configMutex);
         trg_prefs_set_connection(priv->prefs, NULL);
         g_mutex_unlock(&priv->configMutex);
@@ -468,8 +465,7 @@ void trg_client_configunlock(TrgClient * tc)
 void trg_response_free(trg_response * response)
 {
 	if (response) {
-		if (response->obj)
-			json_object_unref(response->obj);
+		g_clear_pointer(&response->obj, json_object_unref);
 
 		if (response->raw)
 			g_free(response->raw);

--- a/src/trg-prefs.c
+++ b/src/trg-prefs.c
@@ -272,8 +272,7 @@ void trg_prefs_set_connection(TrgPrefs * p, JsonObject * profile)
 {
     TrgPrefsPrivate *priv = p->priv;
 
-    if (priv->connectionObj)
-        json_object_unref(priv->connectionObj);
+    g_clear_pointer(&priv->connectionObj, json_object_unref);
 
     if (profile)
         json_object_ref(profile);

--- a/src/trg-torrent-model.c
+++ b/src/trg-torrent-model.c
@@ -191,9 +191,8 @@ static void trg_torrent_model_ref_free(gpointer data)
         GtkTreeIter iter;
         JsonObject *json;
         if (gtk_tree_model_get_iter(model, &iter, path)) {
-            gtk_tree_model_get(model, &iter, TORRENT_COLUMN_JSON, &json,
-                               -1);
-            json_object_unref(json);
+            gtk_tree_model_get(model, &iter, TORRENT_COLUMN_JSON, &json, -1);
+            g_clear_pointer(&json, json_object_unref);
             g_object_set_data(G_OBJECT(model), PROP_REMOVE_IN_PROGRESS,
                               GINT_TO_POINTER(TRUE));
             gtk_list_store_remove(GTK_LIST_STORE(model), &iter);
@@ -631,8 +630,7 @@ update_torrent_iter(TrgTorrentModel * model,
         *whatsChanged |= TORRENT_UPDATE_PATH_CHANGE;
     }
 
-    if (lastJson)
-        json_object_unref(lastJson);
+    g_clear_pointer(&lastJson, json_object_unref);
 
     if ((lastFlags & TORRENT_FLAG_DOWNLOADING)
         && (!(newFlags & TORRENT_FLAG_DOWNLOADING))


### PR DESCRIPTION
There were errors in stderr about NULL being passed into this function,
which violates an assertion in GTK. Fix this by finding all places where
this function is called and guarding it with a NULL check.

Strictly speaking, only the fix trg-client.c mattered, the other check in
trg-torrent-model.c was not being tripped. Nevertheless, it seems like
best practices to do the check there as well.
