### PR TITLE
use GNotification instead of libnotify

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ The following packages are optional dependencies:
  - libmrss >= 0.18, RSS feed support
  - libproxy, HTTP proxy support
  - libgeoip, country of origin of peers
- - libnotify, desktop notifications support
  - libappindicator, Application tray support
 
 If these libraries are installed at build time they will be automatically

--- a/meson.build
+++ b/meson.build
@@ -37,10 +37,9 @@ trg_deps = [gtk_dep, glib_dep, gio_dep, json_dep, libcurl_dep, gthread_dep]
 rss_dep             = dependency('mrss', version: '>=0.18', required: get_option('mrss'))
 geoip_dep           = dependency('geoip', required: get_option('geoip'))
 libproxy_dep        = dependency('libproxy', required: get_option('libproxy'))
-libnotify_dep       = dependency('libnotify', required: get_option('libnotify'))
 libappindicator_dep = dependency('appindicator3-0.1', required: get_option('libappindicator'))
 
-trg_deps += [geoip_dep, libproxy_dep, libnotify_dep, libappindicator_dep]
+trg_deps += [geoip_dep, libproxy_dep, libappindicator_dep]
 
 # compiler
 cc = meson.get_compiler('c')
@@ -86,7 +85,6 @@ conf_data.set('GLIB_VERSION_MIN_REQUIRED', glib_min)
 conf_data.set10('HAVE_RSS', rss_dep.found())
 conf_data.set10('HAVE_GEOIP', geoip_dep.found())
 conf_data.set10('HAVE_LIBPROXY', libproxy_dep.found())
-conf_data.set10('HAVE_LIBNOTIFY', libnotify_dep.found())
 conf_data.set10('ENABLE_NL_LANGINFO', nl_langinfo)
 conf_data.set10('HAVE_LIBAPPINDICATOR', libappindicator_dep.found())
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,6 +1,5 @@
 option('mrss', type: 'feature', value: 'auto', description: 'RSS support')
 option('libproxy', type: 'feature', value: 'auto', description: 'HTTP proxy support')
 option('geoip', type: 'feature', value: 'auto', description: 'geoip support')
-option('libnotify', type: 'feature', value: 'auto', description: 'notification support')
 option('libappindicator', type: 'feature', value: 'auto', description: 'libappindicator')
 option('nl_langinfo', type: 'feature', value: 'auto', description: 'nl_langinfo() support')

--- a/src/trg-main-window.h
+++ b/src/trg-main-window.h
@@ -35,9 +35,6 @@ G_BEGIN_DECLS
 #define TRG_TYPE_MAIN_WINDOW (trg_main_window_get_type())
 G_DECLARE_FINAL_TYPE (TrgMainWindow, trg_main_window, TRG, MAIN_WINDOW, GtkApplicationWindow)
 
-#define TORRENT_COMPLETE_NOTIFY_TMOUT 8000
-#define TORRENT_ADD_NOTIFY_TMOUT 3000
-
 gint trg_add_from_filename(TrgMainWindow * win, gchar ** uris);
 gboolean on_session_set(gpointer data);
 gboolean on_delete_complete(gpointer data);

--- a/src/trg-preferences-dialog.c
+++ b/src/trg-preferences-dialog.c
@@ -778,7 +778,7 @@ static GtkWidget *trg_prefs_viewPage(TrgPreferencesDialog * dlg)
                      G_CALLBACK(toggle_active_arg_is_sensitive), w);
     hig_workarea_add_wide_control(t, &row, w);
 
-#if HAVE_LIBNOTIFY
+
     hig_workarea_add_section_title(t, &row, _("Notifications"));
 
     w = trgp_check_new(dlg, _("Torrent added notifications"),
@@ -789,7 +789,6 @@ static GtkWidget *trg_prefs_viewPage(TrgPreferencesDialog * dlg)
                        TRG_PREFS_KEY_COMPLETE_NOTIFY, TRG_PREFS_GLOBAL,
                        NULL);
     hig_workarea_add_wide_control(t, &row, w);
-#endif
 
     return t;
 }


### PR DESCRIPTION
See commit for reasoning. About removing timeouts:

 - [KDE ignores timeouts](https://community.kde.org/Plasma/Notifications#Closing)
 - [GNOME keeps them forever](https://gitlab.gnome.org/GNOME/gnome-shell/-/issues/112#note_82496)
 - [XFCE makes them disappears after a set time](https://docs.xfce.org/apps/xfce4-notifyd/preferences)
 - Others e.g. [mako](https://github.com/emersion/mako), all have configurable timeouts at the daemon level
 - trg hardcoded timeout values, so that was not very user friendly to begin with

The only remaining question is: is the `GIcon` code right? Does it pull the correct icon?