### PR TITLE
WIP: initial labels support

### DIFF
--- a/data/io.github.TransmissionRemoteGtk.gresource.xml
+++ b/data/io.github.TransmissionRemoteGtk.gresource.xml
@@ -8,5 +8,6 @@
     <file alias="icons/24x24/actions/trg-gtk-disconnect.png">icons/trg-gtk-disconnect-24x24.png</file>
     <file alias="icons/16x16/status/alt-speed-on.png">icons/turtle-blue.png</file>
     <file alias="icons/16x16/status/alt-speed-off.png">icons/turtle-grey.png</file>
+    <file preprocess="xml-stripblanks">ui/labels-dialog.ui</file>
   </gresource>
 </gresources>

--- a/data/ui/labels-dialog.ui
+++ b/data/ui/labels-dialog.ui
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+    <template class="TrgLabelsDialog" parent="GtkDialog">
+        <property name="title">Labels</property>
+        <property name="resizeable">FALSE</property>
+        <child internal-child="content-area">
+            <object class="TrgLabelsBox" id="lb">
+                <property name="margin-start">12</property>
+                <property name="margin-end">12</property>
+                <property name="margin-top">12</property>
+                <property name="margin-bottom">12</property>
+            </object>
+        </child>
+        <child type="action">
+            <object class="GtkButton" id="close">
+                <property name="Label">Close</property>
+            </object>
+            <object class="GtkButton" id="ok_btn">
+                <property name="Label">OK</property>
+            </object>
+        </child>
+        <action-widgets>
+            <action-widget response="cancel" defualt="true">close_btn</action-widget>
+            <action-widget respose="accept">ok_btn</action-widget>
+        </action-widgets>
+    </template>
+</interface>

--- a/meson.build
+++ b/meson.build
@@ -11,6 +11,8 @@ project('transmission-remote-gtk', 'c',
 project_name = meson.project_name()
 project_version = meson.project_version()
 app_id = 'io.github.TransmissionRemoteGtk'
+resource_path = app_id.replace('.', '/')
+
 datadir = get_option('datadir')
 
 # i18n module
@@ -74,6 +76,7 @@ conf_data.set_quoted('PACKAGE_VERSION', project_version)
 conf_data.set_quoted('GETTEXT_PACKAGE', project_name)
 conf_data.set_quoted('APPLICATION_ID', app_id)
 conf_data.set_quoted('LOCALEDIR', get_option('prefix') / get_option('localedir'))
+conf_data.set_quoted('RESOURCE_PATH', resource_path)
 
 # debug options
 debug = get_option('debug')

--- a/src/json.c
+++ b/src/json.c
@@ -69,3 +69,19 @@ gdouble json_node_really_get_double(JsonNode *node)
         return 0.0;
     }
 }
+
+JsonArray *json_str_list_to_array(GList *list)
+{
+    guint len;
+    JsonArray *arr;
+
+    len = g_list_length(list);
+
+    arr = json_array_sized_new(len);
+
+    for (guint i = 0; i < len; i++) {
+        json_array_add_string_element(arr, (gchar *)g_list_nth_data(list, i));
+    }
+
+    return arr;
+}

--- a/src/meson.build
+++ b/src/meson.build
@@ -32,6 +32,7 @@ src_files = [
     'trg-general-panel.c',
     'trg-gtk-app.c',
     'trg-json-widgets.c',
+    'trg-labels.c',
     'trg-main-window.c',
     'trg-menu-bar.c',
     'trg-model.c',

--- a/src/protocol-constants.h
+++ b/src/protocol-constants.h
@@ -92,6 +92,7 @@
 #define FIELD_ACTIVITY_DATE           "activityDate"
 #define FIELD_ISPRIVATE               "isPrivate"
 #define FIELD_METADATAPERCENTCOMPLETE "metadataPercentComplete"
+#define FIELD_LABELS                  "labels"
 
 #define FIELD_FILES_WANTED          "files-wanted"
 #define FIELD_FILES_UNWANTED        "files-unwanted"

--- a/src/requests.c
+++ b/src/requests.c
@@ -222,17 +222,22 @@ JsonNode *torrent_get(gint64 id)
     json_array_add_string_element(fields, FIELD_WANTED);
     json_array_add_string_element(fields, FIELD_PRIORITIES);
     json_array_add_string_element(fields, FIELD_RECHECK_PROGRESS);
+    json_array_add_string_element(fields, FIELD_LABELS);
     json_object_set_array_member(args, PARAM_FIELDS, fields);
     return root;
 }
 
