### PR TITLE
Fix remaining compiler warnings

### DIFF
--- a/extern/rss-glib/rss-document.c
+++ b/extern/rss-glib/rss-document.c
@@ -284,12 +284,10 @@ rss_document_dispose (GObject *object)
 	g_free (priv->image_link);
 
 	/* free the items */
-	g_list_foreach (priv->items, (GFunc) g_object_unref, NULL);
-	g_list_free (priv->items);
+	g_list_free_full(priv->items, g_object_unref);
 
 	/* free the category strings */
-	g_list_foreach (priv->categories, (GFunc) g_free, NULL);
-	g_list_free (priv->categories);
+	g_list_free_full(priv->categories, g_free);
 
 	G_OBJECT_CLASS (rss_document_parent_class)->dispose (object);
 }

--- a/extern/rss-glib/rss-item.c
+++ b/extern/rss-glib/rss-item.c
@@ -211,9 +211,8 @@ rss_item_finalize (GObject *object)
 	g_free (priv->pub_date);
 	g_free (priv->source);
 	g_free (priv->source_url);
-  
-	g_list_foreach (priv->categories, (GFunc) g_free, NULL);
-	g_list_free (priv->categories);
+
+	g_list_free_full(priv->categories, g_free);
 
 	G_OBJECT_CLASS (rss_item_parent_class)->finalize (object);
 }

--- a/src/trg-client.c
+++ b/src/trg-client.c
@@ -664,7 +664,7 @@ static CURL* get_curl(TrgClient *tc, guint http_class)
 
 }
 
-static inline int
+static int
 trg_http_perform_inner(TrgClient * tc, trg_request * request,
                        trg_response * response, gboolean recurse)
 {

--- a/src/trg-rss-cell-renderer.c
+++ b/src/trg-rss-cell-renderer.c
@@ -136,7 +136,7 @@ trg_rss_cell_renderer_get_size(GtkCellRenderer * cell, GtkWidget * widget,
     if (self) {
     	struct TrgRssCellRendererPrivate *p = self->priv;
         int xpad, ypad;
-        int h, w;
+        int h = 0, w = 0;
         GtkRequisition icon_size;
         GtkRequisition name_size;
         GtkRequisition stat_size;

--- a/src/trg-torrent-model.c
+++ b/src/trg-torrent-model.c
@@ -416,7 +416,7 @@ gchar *shorten_download_dir(TrgClient * tc, const gchar * downloadDir)
     return g_strdup(downloadDir);
 }
 
-static inline void
+static void
 update_torrent_iter(TrgTorrentModel * model,
                     TrgClient * tc, gint64 rpcv,
                     gint64 serial, GtkTreeIter * iter,


### PR DESCRIPTION
With these all gone, transmission-remote-gtk compiles with no warnings :)

(Which will change once `-Wdeprecated` `-Wdeprecated-declarations` are turned on)