### PR TITLE
remove leftover win32 ifdef

### DIFF
--- a/src/trg-main-window.c
+++ b/src/trg-main-window.c
@@ -396,11 +396,7 @@ destroy_window(TrgMainWindow * win, gpointer data G_GNUC_UNUSED)
                           TRG_TREE_VIEW_PERSIST_LAYOUT);
     trg_prefs_save(prefs);
 
-#ifdef G_OS_WIN32
-    gtk_main_quit();
-#else
     g_application_quit (g_application_get_default ());
-#endif
 }
 
 static void open_props_cb(GtkWidget * w G_GNUC_UNUSED, TrgMainWindow * win)


### PR DESCRIPTION
No longer necessary now that windows supports gtk_application
activation. gtk_main* in gtk4 and needs to be removed.