### PR TITLE
bump json-glib dependency to >= 1.2.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ transmission-remote-gtk:
 
  - gtk >= 3.22
  - glib >= 2.56 (including gio and gthread)
- - json-glib >= 0.8
+ - json-glib >= 1.2.8
  - libcurl
  - GNU gettext
 

--- a/meson.build
+++ b/meson.build
@@ -38,7 +38,7 @@ add_project_arguments(glib_min_def, glib_max_def, language: 'c')
 gtk_dep     = dependency('gtk+-3.0', version: '>= 3.22')
 gio_dep     = dependency('gio-2.0', version: glib_version_str)
 glib_dep    = dependency('glib-2.0', version: glib_version_str)
-json_dep    = dependency('json-glib-1.0', version: '>= 0.8')
+json_dep    = dependency('json-glib-1.0', version: '>= 1.2.8')
 libcurl_dep = dependency('libcurl')
 gthread_dep = dependency('gthread-2.0', version: glib_version_str)
 


### PR DESCRIPTION
Several issues with older json-glib versions have been reported, and
1.2.8 was released 4 years ago and is distros like debian stable and
ubuntu LTS.

Closes #25, Closes  #41