### PR TITLE
allow status bar to resize

### DIFF
--- a/src/trg-status-bar.c
+++ b/src/trg-status-bar.c
@@ -22,6 +22,7 @@
 #include <glib/gi18n.h>
 #include <glib/gprintf.h>
 #include <gtk/gtk.h>
+#include <pango/pango.h>
 
 #include "trg-prefs.h"
 #include "trg-main-window.h"
@@ -104,6 +105,8 @@ static void trg_status_bar_init(TrgStatusBar * self)
     gtk_container_set_border_width(GTK_CONTAINER(self), 2);
 
     priv->info_lbl = gtk_label_new(_("Disconnected"));
+    gtk_label_set_ellipsize(GTK_LABEL(priv->info_lbl),
+                            PANGO_ELLIPSIZE_END);
     gtk_box_pack_start(GTK_BOX(self), priv->info_lbl, FALSE, TRUE, 0);
 
     priv->turtleImage = gtk_image_new();
@@ -117,10 +120,12 @@ static void trg_status_bar_init(TrgStatusBar * self)
     gtk_box_pack_end(GTK_BOX(self), priv->turtleEventBox, FALSE, TRUE, 5);
 
     priv->speed_lbl = gtk_label_new(NULL);
-    gtk_box_pack_end(GTK_BOX(self), priv->speed_lbl, FALSE, TRUE, 10);
+    gtk_label_set_ellipsize(GTK_LABEL(priv->speed_lbl),
+                            PANGO_ELLIPSIZE_START);
+    gtk_box_pack_end(GTK_BOX(self), priv->speed_lbl, FALSE, TRUE, 5);
 
     priv->free_lbl = gtk_label_new(NULL);
-    gtk_box_pack_end(GTK_BOX(self), priv->free_lbl, FALSE, TRUE, 30);
+    gtk_box_pack_end(GTK_BOX(self), priv->free_lbl, FALSE, TRUE, 5);
 }
 
 void
@@ -140,7 +145,7 @@ trg_status_bar_set_connected_label(TrgStatusBar * sb, JsonObject * session,
                                               TRG_PREFS_KEY_PROFILE_NAME,
                                               TRG_PREFS_CONNECTION);
     gchar *statusMsg =
-        g_strdup_printf(_("Connected: %s :: Transmission %s"),
+        g_strdup_printf(_("Connected: %s :: %s"),
                         profileName,
                         session_get_version_string(session));
 


### PR DESCRIPTION
Full size
![full](https://user-images.githubusercontent.com/16581533/150049895-9255543d-149c-4416-ba2b-7b264e08412c.png)

Halfway resized (activates ellipsize on connection label)
![half](https://user-images.githubusercontent.com/16581533/150049978-66f966d0-c3a2-48cf-8bdb-94731cdc8e3d.png)

As small as it gets (activates ellipsize on speed label)
![tiny](https://user-images.githubusercontent.com/16581533/150050005-db6e834e-fa1a-4a5f-b94b-d4d24cc020bc.png)

Going smaller than this affects the menu bar I think, that requires some more work.

Fixes #79 