-JsonNode *torrent_add_url(const gchar *url, gboolean paused)
+JsonNode *torrent_add_url(const gchar *url, gboolean paused, GList *labels)
 {
     JsonNode *root = base_request(METHOD_TORRENT_ADD);
     JsonObject *args = node_get_arguments(root);
 
     json_object_set_string_member(args, PARAM_FILENAME, url);
     json_object_set_boolean_member(args, PARAM_PAUSED, paused);
+
+    if (labels)
+        json_object_set_array_member(args, FIELD_LABELS, json_str_list_to_array(labels));
+
     request_set_tag(root, TORRENT_GET_TAG_MODE_FULL);
     return root;
 }

--- a/src/requests.h
+++ b/src/requests.h
@@ -37,7 +37,7 @@ JsonNode *torrent_verify(JsonArray *array);
 JsonNode *torrent_reannounce(JsonArray *array);
 JsonNode *torrent_remove(JsonArray *array, int removeData);
 JsonNode *torrent_add_from_file(gchar *filename, gint flags);
-JsonNode *torrent_add_url(const gchar *url, gboolean paused);
+JsonNode *torrent_add_url(const gchar *url, gboolean paused, GList *labels);
 JsonNode *torrent_set_location(JsonArray *array, gchar *location, gboolean move);
 JsonNode *torrent_rename_path(JsonArray *array, const gchar *path, const gchar *name);
 JsonNode *blocklist_update(void);

--- a/src/torrent.c
+++ b/src/torrent.c
@@ -485,6 +485,14 @@ gint64 torrent_get_queue_position(JsonObject *args)
         return -1;
 }
 
+JsonArray *torrent_get_labels(JsonObject *t)
+{
+    if (json_object_has_member(t, FIELD_LABELS))
+        return json_object_get_array_member(t, FIELD_LABELS);
+    else
+        return NULL;
+}
+
 /* tracker stats */
 
 gint64 tracker_stats_get_id(JsonObject *t)

--- a/src/torrent.h
+++ b/src/torrent.h
@@ -101,6 +101,7 @@ gint64 torrent_get_activity_date(JsonObject *t);
 gchar *torrent_get_full_dir(JsonObject *obj);
 gchar *torrent_get_full_path(JsonObject *obj);
 gdouble torrent_get_metadata_percent_complete(JsonObject *t);
+JsonArray *torrent_get_labels(JsonObject *t);
 
 /* outer response object */
 

