### PR TITLE
fix some warnings

### DIFF
--- a/src/torrent-cell-renderer.c
+++ b/src/torrent-cell-renderer.c
@@ -308,14 +308,29 @@ static void getStatusString(GString * gstr, TorrentCellRenderer * r)
 {
     struct TorrentCellRendererPrivate *priv = r->priv;
     char buf[256];
+    const gchar *errstr;
 
     if (priv->error) {
-        const char *fmt[] = { NULL, N_("Tracker gave a warning: \"%s\""),
-            N_("Tracker gave an error: \"%s\""),
-            N_("Error: %s")
-        };
-        g_string_append_printf(gstr, _(fmt[priv->error]),
-                               torrent_get_errorstr(priv->json));
+        errstr = torrent_get_errorstr(priv->json);
+        switch (priv->error) {
+            case 0: /* OK */
+                break;
+            case 1: /* Tracking Warning */
+                g_string_append_printf(gstr,
+                                       _("Tracker gave a warning: \"%s\""),
+                                       errstr);
+                break;
+            case 2: /* Tracker Error */
+                g_string_append_printf(gstr,
+                                       _("Tracker gave an error: \"%s\""),
+                                       errstr);
+                break;
+            case 3: /* Local Error */
+                g_string_append_printf(gstr,
+                                       _("Error: \"%s\""),
+                                       errstr);
+                break;
+        }
     } else if ((priv->flags & TORRENT_FLAG_PAUSED)
                || (priv->flags & TORRENT_FLAG_WAITING_CHECK)
                || (priv->flags & TORRENT_FLAG_CHECKING)

--- a/src/trg-client.c
+++ b/src/trg-client.c
@@ -652,9 +652,9 @@ static CURL* get_curl(TrgClient *tc, guint http_class)
     if (http_class == HTTP_CLASS_TRANSMISSION)
     	curl_easy_setopt(curl, CURLOPT_URL, trg_client_get_url(tc));
 
-	curl_easy_setopt(curl, CURLOPT_TIMEOUT,
-					 (long) trg_prefs_get_int(prefs, TRG_PREFS_KEY_TIMEOUT,
-											  TRG_PREFS_CONNECTION));
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT, (long) trg_prefs_get_int(prefs, TRG_PREFS_KEY_TIMEOUT,
+                                                                     TRG_PREFS_CONNECTION));
+
     curl_easy_setopt(curl, CURLOPT_ACCEPT_ENCODING, "gzip");
 
     g_mutex_unlock(&priv->configMutex);

--- a/src/trg-main-window.c
+++ b/src/trg-main-window.c
@@ -2714,7 +2714,6 @@ static GObject *trg_main_window_constructor(GType type,
     GtkWidget *outerVbox;
     GtkWidget *toolbarHbox;
     //GtkWidget *outerAlignment;
-    GtkIconTheme *theme;
     gint width, height, pos;
     gboolean tray;
     TrgPrefs *prefs;

--- a/src/trg-main-window.c
+++ b/src/trg-main-window.c
@@ -126,8 +126,7 @@ static void delete_cb(GtkWidget * w, TrgMainWindow * win);
 static void open_props_cb(GtkWidget * w, TrgMainWindow * win);
 static gint confirm_action_dialog(GtkWindow * gtk_win,
                                   GtkTreeSelection * selection,
-                                  const gchar * question_single,
-                                  const gchar * question_multi,
+                                  const gchar * action_name,
                                   const gchar * action_label);
 static void view_stats_toggled_cb(GtkWidget * w, gpointer data);
 static void view_states_toggled_cb(GtkCheckMenuItem * w,
@@ -822,8 +821,7 @@ static void down_queue_cb(GtkWidget * w G_GNUC_UNUSED, TrgMainWindow * win)
 static gint
 confirm_action_dialog(GtkWindow * gtk_win,
                       GtkTreeSelection * selection,
-                      const gchar * question_single,
-                      const gchar * question_multi,
+                      const gchar * action_name,
                       const gchar * action_label)
 {
     TrgMainWindow *win = TRG_MAIN_WINDOW(gtk_win);
@@ -854,15 +852,16 @@ confirm_action_dialog(GtkWindow * gtk_win,
                                                     GTK_DIALOG_DESTROY_WITH_PARENT,
                                                     GTK_MESSAGE_QUESTION,
                                                     GTK_BUTTONS_NONE,
-                                                    question_single, name);
+                                                    _("<big><b>%s \"%s\"?</b></big>"),
+                                                    action_name, name);
         g_free(name);
     } else if (selectCount > 1) {
         dialog = gtk_message_dialog_new_with_markup(GTK_WINDOW(win),
                                                     GTK_DIALOG_DESTROY_WITH_PARENT,
                                                     GTK_MESSAGE_QUESTION,
                                                     GTK_BUTTONS_NONE,
-                                                    question_multi,
-                                                    selectCount);
+                                                    _("<big><b>%s %d torrents?</b></big>"),
+                                                    action_name, selectCount);
 
     } else {
         return 0;
@@ -912,9 +911,7 @@ static void remove_cb(GtkWidget * w G_GNUC_UNUSED, TrgMainWindow * win)
         gtk_tree_view_get_selection(GTK_TREE_VIEW(priv->torrentTreeView));
     ids = build_json_id_array(priv->torrentTreeView);
 
-    if (confirm_action_dialog(GTK_WINDOW(win), selection, _
-                              ("<big><b>Remove torrent \"%s\"?</b></big>"),
-                              _("<big><b>Remove %d torrents?</b></big>"),
+    if (confirm_action_dialog(GTK_WINDOW(win), selection, _("Remove"),
                               _("_Remove")) == GTK_RESPONSE_ACCEPT)
         dispatch_async(priv->client, torrent_remove(ids, FALSE),
                        on_generic_interactive_action_response, win);
@@ -935,10 +932,8 @@ static void delete_cb(GtkWidget * w G_GNUC_UNUSED, TrgMainWindow * win)
     if (!is_ready_for_torrent_action(win))
         return;
 
-    if (confirm_action_dialog(GTK_WINDOW(win), selection, _
-                              ("<big><b>Remove and delete torrent \"%s\"?</b></big>"),
-                              _
-                              ("<big><b>Remove and delete %d torrents?</b></big>"),
+    if (confirm_action_dialog(GTK_WINDOW(win), selection,
+                              _("Remove and delete"),
                               _("_Delete")) == GTK_RESPONSE_ACCEPT)
         dispatch_async(priv->client, torrent_remove(ids, TRUE),
                        on_delete_complete, win);

--- a/src/util.c
+++ b/src/util.c
@@ -230,8 +230,7 @@ GRegex *trg_uri_host_regex_new(void)
 
 void g_str_slist_free(GSList * list)
 {
-    g_slist_foreach(list, (GFunc) g_free, NULL);
-    g_slist_free(list);
+    g_slist_free_full(list, (GDestroyNotify) g_free);
 }
 
 void rm_trailing_slashes(gchar * str)


### PR DESCRIPTION
The one I'm really not sure about is bedf0213024662ca00f3d9b1eea0b7bf9cf11c38. I found that function searching for a suitable way to fix that warning, and it seems to do exactly what I want, and doesn't crash. But for all I know this could be a fatally incorrect way of doing this and very leaky.