### PR TITLE
remove unused env from docs

### DIFF
--- a/src/transmission-remote-gtk.pod
+++ b/src/transmission-remote-gtk.pod
@@ -24,16 +24,6 @@ Start the application minimized
 
 =back
 
-=head1 ENVIRONMENT
-
-=over 1
-
-=item TRG_NOUNIQUE
-
-Start a new instance, even if one already exists.
-
-=back
-
 =head1 AUTHOR
 
 Written by Alan Fitton.


### PR DESCRIPTION
This is a legacy of libunique which is long gone.

I think if someone wanted this feature back it would be possible, but right now `GtkApplication` will keep unique instances from starting, so this functionality needs to be implemented via those APIs. Also, I doubt the usefulness of a feature like that. Something better might be to allow multiple daemon connections at the same time. A much larger amount of work but a much better feature.

Fixes #71 