### PR TITLE
fix gtk warning about unescaped markup

### DIFF
--- a/src/trg-cell-renderer-counter.c
+++ b/src/trg-cell-renderer-counter.c
@@ -71,9 +71,9 @@ static void trg_cell_renderer_counter_refresh(TrgCellRendererCounter * cr)
         trg_cell_renderer_counter_get_instance_private(cr);
     if (priv->originalLabel && priv->count > 0) {
         gchar *counterLabel =
-            g_strdup_printf("%s <span size=\"small\">(%d)</span>",
-                            priv->originalLabel,
-                            priv->count);
+            g_markup_printf_escaped("%s <span size=\"small\">(%d)</span>",
+                                    priv->originalLabel,
+                                    priv->count);
         g_object_set(cr, "markup", counterLabel, NULL);
         g_free(counterLabel);
     } else {


### PR DESCRIPTION
This string had some markup in it, so switch to g_markup_printf_escaped
to ensure that it's not printing out any warnings to stderr.

Previous warnings:
```
(transmission-remote-gtk:1483302): Gtk-WARNING **: 17:46:14.313: Failed to set text from markup due to error parsing markup: Error on line 1: Entity did not end with a semicolon; most likely you used an ampersand character without intending to start an entity — escape ampersand as &amp;
```

These disappear (as far as I can tell) with this change.

