### PR TITLE
fix some more warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The following packages are required dependencies for building and running
 transmission-remote-gtk:
 
  - gtk >= 3.16
- - glib >= 2.44 (including gio and gthread)
+ - glib >= 2.56 (including gio and gthread)
  - json-glib >= 0.8
  - libcurl
  - GNU gettext

--- a/meson.build
+++ b/meson.build
@@ -18,7 +18,7 @@ i18n = import('i18n')
 
 
 # glib version info
-glib_version = '2.44'
+glib_version = '2.56'
 glib_max_version = glib_version
 glib_min_version = glib_version
 glib_version_str = '>= @0@'.format(glib_version)

--- a/src/trg-client.c
+++ b/src/trg-client.c
@@ -134,7 +134,7 @@ static void trg_client_finalize(GObject * object)
     g_free(priv->password);
     g_list_free_full(priv->headers, g_free);
     g_free(priv->proxy);
-    g_hash_table_unref(priv->torrentTable);
+    g_clear_pointer(&priv->torrentTable, g_hash_table_unref);
     g_thread_pool_free(priv->pool, TRUE, TRUE);
 
     G_OBJECT_CLASS(trg_client_parent_class)->finalize(object);

--- a/src/trg-files-tree-view-common.c
+++ b/src/trg-files-tree-view-common.c
@@ -108,9 +108,7 @@ view_popup_menu(GtkWidget * treeview, GdkEventButton * event,
 
     gtk_widget_show_all(menu);
 
-    gtk_menu_popup(GTK_MENU(menu), NULL, NULL, NULL, NULL,
-                   (event != NULL) ? event->button : 0,
-                   gdk_event_get_time((GdkEvent *) event));
+    gtk_menu_popup_at_pointer(GTK_MENU(menu), (GdkEvent *)event);
 }
 
 gboolean

--- a/src/trg-main-window.c
+++ b/src/trg-main-window.c
@@ -2341,9 +2341,7 @@ trg_torrent_tv_view_menu(GtkWidget * treeview,
 
     gtk_widget_show_all(menu);
 
-    gtk_menu_popup(GTK_MENU(menu), NULL, NULL, NULL, NULL,
-                   (event != NULL) ? event->button : 0,
-                   gdk_event_get_time((GdkEvent *) event));
+    gtk_menu_popup_at_pointer(GTK_MENU(menu), (GdkEvent *)event);
 }
 
 static GtkMenu *trg_status_icon_view_menu(TrgMainWindow * win,

--- a/src/trg-main-window.c
+++ b/src/trg-main-window.c
@@ -1718,10 +1718,8 @@ trg_main_window_conn_changed(TrgMainWindow * win, gboolean connected)
 #endif
 
         trg_torrent_model_remove_all(priv->torrentModel);
-
-        g_source_remove(priv->timerId);
-        g_source_remove(priv->sessionTimerId);
-        priv->sessionTimerId = priv->timerId = 0;
+        g_clear_handle_id(&priv->timerId, g_source_remove);
+        g_clear_handle_id(&priv->sessionTimerId, g_source_remove);
     }
 
     trg_client_status_change(tc, connected);
@@ -2475,8 +2473,9 @@ static void trg_main_window_set_hidden_to_tray(TrgMainWindow * win,
         gtk_window_deiconify(GTK_WINDOW(win));
         gtk_window_present(GTK_WINDOW(win));
 
+
         if (priv->timerId > 0) {
-            g_source_remove(priv->timerId);
+            g_clear_handle_id(&priv->timerId, g_source_remove);
             dispatch_async(priv->client,
                            torrent_get(TORRENT_GET_TAG_MODE_FULL),
                            on_torrent_get_update, win);

--- a/src/trg-prefs.c
+++ b/src/trg-prefs.c
@@ -423,10 +423,10 @@ JsonArray *trg_prefs_get_profiles(TrgPrefs * p)
                                         TRG_PREFS_KEY_PROFILES);
 }
 
