### PR TITLE
windows support

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -7,7 +7,7 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
+  build-unix:
 
     runs-on: ubuntu-latest
     steps:
@@ -20,6 +20,44 @@ jobs:
           # Meson is too old on ubuntu
           pip3 install --no-input meson ninja
       - name: meson configure
+        run: meson build
+      - name: build
+        run: meson compile -C build
+      - name: dist
+        run: meson dist -C build
+
+  build-windows:
+
+    runs-on: windows-latest
+
+    defaults:
+      run:
+        shell: msys2 {0}
+
+    steps:
+
+      - uses: msys2/setup-msys2@v2
+      - name: install deps
+        run: |
+          pacman -S --noconfirm \
+                    git \
+                    mingw-w64-x86_64-gcc \
+                    mingw-w64-x86_64-meson \
+                    mingw-w64-x86_64-ninja \
+                    mingw-w64-x86_64-pkg-config \
+                    \
+                    mingw-w64-x86_64-gtk3 \
+                    mingw-w64-x86_64-curl \
+                    mingw-w64-x86_64-glib2 \
+                    mingw-w64-x86_64-gettext \
+                    mingw-w64-x86_64-json-glib \
+                    \
+                    mingw-w64-x86_64-libproxy \
+                    mingw-w64-x86_64-appstream-glib \
+                    mingw-w64-x86_64-desktop-file-utils
+
+      - uses: actions/checkout@v2
+      - name: configure
         run: meson build
       - name: build
         run: meson compile -C build

--- a/meson.build
+++ b/meson.build
@@ -36,7 +36,7 @@ trg_deps = [gtk_dep, glib_dep, gio_dep, json_dep, libcurl_dep, gthread_dep]
 # optional dependencies
 rss_dep             = dependency('mrss', version: '>=0.18', required: get_option('mrss'))
 geoip_dep           = dependency('geoip', required: get_option('geoip'))
-libproxy_dep        = dependency('libproxy', required: get_option('libproxy'))
+libproxy_dep        = dependency('libproxy-1.0', required: get_option('libproxy'))
 libappindicator_dep = dependency('appindicator3-0.1', required: get_option('libappindicator'))
 
 trg_deps += [geoip_dep, libproxy_dep, libappindicator_dep]

--- a/meson.build
+++ b/meson.build
@@ -127,7 +127,8 @@ if win32
 
   win_ldflags = cc.get_supported_link_arguments('-Wl,--allow-multiple-definitions',
                                                 '-lws2_32',
-                                                '-lintl')
+                                                '-lintl',
+                                                '-lssp')
   add_project_link_arguments(win_ldflags, language: 'c')
 endif
 

--- a/src/win32-mailslot.c
+++ b/src/win32-mailslot.c
@@ -19,11 +19,10 @@
 
 #include "config.h"
 
-#ifdef G_OS_WIN32
-
 #define TRG_MAILSLOT_NAME "\\\\.\\mailslot\\TransmissionRemoteGTK"
 #define MAILSLOT_BUFFER_SIZE 1024*32
 
+#include <winsock2.h>
 #include <windows.h>
 #include <glib-object.h>
 #include <gtk/gtk.h>
@@ -73,7 +72,7 @@ static gpointer mailslot_recv_thread(gpointer data)
                                NULL);   /* default security attribute */
 
     if (INVALID_HANDLE_VALUE == hMailslot) {
-        g_error("\nError occurred while creating the mailslot: %d",
+        g_error("\nError occurred while creating the mailslot: %ld",
                 GetLastError());
         return NULL;            /* Error */
     }
@@ -86,7 +85,7 @@ static gpointer mailslot_recv_thread(gpointer data)
                            NULL);       /* not overlapped I/O */
 
         if ((!bResult) || (0 == cbBytes)) {
-            g_error("Mailslot error from client: %d", GetLastError());
+            g_error("Mailslot error from client: %ld", GetLastError());
             break;
         }
 
@@ -194,5 +193,3 @@ gboolean mailslot_send_message(gchar ** args)
 
     return FALSE;
 }
-
-#endif

--- a/src/win32-mailslot.h
+++ b/src/win32-mailslot.h
@@ -20,13 +20,11 @@
 #ifndef WIN32_MAILSLOT_H_
 #define WIN32_MAILSLOT_H_
 
-#ifdef G_OS_WIN32
-
+#include <winsock2.h>
 #include <windows.h>
 #include "trg-main-window.h"
 
 void mailslot_start_background_listener(TrgMainWindow * win);
 int mailslot_send_message(gchar ** args);
 
-#endif
 #endif                          /* WIN32_MAILSLOT_H_ */


### PR DESCRIPTION
Enable a minimum working windows build. No idea if it actually works.

Eventually, I'd like to remove `win32-mailslots.*` and drop all the win32 specific code, I think glib and gtk handles all of that for us. Also the compiler options for windows probably need to be reviewed, I blindly copied them but I don't know what half of them do.