--- a/src/trg-general-panel.c
+++ b/src/trg-general-panel.c
@@ -63,6 +63,7 @@ struct _TrgGeneralPanelPrivate {
     GtkLabel *gen_completedat_label;
     GtkLabel *gen_downloaddir_label;
     GtkLabel *gen_comment_label;
+    GtkLabel *gen_labels_label;
     GtkLabel *gen_hash_label;
     GtkLabel *gen_error_label;
     GtkTreeModel *model;
@@ -210,6 +211,12 @@ void trg_general_panel_update(TrgGeneralPanel *panel, JsonObject *t, GtkTreeIter
     gtk_label_set_markup(GTK_LABEL(priv->gen_comment_label), comment);
     g_free(comment);
 
+    GList *label_list = json_array_get_elements(torrent_get_labels(t));
+    gchar *labels_str = tr_list_concat(", ", label_list);
+    gtk_label_set_text(GTK_LABEL(priv->gen_labels_label), labels_str);
+    g_list_free(label_list);
+    g_free(labels_str);
+
     errorStr = torrent_get_errorstr(t);
     keyLabel = gen_panel_label_get_key_label(GTK_LABEL(priv->gen_error_label));
     if (strlen(errorStr) > 0) {
@@ -305,10 +312,10 @@ static void trg_general_panel_init(TrgGeneralPanel *self)
         = trg_general_panel_add_label_with_width(self, _("Location"), 0, 6, -1);
 
     priv->gen_comment_label = trg_general_panel_add_label(self, _("Comment"), 0, 7);
+    priv->gen_labels_label = trg_general_panel_add_label(self, _("Labels"), 0, 8);
+    priv->gen_hash_label = trg_general_panel_add_label(self, _("Hash"), 0, 9);
 
-    priv->gen_hash_label = trg_general_panel_add_label(self, _("Hash"), 0, 8);
-
-    priv->gen_error_label = trg_general_panel_add_label_with_width(self, "", 0, 9, -1);
+    priv->gen_error_label = trg_general_panel_add_label_with_width(self, "", 0, 10, -1);
 
     gtk_grid_set_row_homogeneous(GTK_GRID(self), TRUE);
     gtk_grid_set_column_spacing(GTK_GRID(self), TRG_GENERAL_PANEL_SPACING_X);

--- a/src/trg-labels.c
+++ b/src/trg-labels.c
@@ -1,0 +1,129 @@
+/*
+ * transmission-remote-gtk - A GTK RPC client to Transmission
+ * Copyright (C) 2011-2013  Alan Fitton
+
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "config.h"
+
+#include "trg-labels.h"
+#include "util.h"
+#include <glib.h>
+#include <gtk/gtk.h>
+
+/* TrgLabelsBox */
+struct _TrgLabelsBox {
+    GtkBox parent;
+    GtkEntry *labels_entry;
+    GtkLabel *errors_label;
+    GRegex *labels_regex;
+};
+G_DEFINE_TYPE(TrgLabelsBox, trg_labels_box, GTK_TYPE_BOX);
+static void trg_labels_box_init(TrgLabelsBox *tv)
+{
+    tv->labels_regex = g_regex_new("^([^,]+,?)+?[^,]+$", G_REGEX_EXTENDED, 0, NULL);
+    tv->labels_entry = GTK_ENTRY(gtk_entry_new());
+    tv->errors_label = GTK_LABEL(gtk_label_new(""));
+
+    gtk_box_pack_start(GTK_BOX(tv), GTK_WIDGET(tv->labels_entry), TRUE, TRUE, 5);
+    gtk_box_pack_end(GTK_BOX(tv), GTK_WIDGET(tv->errors_label), TRUE, TRUE, 0);
+};
+
+static void trg_labels_box_class_init(TrgLabelsBoxClass *klass) {};
+
+gboolean trg_labels_box_is_valid(TrgLabelsBox *trglb)
+{
+    return g_strcmp0("", gtk_label_get_label(trglb->errors_label)) == 0;
+}
+
+GList *trg_labels_box_get_labels(TrgLabelsBox *trglb)
+{
+    if (!trg_labels_box_is_valid(trglb))
+        return NULL;
+
+    GtkEntryBuffer *buf = gtk_entry_get_buffer(trglb->labels_entry);
+
+    return tr_split_to_list(",", gtk_entry_buffer_get_text(buf));
+}
+
+static void check_regex(TrgLabelsBox *labels_box)
+{
+    const gchar *buf_text;
+    GtkEntryBuffer *entry_buf;
+
+    entry_buf = gtk_entry_get_buffer(labels_box->labels_entry);
+    buf_text = gtk_entry_buffer_get_text(entry_buf);
+
+    if (g_regex_match(labels_box->labels_regex, buf_text, 0, NULL)) {
+        gtk_label_set_label(labels_box->errors_label, "");
+        return;
+    };
+
+    gtk_label_set_markup(labels_box->errors_label,
+                         "<span color=\"red\" weight=\"bold\">"
+                         "Labels must be comma separated string"
+                         "</span>");
+}
+
+GtkWidget *trg_labels_box_new(void)
+{
+    TrgLabelsBox *self;
+    self = g_object_new(TRG_TYPE_LABELS_BOX, "orientation", GTK_ORIENTATION_VERTICAL, NULL);
+
+    /* check regex when leaving focus */
+    g_signal_connect_swapped(GTK_WIDGET(self->labels_entry), "focus-out-event",
+                             G_CALLBACK(check_regex), self);
+
+    return GTK_WIDGET(self);
+}
+
+/* TrgLabelsDialog */
+struct _TrgLabelsDialog {
+    TrgLabelsBox *labels_box;
+    TrgClient *client;
+    TrgMainWindow *win;
+};
+G_DEFINE_TYPE(TrgLabelsDialog, trg_labels_dialog, GTK_TYPE_DIALOG);
+
+static void trg_labels_dialog_init(TrgLabelsDialog *ld)
+{
+    gtk_widget_init_template(GTK_WIDGET(ld));
+
+    ld->labels_box = TRG_LABELS_BOX(trg_labels_box_new());
+}
+
+static void trg_labels_dialog_class_init(TrgLabelsDialogClass *class)
+{
+    gtk_widget_class_set_template_from_resource(GTK_WIDGET_CLASS(class),
+                                                RESOURCE_PATH "/ui/labels-dialog.ui");
+
+    gtk_widget_class_bind_template_child(GTK_WIDGET_CLASS(class), TrgLabelsDialog, labels_box);
+}
+
+static void on_response_cb(TrgLabelsDialog *dlg, gint res_id, gpointer data)
+{
+}
+TrgLabelsDialog *trg_labels_dialog_new(TrgMainWindow *win, TrgClient *client)
+{
+    TrgLabelsDialog *self;
+    self = TRG_LABELS_DIALOG(g_object_new(TRG_TYPE_LABELS_DIALOG, NULL));
+
+    self->client = client;
+    self->win = win;
+
+    g_signal_connect(G_OBJECT(self), "response", G_CALLBACK(on_response_cb), win);
+    return TRG_LABELS_DIALOG(self);
+}

--- a/src/trg-labels.h
+++ b/src/trg-labels.h
@@ -17,18 +17,22 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef JSON_H_
-#define JSON_H_
+#pragma once
 
 #include <glib-object.h>
-#include <json-glib/json-glib.h>
+#include <gtk/gtk.h>
 
 #include "trg-client.h"
+#include "trg-main-window.h"
 
-JsonGenerator *trg_json_serializer(JsonNode *req, gboolean pretty);
-JsonObject *get_arguments(JsonObject *req);
-JsonObject *node_get_arguments(JsonNode *req);
-gdouble json_double_to_progress(JsonNode *n);
-gdouble json_node_really_get_double(JsonNode *node);
-JsonArray *json_str_list_to_array(GList *list);
-#endif /* JSON_H_ */
+#define TRG_TYPE_LABELS_BOX trg_labels_box_get_type()
+G_DECLARE_FINAL_TYPE(TrgLabelsBox, trg_labels_box, TRG, LABELS_BOX, GtkBox);
+
+GtkWidget *trg_labels_box_new(void);
+gboolean trg_labels_box_is_valid(TrgLabelsBox *trglb);
+GList *trg_labels_box_get_labels(TrgLabelsBox *trglb);
+
+#define TRG_TYPE_LABELS_DIALOG trg_labels_dialog_get_type()
+G_DECLARE_FINAL_TYPE(TrgLabelsDialog, trg_labels_dialog, TRG, LABELS_DIALOG, GtkDialog);
+
+TrgLabelsDialog *trg_labels_dialog_new(TrgMainWindow *win, TrgClient *client);

--- a/src/trg-torrent-props-dialog.c
+++ b/src/trg-torrent-props-dialog.c
@@ -99,6 +99,7 @@ struct _TrgTorrentPropsDialogPrivate {
     GtkWidget *hash_lb;
     GtkWidget *privacy_lb;
     GtkWidget *origin_lb;
+    GtkWidget *labels_lb;
     GtkTextBuffer *comment_buffer;
     gboolean show_details;
 };
@@ -256,6 +257,11 @@ static GtkWidget *info_page_new(TrgTorrentPropsDialog *dialog)
     hig_workarea_add_row(t, &row, _("Origin:"), l, NULL);
     priv->origin_lb = l;
 
+    /* labels */
+    l = g_object_new(GTK_TYPE_LABEL, "selectable", TRUE, "ellipsize", PANGO_ELLIPSIZE_END, NULL);
+    hig_workarea_add_row(t, &row, _("Labels:"), l, NULL);
+    priv->labels_lb = l;
+
     /* comment */
     b = priv->comment_buffer = gtk_text_buffer_new(NULL);
     w = gtk_text_view_new_with_buffer(b);
@@ -320,6 +326,14 @@ static void info_page_update(TrgTorrentPropsDialog *dialog, JsonObject *t,
         gtk_label_set_text(GTK_LABEL(priv->origin_lb), buf);
     }
 
+    /* labels */
+    GList *label_list = json_array_get_elements(torrent_get_labels(t));
+    gchar *labels_str = tr_list_concat(", ", label_list);
+    gtk_label_set_text(GTK_LABEL(priv->labels_lb), labels_str);
+    g_list_free(label_list);
+    g_free(labels_str);
+
+    /* comment */
     gtk_text_buffer_set_text(priv->comment_buffer, torrent_get_comment(t), -1);
     gtk_label_set_text(GTK_LABEL(priv->destination_lb), torrent_get_download_dir(t));
 

--- a/src/upload.c
+++ b/src/upload.c
@@ -53,6 +53,11 @@ static void add_wanteds(JsonObject *args, gint *wanteds, gint n_files)
     }
 }
 
+static void add_labels(JsonObject *args, GList *labels)
+{
+    json_object_set_array_member(args, FIELD_LABELS, json_str_list_to_array(labels));
+}
+
 static void next_upload(trg_upload *upload)
 {
     JsonNode *req = NULL;
@@ -72,6 +77,9 @@ static void next_upload(trg_upload *upload)
 
         if (upload->file_priorities)
             add_priorities(args, upload->file_priorities, upload->n_files);
+
+        if (upload->labels)
+            add_labels(args, upload->labels);
 
         upload->progress_index++;
         dispatch_rpc_async(upload->client, req, upload_complete_callback, upload);

--- a/src/upload.h
+++ b/src/upload.h
@@ -18,6 +18,7 @@ typedef struct {
     gint *file_priorities;
     gint *file_wanted;
     guint n_files;
+    GList *labels;
     gboolean extra_args;
     guint progress_index;
     GSourceFunc callback;

--- a/src/util.c
+++ b/src/util.c
@@ -516,6 +516,46 @@ char *tr_strlsize(char *buf, guint64 bytes, size_t buflen)
     return buf;
 }
 
+/* Take a GList of strings and concatenate them.
+ * Opposite of tr_split_to_list */
+gchar *tr_list_concat(const gchar *separator, GList *list)
+{
+    gchar *str_out;
+    gchar **str;
+
+    guint len = g_list_length(list);
+    if (len == 0)
+        return g_strdup("");
+
+    str = g_malloc0(sizeof(gchar *) * (len + 1));
+
+    for (guint i = 0; i < len; i++) {
+        str[i] = json_node_dup_string(g_list_nth_data(list, i));
+    }
+
+    str_out = g_strjoinv(separator, str);
+    g_strfreev(str);
+    return str_out;
+}
+
+/* Take a delimited string and split it to a GList.
+ * Opposite of tr_list_concat */
+GList *tr_split_to_list(const gchar *separator, const gchar *str)
+{
+    GList *list_out = NULL;
+    gchar **split_str;
+
+    split_str = g_strsplit(str, separator, -1);
+
+    for (guint i = 0; i < g_strv_length(split_str); i++) {
+        list_out = g_list_append(list_out, g_strdup(split_str[i]));
+    }
+
+    g_strfreev(split_str);
+
+    return list_out;
+}
+
 gboolean is_minimised_arg(const gchar *arg)
 {
     return !g_strcmp0(arg, "-m") || !g_strcmp0(arg, "--minimized") || !g_strcmp0(arg, "/m");

--- a/src/util.h
+++ b/src/util.h
@@ -75,6 +75,8 @@ char *gtr_localtime(time_t time);
 char *gtr_localtime2(char *buf, time_t time, size_t buflen);
 double tr_truncd(double x, int decimal_places);
 char *tr_strlsize(char *buf, guint64 bytes, size_t buflen);
+gchar *tr_list_concat(const gchar *separator, GList *list);
+GList *tr_split_to_list(const gchar *separator, const gchar *str);
 void rm_trailing_slashes(gchar *str);
 void trg_widget_set_visible(GtkWidget *w, gboolean visible);
 gchar *trg_base64encode(const gchar *filename);


### PR DESCRIPTION
I plan to fully support labels, including adding them to the state selector as well as adding a dialog for adding and removing labels. Unfortunately the daemon does not allow for setting labels with the `torrent-add` method. But I will attempt to add that upstream in the coming weeks.

TODO:
 - [x] ~~Think of a better UI for general-panel/properties rather than concat'ing all labels with `,`~~ This is currently how all other tools do this, commas are not allowed in labels
 - [x] ~~Add to state selector to filter by label~~ Another PR, `trg-state-selector.c` needs some cleanup before this is viable.
 - [ ] Add ability to add labels via right click menu option and new dialog
 - [x] Add labels within the torrent-add dialog and add url dialog


Closes #133 