-JsonArray *trg_prefs_get_rss(TrgPrefs *p) {
-	TrgPrefsPrivate *priv = p->priv;
-	return json_object_get_array_member(priv->userObj,
-            TRG_PREFS_KEY_RSS);
+JsonArray *trg_prefs_get_rss(TrgPrefs *p)
+{
+    return trg_prefs_get_array(p, TRG_PREFS_KEY_RSS,
+                               TRG_PREFS_GLOBAL);
 }
 
 void

--- a/src/trg-rss-model.c
+++ b/src/trg-rss-model.c
@@ -139,7 +139,7 @@ void trg_rss_model_update(TrgRssModel * model) {
 	GList *li;
 
 	if (!feeds)
-		return;
+	    return;
 
 	cookie_regex = g_regex_new("(.*):COOKIE:(.*)", 0, 0, NULL);
 

--- a/src/trg-state-selector.c
+++ b/src/trg-state-selector.c
@@ -227,9 +227,7 @@ view_popup_menu(GtkWidget * treeview, GdkEventButton * event,
 
     gtk_widget_show_all(menu);
 
-    gtk_menu_popup(GTK_MENU(menu), NULL, NULL, NULL, NULL,
-                   (event != NULL) ? event->button : 0,
-                   gdk_event_get_time((GdkEvent *) event));
+    gtk_menu_popup_at_pointer(GTK_MENU(menu), (GdkEvent *)event);
 }
 
 static gboolean view_onPopupMenu(GtkWidget * treeview, gpointer userdata)

--- a/src/trg-torrent-graph.c
+++ b/src/trg-torrent-graph.c
@@ -347,8 +347,7 @@ static void trg_torrent_graph_dispose(GObject * object)
 
     trg_torrent_graph_stop(g);
 
-    if (priv->timer_index)
-        g_source_remove(priv->timer_index);
+    g_clear_handle_id(&priv->timer_index, g_source_remove);
 
     trg_torrent_graph_clear_background(g);
 

--- a/src/trg-trackers-tree-view.c
+++ b/src/trg-trackers-tree-view.c
@@ -290,9 +290,7 @@ view_popup_menu_add_only(GtkWidget * treeview, GdkEventButton * event,
 
     gtk_widget_show_all(menu);
 
-    gtk_menu_popup(GTK_MENU(menu), NULL, NULL, NULL, NULL,
-                   (event != NULL) ? event->button : 0,
-                   gdk_event_get_time((GdkEvent *) event));
+    gtk_menu_popup_at_pointer(GTK_MENU(menu), (GdkEvent *)event);
 }
 
 static void
@@ -317,9 +315,7 @@ view_popup_menu(GtkWidget * treeview, GdkEventButton * event,
 
     gtk_widget_show_all(menu);
 
-    gtk_menu_popup(GTK_MENU(menu), NULL, NULL, NULL, NULL,
-                   (event != NULL) ? event->button : 0,
-                   gdk_event_get_time((GdkEvent *) event));
+    gtk_menu_popup_at_pointer(GTK_MENU(menu), (GdkEvent *)event);
 }
 
 static gboolean

--- a/src/trg-tree-view.c
+++ b/src/trg-tree-view.c
@@ -375,9 +375,7 @@ view_popup_menu(GtkButton * button, GdkEventButton * event,
 
     gtk_widget_show_all(menu);
 
-    gtk_menu_popup(GTK_MENU(menu), NULL, NULL, NULL, NULL,
-                   (event != NULL) ? event->button : 0,
-                   gdk_event_get_time((GdkEvent *) event));
+    gtk_menu_popup_at_pointer(GTK_MENU(menu), (GdkEvent*)event);
 }
 
 /* This used to get the column as an argument binded when the signal was


### PR DESCRIPTION
All of these are fixed now
```
(transmission-remote-gtk:2239211): GLib-CRITICAL **: 17:20:45.418: g_source_remove: assertion 'tag > 0' failed

(transmission-remote-gtk:2254740): Json-CRITICAL **: 17:47:05.485: json_object_get_array_member: assertion 'node != NULL' failed

Gdk-Message: 17:20:47.679: Window 0x55e079c502b0 is a temporary window without parent, application will not be able to position it on screen.
(transmission-remote-gtk:2239211): Gdk-CRITICAL **: 17:20:47.680: gdk_wayland_window_handle_configure_popup: assertion 'impl->transient_for' failed
```
