### PR TITLE
bump gtk3 dep to 3.22

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ the Transmission BitTorrent client, using its HTTP RPC protocol.
 The following packages are required dependencies for building and running
 transmission-remote-gtk:
 
- - gtk >= 3.16
+ - gtk >= 3.22
  - glib >= 2.56 (including gio and gthread)
  - json-glib >= 0.8
  - libcurl

--- a/meson.build
+++ b/meson.build
@@ -24,7 +24,7 @@ glib_min_version = glib_version
 glib_version_str = '>= @0@'.format(glib_version)
 
 # required dependencies
-gtk_dep     = dependency('gtk+-3.0', version: '>= 3.16')
+gtk_dep     = dependency('gtk+-3.0', version: '>= 3.22')
 gio_dep     = dependency('gio-2.0', version: glib_version_str)
 glib_dep    = dependency('glib-2.0', version: glib_version_str)
 json_dep    = dependency('json-glib-1.0', version: '>= 0.8')


### PR DESCRIPTION
In 6d1f20dca06124635709a0a4ed666cf967169ba2 gtk_menu_popup_at_pointer()
was introduced, which is a function introduced in 3.22. This version
exists in debian old stable so there should be no issues with
dependencies on other distros.