### PR TITLE
Use clang-format for code style

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,13 @@
+﻿---
+BasedOnStyle: WebKit
+AlignAfterOpenBracket: 'true'
+AlignConsecutiveMacros: 'true'
+AllowShortFunctionsOnASingleLine: 'false'
+AllowShortEnumsOnASingleLine: 'false'
+AllowShortIfStatementsOnASingleLine: 'false'
+AllowShortBlocksOnASingleLine: 'false'
+BreakBeforeBraces: Linux
+ColumnLimit: '100'
+UseTab: Never
+PointerAlignment: Right
+...

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,0 +1,18 @@
+name: clang-format
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  formatting-check:
+    name: Formatting Check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run clang-format style check for C/C++/Protobuf programs.
+      uses: jidicula/clang-format-action@v4.6.2
+      with:
+        check-path: 'src'
+        clang-format-version: '14'

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# pre-commit formatting hook
+# inspired by https://github.com/transmission/transmission/blob/main/extras/pre-commit
+# to use: `cp scripts/pre-commit .git/hooks/
+
+# allow hook to be skipped for special cases
+[ -z "$TRG_SKIP_HOOKS" ] || exit 0
+
+root="$(git rev-parse --show-toplevel)"
+clang-format -n --Werror "${root}"/src/*.{c,h}

--- a/src/bencode.c
+++ b/src/bencode.c
@@ -26,9 +26,9 @@
 
 #include "config.h"
 
-#include <stdlib.h>             /* malloc() realloc() free() strtoll() */
-#include <string.h>             /* memset() */
 #include <ctype.h>
+#include <stdlib.h> /* malloc() realloc() free() strtoll() */
+#include <string.h> /* memset() */
 
 #include <glib.h>
 
@@ -42,7 +42,7 @@ static be_node *be_alloc(be_type type)
     return ret;
 }
 
-static gint64 _be_decode_int(const char **data, gint64 * data_len)
+static gint64 _be_decode_int(const char **data, gint64 *data_len)
 {
     char *endp;
     gint64 ret = strtoll(*data, &endp, 10);
@@ -51,7 +51,7 @@ static gint64 _be_decode_int(const char **data, gint64 * data_len)
     return ret;
 }
 
-gint64 be_str_len(be_node * node)
+gint64 be_str_len(be_node *node)
 {
     gint64 ret = 0;
     if (node->val.s)
@@ -59,7 +59,7 @@ gint64 be_str_len(be_node * node)
     return ret;
 }
 
-static char *_be_decode_str(const char **data, gint64 * data_len)
+static char *_be_decode_str(const char **data, gint64 *data_len)
 {
     gint64 sllen = _be_decode_int(data, data_len);
     long slen = sllen;
@@ -96,7 +96,7 @@ static char *_be_decode_str(const char **data, gint64 * data_len)
     return ret;
 }
 
-static be_node *_be_decode(const char **data, gint64 * data_len)
+static be_node *_be_decode(const char **data, gint64 *data_len)
 {
     be_node *ret = NULL;
     char dc;
@@ -113,8 +113,7 @@ static be_node *_be_decode(const char **data, gint64 * data_len)
         --(*data_len);
         ++(*data);
         while (**data != 'e') {
-            ret->val.l =
-                g_realloc(ret->val.l, (i + 2) * sizeof(*ret->val.l));
+            ret->val.l = g_realloc(ret->val.l, (i + 2) * sizeof(*ret->val.l));
             ret->val.l[i] = _be_decode(data, data_len);
             if (!ret->val.l[i])
                 break;
@@ -135,8 +134,7 @@ static be_node *_be_decode(const char **data, gint64 * data_len)
         --(*data_len);
         ++(*data);
         while (**data != 'e') {
-            ret->val.d =
-                g_realloc(ret->val.d, (i + 2) * sizeof(*ret->val.d));
+            ret->val.d = g_realloc(ret->val.d, (i + 2) * sizeof(*ret->val.d));
             ret->val.d[i].key = _be_decode_str(data, data_len);
             ret->val.d[i].val = _be_decode(data, data_len);
             if (!ret->val.l[i])
@@ -182,7 +180,7 @@ be_node *be_decode(const char *data)
     return be_decoden(data, strlen(data));
 }
 
-gboolean be_validate_node(be_node * node, be_type type)
+gboolean be_validate_node(be_node *node, be_type type)
 {
     if (!node || node->type != type)
         return FALSE;
@@ -196,7 +194,7 @@ static inline void _be_free_str(char *str)
         g_free(str - sizeof(gint64));
 }
 
-void be_free(be_node * node)
+void be_free(be_node *node)
 {
     switch (node->type) {
     case BE_STR:
@@ -206,34 +204,32 @@ void be_free(be_node * node)
     case BE_INT:
         break;
 
-    case BE_LIST:
-        {
-            unsigned int i;
-            if (node->val.l) {
-                for (i = 0; node->val.l[i]; ++i)
-                    be_free(node->val.l[i]);
-                g_free(node->val.l);
-            }
-            break;
+    case BE_LIST: {
+        unsigned int i;
+        if (node->val.l) {
+            for (i = 0; node->val.l[i]; ++i)
+                be_free(node->val.l[i]);
+            g_free(node->val.l);
         }
+        break;
+    }
 
-    case BE_DICT:
-        {
-            unsigned int i;
-            if (node->val.d) {
-                for (i = 0; node->val.d[i].val; ++i) {
-                    _be_free_str(node->val.d[i].key);
-                    be_free(node->val.d[i].val);
-                }
-                g_free(node->val.d);
+    case BE_DICT: {
+        unsigned int i;
+        if (node->val.d) {
+            for (i = 0; node->val.d[i].val; ++i) {
+                _be_free_str(node->val.d[i].key);
+                be_free(node->val.d[i].val);
             }
-            break;
+            g_free(node->val.d);
         }
+        break;
+    }
     }
     g_free(node);
 }
 
-be_node *be_dict_find(be_node * node, char *key, be_type type)
+be_node *be_dict_find(be_node *node, char *key, be_type type)
 {
     int i;
     for (i = 0; node->val.d[i].val; ++i) {
@@ -247,8 +243,8 @@ be_node *be_dict_find(be_node * node, char *key, be_type type)
 }
 
 #ifdef BE_DEBUG
-#include <stdio.h>
 #include <stdint.h>
+#include <stdio.h>
 
 static void _be_dump_indent(ssize_t indent)
 {
@@ -256,7 +252,7 @@ static void _be_dump_indent(ssize_t indent)
         printf("    ");
 }
 
-static void _be_dump(be_node * node, ssize_t indent)
+static void _be_dump(be_node *node, ssize_t indent)
 {
     size_t i;
 
@@ -297,7 +293,7 @@ static void _be_dump(be_node * node, ssize_t indent)
     }
 }
 
-void be_dump(be_node * node)
+void be_dump(be_node *node)
 {
     _be_dump(node, 0);
 }

--- a/src/bencode.h
+++ b/src/bencode.h
@@ -23,42 +23,42 @@
 extern "C" {
 #endif
 
-    typedef enum {
-        BE_STR,
-        BE_INT,
-        BE_LIST,
-        BE_DICT
-    } be_type;
+typedef enum {
+    BE_STR,
+    BE_INT,
+    BE_LIST,
+    BE_DICT
+} be_type;
 
-    struct be_dict;
-    struct be_node;
+struct be_dict;
+struct be_node;
 
 /*
  * XXX: the "val" field of be_dict and be_node can be confusing ...
  */
 
-    typedef struct be_dict {
-        char *key;
-        struct be_node *val;
-    } be_dict;
+typedef struct be_dict {
+    char *key;
+    struct be_node *val;
+} be_dict;
 
-    typedef struct be_node {
-        be_type type;
-        union {
-            char *s;
-            gint64 i;
-            struct be_node **l;
-            struct be_dict *d;
-        } val;
-    } be_node;
+typedef struct be_node {
+    be_type type;
+    union {
+        char *s;
+        gint64 i;
+        struct be_node **l;
+        struct be_dict *d;
+    } val;
+} be_node;
 
-    gint64 be_str_len(be_node * node);
-    be_node *be_decode(const char *bencode);
-    be_node *be_decoden(const char *bencode, gint64 bencode_len);
-    void be_free(be_node * node);
-    void be_dump(be_node * node);
-    be_node *be_dict_find(be_node * node, char *key, be_type type);
-    gboolean be_validate_node(be_node * node, be_type type);
+gint64 be_str_len(be_node *node);
+be_node *be_decode(const char *bencode);
+be_node *be_decoden(const char *bencode, gint64 bencode_len);
+void be_free(be_node *node);
+void be_dump(be_node *node);
+be_node *be_dict_find(be_node *node, char *key, be_type type);
+gboolean be_validate_node(be_node *node, be_type type);
 
 #ifdef __cplusplus
 }

--- a/src/hig.c
+++ b/src/hig.c
@@ -12,155 +12,130 @@
 
 #include "config.h"
 
-#include <gtk/gtk.h>
 #include "hig.h"
+#include <gtk/gtk.h>
 
-GtkWidget*
-hig_workarea_create (void)
+GtkWidget *hig_workarea_create(void)
 {
-    GtkWidget * grid = gtk_grid_new ();
+    GtkWidget *grid = gtk_grid_new();
 
-    gtk_container_set_border_width (GTK_CONTAINER (grid), GUI_PAD_BIG);
-    gtk_grid_set_row_spacing (GTK_GRID (grid), GUI_PAD);
-    gtk_grid_set_column_spacing (GTK_GRID (grid), GUI_PAD_BIG);
+    gtk_container_set_border_width(GTK_CONTAINER(grid), GUI_PAD_BIG);
+    gtk_grid_set_row_spacing(GTK_GRID(grid), GUI_PAD);
+    gtk_grid_set_column_spacing(GTK_GRID(grid), GUI_PAD_BIG);
 
     return grid;
 }
 
-void
-hig_workarea_add_section_title_widget (GtkWidget * t, guint * row, GtkWidget * w)
+void hig_workarea_add_section_title_widget(GtkWidget *t, guint *row, GtkWidget *w)
 {
-    gtk_widget_set_hexpand (w, TRUE);
-    gtk_grid_attach (GTK_GRID (t), w, 0, *row, 2, 1);
-    ++ * row;
+    gtk_widget_set_hexpand(w, TRUE);
+    gtk_grid_attach(GTK_GRID(t), w, 0, *row, 2, 1);
+    ++*row;
 }
 
-void
-hig_workarea_add_section_title (GtkWidget *  t, guint * row, const char * section_title)
+void hig_workarea_add_section_title(GtkWidget *t, guint *row, const char *section_title)
 {
     char buf[512];
-    GtkWidget * l;
+    GtkWidget *l;
 
-    g_snprintf (buf, sizeof (buf), "<b>%s</b>", section_title);
-    l = gtk_label_new (buf);
-    gtk_label_set_xalign (GTK_LABEL (l), 0.0f);
-    gtk_label_set_yalign (GTK_LABEL (l), 0.5f);
-    gtk_label_set_use_markup (GTK_LABEL (l), TRUE);
-    hig_workarea_add_section_title_widget (t, row, l);
+    g_snprintf(buf, sizeof(buf), "<b>%s</b>", section_title);
+    l = gtk_label_new(buf);
+    gtk_label_set_xalign(GTK_LABEL(l), 0.0f);
+    gtk_label_set_yalign(GTK_LABEL(l), 0.5f);
+    gtk_label_set_use_markup(GTK_LABEL(l), TRUE);
+    hig_workarea_add_section_title_widget(t, row, l);
 }
 
-void
-hig_workarea_add_wide_control (GtkWidget * t, guint * row, GtkWidget * w)
+void hig_workarea_add_wide_control(GtkWidget *t, guint *row, GtkWidget *w)
 {
-    gtk_widget_set_hexpand (w, TRUE);
-    gtk_widget_set_margin_start (w, 18);
-    gtk_grid_attach (GTK_GRID (t), w, 0, *row, 2, 1);
-    ++ * row;
+    gtk_widget_set_hexpand(w, TRUE);
+    gtk_widget_set_margin_start(w, 18);
+    gtk_grid_attach(GTK_GRID(t), w, 0, *row, 2, 1);
+    ++*row;
 }
-void
-hig_workarea_add_wide_tall_control (GtkWidget * t, guint * row, GtkWidget * w)
+void hig_workarea_add_wide_tall_control(GtkWidget *t, guint *row, GtkWidget *w)
 {
-    gtk_widget_set_hexpand (w, TRUE);
-    gtk_widget_set_vexpand (w, TRUE);
-    hig_workarea_add_wide_control (t, row, w);
+    gtk_widget_set_hexpand(w, TRUE);
+    gtk_widget_set_vexpand(w, TRUE);
+    hig_workarea_add_wide_control(t, row, w);
 }
 
-GtkWidget *
-hig_workarea_add_wide_checkbutton (GtkWidget  * t,
-                                   guint      * row,
-                                   const char * mnemonic_string,
-                                   gboolean     is_active)
+GtkWidget *hig_workarea_add_wide_checkbutton(GtkWidget *t, guint *row, const char *mnemonic_string,
+                                             gboolean is_active)
 {
-    GtkWidget * w = gtk_check_button_new_with_mnemonic (mnemonic_string);
+    GtkWidget *w = gtk_check_button_new_with_mnemonic(mnemonic_string);
 
-    gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (w), is_active);
-    hig_workarea_add_wide_control (t, row, w);
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(w), is_active);
+    hig_workarea_add_wide_control(t, row, w);
     return w;
 }
 
-void
-hig_workarea_add_label_w (GtkWidget * t, guint row, GtkWidget * w)
+void hig_workarea_add_label_w(GtkWidget *t, guint row, GtkWidget *w)
 {
-    gtk_widget_set_margin_start (w, 18);
-    if (GTK_IS_LABEL (w)) {
-        gtk_label_set_use_markup (GTK_LABEL (w), TRUE);
-        gtk_label_set_xalign(GTK_LABEL (w), 0.0f);
-        gtk_label_set_yalign(GTK_LABEL (w), 0.5f);
+    gtk_widget_set_margin_start(w, 18);
+    if (GTK_IS_LABEL(w)) {
+        gtk_label_set_use_markup(GTK_LABEL(w), TRUE);
+        gtk_label_set_xalign(GTK_LABEL(w), 0.0f);
+        gtk_label_set_yalign(GTK_LABEL(w), 0.5f);
     }
-    gtk_grid_attach (GTK_GRID (t), w, 0, row, 1, 1);
+    gtk_grid_attach(GTK_GRID(t), w, 0, row, 1, 1);
 }
 
-static void
-hig_workarea_add_tall_control (GtkWidget * t, guint row, GtkWidget * control)
+static void hig_workarea_add_tall_control(GtkWidget *t, guint row, GtkWidget *control)
 {
-    if (GTK_IS_LABEL (control)) {
+    if (GTK_IS_LABEL(control)) {
 
-        gtk_label_set_xalign (GTK_LABEL (control), 0.0f);
-        gtk_label_set_yalign (GTK_LABEL (control), 0.5f);
+        gtk_label_set_xalign(GTK_LABEL(control), 0.0f);
+        gtk_label_set_yalign(GTK_LABEL(control), 0.5f);
     }
-    g_object_set (control, "expand", TRUE, NULL);
-    gtk_grid_attach (GTK_GRID (t), control, 1, row, 1, 1);
+    g_object_set(control, "expand", TRUE, NULL);
+    gtk_grid_attach(GTK_GRID(t), control, 1, row, 1, 1);
 }
 
-static void
-hig_workarea_add_control (GtkWidget * t, guint row, GtkWidget * control)
+static void hig_workarea_add_control(GtkWidget *t, guint row, GtkWidget *control)
 {
-    if (GTK_IS_LABEL (control)) {
-        gtk_label_set_xalign (GTK_LABEL (control), 0.0f);
-        gtk_label_set_yalign (GTK_LABEL (control), 0.5f);
+    if (GTK_IS_LABEL(control)) {
+        gtk_label_set_xalign(GTK_LABEL(control), 0.0f);
+        gtk_label_set_yalign(GTK_LABEL(control), 0.5f);
     }
-    gtk_widget_set_hexpand (control, TRUE);
-    gtk_grid_attach (GTK_GRID (t), control, 1, row, 1, 1);
+    gtk_widget_set_hexpand(control, TRUE);
+    gtk_grid_attach(GTK_GRID(t), control, 1, row, 1, 1);
 }
 
-void
-hig_workarea_add_row_w (GtkWidget * t,
-                        guint     * row,
-                        GtkWidget * label,
-                        GtkWidget * control,
-                        GtkWidget * mnemonic)
+void hig_workarea_add_row_w(GtkWidget *t, guint *row, GtkWidget *label, GtkWidget *control,
+                            GtkWidget *mnemonic)
 {
-    hig_workarea_add_label_w (t, *row, label);
-    hig_workarea_add_control (t, *row, control);
-    if (GTK_IS_LABEL (label))
-        gtk_label_set_mnemonic_widget (GTK_LABEL (label),
-                                       mnemonic ? mnemonic : control);
-    ++ * row;
+    hig_workarea_add_label_w(t, *row, label);
+    hig_workarea_add_control(t, *row, control);
+    if (GTK_IS_LABEL(label))
+        gtk_label_set_mnemonic_widget(GTK_LABEL(label), mnemonic ? mnemonic : control);
+    ++*row;
 }
 
-GtkWidget*
-hig_workarea_add_row (GtkWidget  * t,
-                      guint      * row,
-                      const char * mnemonic_string,
-                      GtkWidget  * control,
-                      GtkWidget  * mnemonic)
+GtkWidget *hig_workarea_add_row(GtkWidget *t, guint *row, const char *mnemonic_string,
+                                GtkWidget *control, GtkWidget *mnemonic)
 {
-    GtkWidget * l = gtk_label_new_with_mnemonic (mnemonic_string);
+    GtkWidget *l = gtk_label_new_with_mnemonic(mnemonic_string);
 
-    hig_workarea_add_row_w (t, row, l, control, mnemonic);
+    hig_workarea_add_row_w(t, row, l, control, mnemonic);
     return l;
 }
 
-GtkWidget*
-hig_workarea_add_tall_row (GtkWidget  * table,
-                           guint      * row,
-                           const char * mnemonic_string,
-                           GtkWidget  * control,
-                           GtkWidget  * mnemonic)
+GtkWidget *hig_workarea_add_tall_row(GtkWidget *table, guint *row, const char *mnemonic_string,
+                                     GtkWidget *control, GtkWidget *mnemonic)
 {
-    GtkWidget * l = gtk_label_new_with_mnemonic (mnemonic_string);
-    GtkWidget * h = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 0);
-    GtkWidget * v = gtk_box_new (GTK_ORIENTATION_VERTICAL, 0);
-    gtk_box_pack_start (GTK_BOX (h), l, FALSE, FALSE, 0);
-    gtk_box_pack_start (GTK_BOX (v), h, FALSE, FALSE, GUI_PAD_SMALL);
+    GtkWidget *l = gtk_label_new_with_mnemonic(mnemonic_string);
+    GtkWidget *h = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+    GtkWidget *v = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+    gtk_box_pack_start(GTK_BOX(h), l, FALSE, FALSE, 0);
+    gtk_box_pack_start(GTK_BOX(v), h, FALSE, FALSE, GUI_PAD_SMALL);
 
-    hig_workarea_add_label_w (table, *row, v);
-    hig_workarea_add_tall_control (table, *row, control);
+    hig_workarea_add_label_w(table, *row, v);
+    hig_workarea_add_tall_control(table, *row, control);
 
-    if (GTK_IS_LABEL (l))
-        gtk_label_set_mnemonic_widget (GTK_LABEL (l),
-                                       mnemonic ? mnemonic : control);
+    if (GTK_IS_LABEL(l))
+        gtk_label_set_mnemonic_widget(GTK_LABEL(l), mnemonic ? mnemonic : control);
 
-    ++ * row;
+    ++*row;
     return l;
 }

--- a/src/hig.h
+++ b/src/hig.h
@@ -20,53 +20,31 @@
 *** see section 8.2.2, Visual Design > Window Layout > Dialogs.
 **/
 
-GtkWidget* hig_workarea_create (void);
+GtkWidget *hig_workarea_create(void);
 
-void       hig_workarea_add_section_title_widget (GtkWidget * t,
-                                                  guint     * row,
-                                                  GtkWidget * w);
+void hig_workarea_add_section_title_widget(GtkWidget *t, guint *row, GtkWidget *w);
 
-void       hig_workarea_add_section_title (GtkWidget  *  table,
-                                           guint      * row,
-                                           const char * section_title);
+void hig_workarea_add_section_title(GtkWidget *table, guint *row, const char *section_title);
 
-void       hig_workarea_add_wide_tall_control (GtkWidget * table,
-                                               guint     * row,
-                                               GtkWidget * w);
+void hig_workarea_add_wide_tall_control(GtkWidget *table, guint *row, GtkWidget *w);
 
-void       hig_workarea_add_wide_control (GtkWidget * table,
-                                          guint     * row,
-                                          GtkWidget * w);
+void hig_workarea_add_wide_control(GtkWidget *table, guint *row, GtkWidget *w);
 
-GtkWidget* hig_workarea_add_wide_checkbutton (GtkWidget  * table,
-                                              guint      * row,
-                                              const char * mnemonic_string,
-                                              gboolean     is_active);
+GtkWidget *hig_workarea_add_wide_checkbutton(GtkWidget *table, guint *row,
+                                             const char *mnemonic_string, gboolean is_active);
 
-void       hig_workarea_add_label_w (GtkWidget * table,
-                                     guint       row,
-                                     GtkWidget * label_widget);
+void hig_workarea_add_label_w(GtkWidget *table, guint row, GtkWidget *label_widget);
 
-GtkWidget* hig_workarea_add_tall_row (GtkWidget  * table,
-                                      guint      * row,
-                                      const char * mnemonic_string,
-                                      GtkWidget  * control,
-                                      GtkWidget  * mnemonic_or_null_for_control);
+GtkWidget *hig_workarea_add_tall_row(GtkWidget *table, guint *row, const char *mnemonic_string,
+                                     GtkWidget *control, GtkWidget *mnemonic_or_null_for_control);
 
-GtkWidget* hig_workarea_add_row (GtkWidget  * table,
-                                 guint      * row,
-                                 const char * mnemonic_string,
-                                 GtkWidget  * control,
-                                 GtkWidget  * mnemonic_or_null_for_control);
+GtkWidget *hig_workarea_add_row(GtkWidget *table, guint *row, const char *mnemonic_string,
+                                GtkWidget *control, GtkWidget *mnemonic_or_null_for_control);
 
-void       hig_workarea_add_row_w (GtkWidget * table,
-                                   guint     * row,
-                                   GtkWidget * label,
-                                   GtkWidget * control,
-                                   GtkWidget * mnemonic_or_null_for_control);
+void hig_workarea_add_row_w(GtkWidget *table, guint *row, GtkWidget *label, GtkWidget *control,
+                            GtkWidget *mnemonic_or_null_for_control);
 
-enum
-{
+enum {
     GUI_PAD_SMALL = 3,
     GUI_PAD = 6,
     GUI_PAD_BIG = 12,

--- a/src/icons.c
+++ b/src/icons.c
@@ -8,11 +8,10 @@
 
 #include "config.h"
 
-#include <string.h>             /* strcmp */
-#include <glib.h>
-#include <gtk/gtk.h>
-#include <gio/gio.h>
 #include "icons.h"
+#include <gio/gio.h>
+#include <glib.h>
+#include <string.h> /* strcmp */
 
 #define VOID_PIXBUF_KEY "void-pixbuf"
 
@@ -35,10 +34,7 @@ typedef struct {
     GHashTable *cache;
 } IconCache;
 
-
-static IconCache *icon_cache[7] =
-    { NULL, NULL, NULL, NULL, NULL, NULL, NULL };
-
+static IconCache *icon_cache[7] = { NULL, NULL, NULL, NULL, NULL, NULL, NULL };
 
 static GdkPixbuf *create_void_pixbuf(int width, int height)
 {
@@ -50,7 +46,6 @@ static GdkPixbuf *create_void_pixbuf(int width, int height)
     return p;
 }
 
-
 static int get_size_in_pixels(GtkIconSize icon_size)
 {
     int width, height;
@@ -59,29 +54,24 @@ static int get_size_in_pixels(GtkIconSize icon_size)
     return MAX(width, height);
 }
 
-
-static IconCache *icon_cache_new(GtkWidget * for_widget, int icon_size)
+static IconCache *icon_cache_new(GtkWidget *for_widget, int icon_size)
 {
     IconCache *icon_cache;
 
     g_return_val_if_fail(for_widget != NULL, NULL);
 
     icon_cache = g_new0(IconCache, 1);
-    icon_cache->icon_theme =
-        gtk_icon_theme_get_for_screen(gtk_widget_get_screen(for_widget));
+    icon_cache->icon_theme = gtk_icon_theme_get_for_screen(gtk_widget_get_screen(for_widget));
     icon_cache->icon_size = get_size_in_pixels(icon_size);
-    icon_cache->cache =
-        g_hash_table_new_full(g_str_hash, g_str_equal, NULL,
-                              g_object_unref);
+    icon_cache->cache = g_hash_table_new_full(g_str_hash, g_str_equal, NULL, g_object_unref);
 
-    g_hash_table_insert(icon_cache->cache, (void *) VOID_PIXBUF_KEY,
-                        create_void_pixbuf(icon_cache->icon_size,
-                                           icon_cache->icon_size));
+    g_hash_table_insert(icon_cache->cache, (void *)VOID_PIXBUF_KEY,
+                        create_void_pixbuf(icon_cache->icon_size, icon_cache->icon_size));
 
     return icon_cache;
 }
 
-static const char *_icon_cache_get_icon_key(GIcon * icon)
+static const char *_icon_cache_get_icon_key(GIcon *icon)
 {
     const char *key = NULL;
 
@@ -112,10 +102,7 @@ static const char *_icon_cache_get_icon_key(GIcon * icon)
     return key;
 }
 
-
-static GdkPixbuf *get_themed_icon_pixbuf(GThemedIcon * icon,
-                                         int size,
-                                         GtkIconTheme * icon_theme)
+static GdkPixbuf *get_themed_icon_pixbuf(GThemedIcon *icon, int size, GtkIconTheme *icon_theme)
 {
     char **icon_names = NULL;
     GtkIconInfo *icon_info;
@@ -124,13 +111,10 @@ static GdkPixbuf *get_themed_icon_pixbuf(GThemedIcon * icon,
 
     g_object_get(icon, "names", &icon_names, NULL);
 
-    icon_info =
-        gtk_icon_theme_choose_icon(icon_theme, (const char **) icon_names,
-                                   size, 0);
+    icon_info = gtk_icon_theme_choose_icon(icon_theme, (const char **)icon_names, size, 0);
     if (icon_info == NULL)
-        icon_info =
-            gtk_icon_theme_lookup_icon(icon_theme, "text-x-generic", size,
-                                       GTK_ICON_LOOKUP_USE_BUILTIN);
+        icon_info = gtk_icon_theme_lookup_icon(icon_theme, "text-x-generic", size,
+                                               GTK_ICON_LOOKUP_USE_BUILTIN);
 
     pixbuf = gtk_icon_info_load_icon(icon_info, &error);
     if (pixbuf == NULL) {
@@ -145,8 +129,7 @@ static GdkPixbuf *get_themed_icon_pixbuf(GThemedIcon * icon,
     return pixbuf;
 }
 
-
-static GdkPixbuf *get_file_icon_pixbuf(GFileIcon * icon, int size)
+static GdkPixbuf *get_file_icon_pixbuf(GFileIcon *icon, int size)
 {
     GFile *file;
     char *filename;
@@ -161,9 +144,7 @@ static GdkPixbuf *get_file_icon_pixbuf(GFileIcon * icon, int size)
     return pixbuf;
 }
 
-
-static GdkPixbuf *_get_icon_pixbuf(GIcon * icon, int size,
-                                   GtkIconTheme * theme)
+static GdkPixbuf *_get_icon_pixbuf(GIcon *icon, int size, GtkIconTheme *theme)
 {
     if (icon == NULL)
         return NULL;
@@ -174,9 +155,7 @@ static GdkPixbuf *_get_icon_pixbuf(GIcon * icon, int size,
     return NULL;
 }
 
-
-static GdkPixbuf *icon_cache_get_mime_type_icon(IconCache * icon_cache,
-                                                const char *mime_type)
+static GdkPixbuf *icon_cache_get_mime_type_icon(IconCache *icon_cache, const char *mime_type)
 {
     GIcon *icon;
     const char *key = NULL;
@@ -195,21 +174,17 @@ static GdkPixbuf *icon_cache_get_mime_type_icon(IconCache * icon_cache,
         return pixbuf;
     }
 
-    pixbuf =
-        _get_icon_pixbuf(icon, icon_cache->icon_size,
-                         icon_cache->icon_theme);
+    pixbuf = _get_icon_pixbuf(icon, icon_cache->icon_size, icon_cache->icon_theme);
     if (pixbuf != NULL)
-        g_hash_table_insert(icon_cache->cache, (gpointer) key,
-                            g_object_ref(pixbuf));
+        g_hash_table_insert(icon_cache->cache, (gpointer)key, g_object_ref(pixbuf));
 
     g_object_unref(G_OBJECT(icon));
 
     return pixbuf;
 }
 
-GdkPixbuf *gtr_get_mime_type_icon(const char *mime_type,
-                                  GtkIconSize icon_size,
-                                  GtkWidget * for_widget)
+GdkPixbuf *gtr_get_mime_type_icon(const char *mime_type, GtkIconSize icon_size,
+                                  GtkWidget *for_widget)
 {
     int n;
 
@@ -232,7 +207,7 @@ GdkPixbuf *gtr_get_mime_type_icon(const char *mime_type,
     case GTK_ICON_SIZE_DIALOG:
         n = 6;
         break;
-    default /*GTK_ICON_SIZE_INVALID */ :
+    default /*GTK_ICON_SIZE_INVALID */:
         n = 0;
         break;
     }
@@ -242,7 +217,6 @@ GdkPixbuf *gtr_get_mime_type_icon(const char *mime_type,
 
     return icon_cache_get_mime_type_icon(icon_cache[n], mime_type);
 }
-
 
 const char *gtr_get_mime_type_from_filename(const char *file G_GNUC_UNUSED)
 {

--- a/src/icons.h
+++ b/src/icons.h
@@ -9,13 +9,14 @@
 #ifndef GTR_ICONS_H
 #define GTR_ICONS_H
 
+#include <gtk/gtk.h>
+
 #define DIRECTORY_MIME_TYPE "folder"
-#define UNKNOWN_MIME_TYPE "unknown"
+#define UNKNOWN_MIME_TYPE   "unknown"
 
 const char *gtr_get_mime_type_from_filename(const char *file);
 
-GdkPixbuf *gtr_get_mime_type_icon(const char *mime_type,
-                                  GtkIconSize icon_size,
-                                  GtkWidget * for_widget);
+GdkPixbuf *gtr_get_mime_type_icon(const char *mime_type, GtkIconSize icon_size,
+                                  GtkWidget *for_widget);
 
 #endif

--- a/src/json.c
+++ b/src/json.c
@@ -21,16 +21,16 @@
 
 #include <glib-object.h>
 #include <glib/gprintf.h>
-#include <json-glib/json-glib.h>
 #include <gtk/gtk.h>
+#include <json-glib/json-glib.h>
 
+#include "json.h"
 #include "protocol-constants.h"
 #include "requests.h"
-#include "json.h"
 
 /* JSON helper functions */
 
-gchar *trg_serialize(JsonNode * req)
+gchar *trg_serialize(JsonNode *req)
 {
     JsonGenerator *generator;
     gsize length;
@@ -45,15 +45,14 @@ gchar *trg_serialize(JsonNode * req)
     return response;
 }
 
-JsonObject *trg_deserialize(trg_response * response, GError ** error)
+JsonObject *trg_deserialize(trg_response *response, GError **error)
 {
     JsonParser *parser;
     JsonNode *root;
     JsonObject *ret = NULL;
 
     parser = json_parser_new();
-    json_parser_load_from_data(parser, response->raw, response->size,
-                               error);
+    json_parser_load_from_data(parser, response->raw, response->size, error);
     if (*error == NULL) {
         root = json_parser_get_root(parser);
 #ifdef DEBUG
@@ -83,30 +82,30 @@ JsonObject *trg_deserialize(trg_response * response, GError ** error)
     return ret;
 }
 
-JsonObject *node_get_arguments(JsonNode * req)
+JsonObject *node_get_arguments(JsonNode *req)
 {
     JsonObject *rootObj = json_node_get_object(req);
     return get_arguments(rootObj);
 }
 
-JsonObject *get_arguments(JsonObject * req)
+JsonObject *get_arguments(JsonObject *req)
 {
     return json_object_get_object_member(req, PARAM_ARGUMENTS);
 }
 
-gdouble json_double_to_progress(JsonNode * n)
+gdouble json_double_to_progress(JsonNode *n)
 {
     return json_node_really_get_double(n) * 100.0;
 }
 
-gdouble json_node_really_get_double(JsonNode * node)
+gdouble json_node_really_get_double(JsonNode *node)
 {
     GValue a = G_VALUE_INIT;
 
     json_node_get_value(node, &a);
     switch (G_VALUE_TYPE(&a)) {
     case G_TYPE_INT64:
-        return (gdouble) g_value_get_int64(&a);
+        return (gdouble)g_value_get_int64(&a);
     case G_TYPE_DOUBLE:
         return g_value_get_double(&a);
     default:

--- a/src/json.h
+++ b/src/json.h
@@ -25,11 +25,11 @@
 
 #include "trg-client.h"
 
-gchar *trg_serialize(JsonNode * req);
-JsonObject *trg_deserialize(trg_response * response, GError ** error);
-JsonObject *get_arguments(JsonObject * req);
-JsonObject *node_get_arguments(JsonNode * req);
-gdouble json_double_to_progress(JsonNode * n);
-gdouble json_node_really_get_double(JsonNode * node);
+gchar *trg_serialize(JsonNode *req);
+JsonObject *trg_deserialize(trg_response *response, GError **error);
+JsonObject *get_arguments(JsonObject *req);
+JsonObject *node_get_arguments(JsonNode *req);
+gdouble json_double_to_progress(JsonNode *n);
+gdouble json_node_really_get_double(JsonNode *node);
 
-#endif                          /* JSON_H_ */
+#endif /* JSON_H_ */

--- a/src/main.c
+++ b/src/main.c
@@ -22,13 +22,13 @@
 #include <curl/curl.h>
 #include <curl/easy.h>
 
-#include <glib/gi18n.h>
 #include <glib-object.h>
+#include <glib/gi18n.h>
 #include <gtk/gtk.h>
 
+#include "trg-client.h"
 #include "trg-gtk-app.h"
 #include "trg-main-window.h"
-#include "trg-client.h"
 
 /* Handle arguments and start the main window. */
 
@@ -36,11 +36,9 @@
 static void bindtext_wrapper(void)
 {
 #ifdef G_OS_WIN32
-    gchar *moddir =
-        g_win32_get_package_installation_directory_of_module(NULL);
+    gchar *moddir = g_win32_get_package_installation_directory_of_module(NULL);
 
-    gchar *localedir = g_build_path(G_DIR_SEPARATOR_S,
-                                    moddir, "share", "locale", NULL);
+    gchar *localedir = g_build_path(G_DIR_SEPARATOR_S, moddir, "share", "locale", NULL);
 
     bindtextdomain(GETTEXT_PACKAGE, localedir);
     g_free(moddir);

--- a/src/protocol-constants.h
+++ b/src/protocol-constants.h
@@ -22,120 +22,120 @@
 
 /* generic contstants */
 
-#define PARAM_METHOD		"method"
-#define FIELD_ID                "id"
+#define PARAM_METHOD "method"
+#define FIELD_ID     "id"
 
 /* top level */
 
-#define FIELD_RESULT        "result"
-#define FIELD_SUCCESS       "success"
+#define FIELD_RESULT  "result"
+#define FIELD_SUCCESS "success"
 
 /* torrents */
 
-#define FIELD_RECENTLY_ACTIVE     "recently-active"
-#define FIELD_TORRENTS          "torrents"      /* parent node */
-#define FIELD_REMOVED           "removed"
-#define FIELD_ANNOUNCE_URL      "announceUrl"
-#define FIELD_LEFT_UNTIL_DONE   "leftUntilDone"
-#define FIELD_TOTAL_SIZE        "totalSize"
-#define FIELD_DONE_DATE         "doneDate"
-#define FIELD_ADDED_DATE        "addedDate"
-#define FIELD_DATE_CREATED      "dateCreated"
-#define FIELD_TRACKER_STATS          "trackerStats"
-#define FIELD_DOWNLOAD_DIR      "downloadDir"
-#define FIELD_HASH_STRING       "hashString"
+#define FIELD_RECENTLY_ACTIVE "recently-active"
+#define FIELD_TORRENTS        "torrents" /* parent node */
+#define FIELD_REMOVED         "removed"
+#define FIELD_ANNOUNCE_URL    "announceUrl"
+#define FIELD_LEFT_UNTIL_DONE "leftUntilDone"
+#define FIELD_TOTAL_SIZE      "totalSize"
+#define FIELD_DONE_DATE       "doneDate"
+#define FIELD_ADDED_DATE      "addedDate"
+#define FIELD_DATE_CREATED    "dateCreated"
+#define FIELD_TRACKER_STATS   "trackerStats"
+#define FIELD_DOWNLOAD_DIR    "downloadDir"
+#define FIELD_HASH_STRING     "hashString"
 //#define FIELD_SWARM_SPEED       "swarmSpeed"
-#define FIELD_NAME				"name"
-#define FIELD_PATH				"path"
-#define FIELD_SIZEWHENDONE		"sizeWhenDone"
-#define FIELD_STATUS			"status"
-#define FIELD_MOVE				"move"
-#define FIELD_CREATOR           "creator"
-#define FIELD_LOCATION			"location"
-#define FIELD_RATEDOWNLOAD		"rateDownload"
-#define FIELD_RATEUPLOAD		"rateUpload"
-#define FIELD_ETA				"eta"
-#define FIELD_UPLOADEDEVER		"uploadedEver"
-#define FIELD_DOWNLOADEDEVER	"downloadedEver"
-#define FIELD_CORRUPTEVER		"corruptEver"
-#define FIELD_HAVEVALID			"haveValid"
-#define FIELD_HAVEUNCHECKED		"haveUnchecked"
-#define FIELD_PERCENTDONE		"percentDone"
-#define FIELD_PEERS             "peers"
-#define FIELD_PEERSFROM         "peersFrom"
-#define FIELD_FILES             "files"
-#define FIELD_WANTED            "wanted"
+#define FIELD_NAME                    "name"
+#define FIELD_PATH                    "path"
+#define FIELD_SIZEWHENDONE            "sizeWhenDone"
+#define FIELD_STATUS                  "status"
+#define FIELD_MOVE                    "move"
+#define FIELD_CREATOR                 "creator"
+#define FIELD_LOCATION                "location"
+#define FIELD_RATEDOWNLOAD            "rateDownload"
+#define FIELD_RATEUPLOAD              "rateUpload"
+#define FIELD_ETA                     "eta"
+#define FIELD_UPLOADEDEVER            "uploadedEver"
+#define FIELD_DOWNLOADEDEVER          "downloadedEver"
+#define FIELD_CORRUPTEVER             "corruptEver"
+#define FIELD_HAVEVALID               "haveValid"
+#define FIELD_HAVEUNCHECKED           "haveUnchecked"
+#define FIELD_PERCENTDONE             "percentDone"
+#define FIELD_PEERS                   "peers"
+#define FIELD_PEERSFROM               "peersFrom"
+#define FIELD_FILES                   "files"
+#define FIELD_WANTED                  "wanted"
 #define FIELD_WEB_SEEDS_SENDING_TO_US "webseedsSendingToUs"
-#define FIELD_PRIORITIES        "priorities"
-#define FIELD_COMMENT           "comment"
-#define FIELD_LEFTUNTILDONE     "leftUntilDone"
-#define FIELD_ISFINISHED        "isFinished"
-#define FIELD_ISPRIVATE         "isPrivate"
-#define FIELD_MAGNETLINK        "magnetLink"
-#define FIELD_ERROR				"error"
-#define FIELD_ERROR_STRING      "errorString"
-#define FIELD_BANDWIDTH_PRIORITY "bandwidthPriority"
-#define FIELD_UPLOAD_LIMIT      "uploadLimit"
-#define FIELD_UPLOAD_LIMITED    "uploadLimited"
-#define FIELD_DOWNLOAD_LIMIT    "downloadLimit"
-#define FIELD_DOWNLOAD_LIMITED  "downloadLimited"
-#define FIELD_HONORS_SESSION_LIMITS "honorsSessionLimits"
-#define FIELD_SEED_RATIO_MODE   "seedRatioMode"
-#define FIELD_SEED_RATIO_LIMIT   "seedRatioLimit"
-#define FIELD_PEER_LIMIT         "peer-limit"
-#define FIELD_DOWNLOAD_DIR		"downloadDir"
-#define FIELD_FILE_DOWNLOAD_DIR "download-dir"
-#define FIELD_PEERS_SENDING_TO_US "peersSendingToUs"
-#define FIELD_PEERS_GETTING_FROM_US "peersGettingFromUs"
-#define FIELD_PEERS_CONNECTED "peersConnected"
-#define FIELD_QUEUE_POSITION "queuePosition"
-#define FIELD_ACTIVITY_DATE "activityDate"
-#define FIELD_ISPRIVATE "isPrivate"
+#define FIELD_PRIORITIES              "priorities"
+#define FIELD_COMMENT                 "comment"
+#define FIELD_LEFTUNTILDONE           "leftUntilDone"
+#define FIELD_ISFINISHED              "isFinished"
+#define FIELD_ISPRIVATE               "isPrivate"
+#define FIELD_MAGNETLINK              "magnetLink"
+#define FIELD_ERROR                   "error"
+#define FIELD_ERROR_STRING            "errorString"
+#define FIELD_BANDWIDTH_PRIORITY      "bandwidthPriority"
+#define FIELD_UPLOAD_LIMIT            "uploadLimit"
+#define FIELD_UPLOAD_LIMITED          "uploadLimited"
+#define FIELD_DOWNLOAD_LIMIT          "downloadLimit"
+#define FIELD_DOWNLOAD_LIMITED        "downloadLimited"
+#define FIELD_HONORS_SESSION_LIMITS   "honorsSessionLimits"
+#define FIELD_SEED_RATIO_MODE         "seedRatioMode"
+#define FIELD_SEED_RATIO_LIMIT        "seedRatioLimit"
+#define FIELD_PEER_LIMIT              "peer-limit"
+#define FIELD_DOWNLOAD_DIR            "downloadDir"
+#define FIELD_FILE_DOWNLOAD_DIR       "download-dir"
+#define FIELD_PEERS_SENDING_TO_US     "peersSendingToUs"
+#define FIELD_PEERS_GETTING_FROM_US   "peersGettingFromUs"
+#define FIELD_PEERS_CONNECTED         "peersConnected"
+#define FIELD_QUEUE_POSITION          "queuePosition"
+#define FIELD_ACTIVITY_DATE           "activityDate"
+#define FIELD_ISPRIVATE               "isPrivate"
 #define FIELD_METADATAPERCENTCOMPLETE "metadataPercentComplete"
 
-#define FIELD_FILES_WANTED      "files-wanted"
-#define FIELD_FILES_UNWANTED    "files-unwanted"
-#define FIELD_FILES_PRIORITY_HIGH "priority-high"
+#define FIELD_FILES_WANTED          "files-wanted"
+#define FIELD_FILES_UNWANTED        "files-unwanted"
+#define FIELD_FILES_PRIORITY_HIGH   "priority-high"
 #define FIELD_FILES_PRIORITY_NORMAL "priority-normal"
-#define FIELD_FILES_PRIORITY_LOW "priority-low"
+#define FIELD_FILES_PRIORITY_LOW    "priority-low"
 
 /* trackers */
 
-#define FIELD_TIER                      "tier"
-#define FIELD_ANNOUNCE                  "announce"
-#define FIELD_SCRAPE                    "scrape"
-#define FIELD_LAST_ANNOUNCE_PEER_COUNT  "lastAnnouncePeerCount"
-#define FIELD_LAST_ANNOUNCE_TIME        "lastAnnounceTime"
-#define FIELD_LAST_SCRAPE_TIME          "lastScrapeTime"
-#define FIELD_SEEDERCOUNT               "seederCount"
-#define FIELD_LEECHERCOUNT              "leecherCount"
-#define FIELD_DOWNLOADCOUNT             "downloadCount"
-#define FIELD_HOST                      "host"
-#define FIELD_LAST_ANNOUNCE_RESULT      "lastAnnounceResult"
-#define FIELD_RECHECK_PROGRESS          "recheckProgress"
+#define FIELD_TIER                     "tier"
+#define FIELD_ANNOUNCE                 "announce"
+#define FIELD_SCRAPE                   "scrape"
+#define FIELD_LAST_ANNOUNCE_PEER_COUNT "lastAnnouncePeerCount"
+#define FIELD_LAST_ANNOUNCE_TIME       "lastAnnounceTime"
+#define FIELD_LAST_SCRAPE_TIME         "lastScrapeTime"
+#define FIELD_SEEDERCOUNT              "seederCount"
+#define FIELD_LEECHERCOUNT             "leecherCount"
+#define FIELD_DOWNLOADCOUNT            "downloadCount"
+#define FIELD_HOST                     "host"
+#define FIELD_LAST_ANNOUNCE_RESULT     "lastAnnounceResult"
+#define FIELD_RECHECK_PROGRESS         "recheckProgress"
 
 /* methods */
 
-#define METHOD_TORRENT_START    "torrent-start"
-#define METHOD_SESSION_GET      "session-get"
-#define METHOD_SESSION_SET      "session-set"
-#define METHOD_TORRENT_GET      "torrent-get"
-#define METHOD_TORRENT_SET      "torrent-set"
+#define METHOD_TORRENT_START        "torrent-start"
+#define METHOD_SESSION_GET          "session-get"
+#define METHOD_SESSION_SET          "session-set"
+#define METHOD_TORRENT_GET          "torrent-get"
+#define METHOD_TORRENT_SET          "torrent-set"
 #define METHOD_TORRENT_SET_LOCATION "torrent-set-location"
-#define METHOD_TORRENT_RENAME_PATH "torrent-rename-path"
-#define METHOD_TORRENT_STOP     "torrent-stop"
-#define METHOD_TORRENT_VERIFY   "torrent-verify"
-#define METHOD_TORRENT_REMOVE   "torrent-remove"
-#define METHOD_TORRENT_ADD      "torrent-add"
-#define METHOD_TORRENT_REANNOUNCE "torrent-reannounce"
-#define METHOD_PORT_TEST		"port-test"
-#define METHOD_BLOCKLIST_UPDATE	"blocklist-update"
-#define METHOD_SESSION_STATS	"session-stats"
-#define METHOD_QUEUE_MOVE_TOP   "queue-move-top"
-#define METHOD_QUEUE_MOVE_UP    "queue-move-up"
-#define METHOD_QUEUE_MOVE_BOTTOM "queue-move-bottom"
-#define METHOD_QUEUE_MOVE_DOWN  "queue-move-down"
-#define METHOD_TORRENT_START_NOW "torrent-start-now"
+#define METHOD_TORRENT_RENAME_PATH  "torrent-rename-path"
+#define METHOD_TORRENT_STOP         "torrent-stop"
+#define METHOD_TORRENT_VERIFY       "torrent-verify"
+#define METHOD_TORRENT_REMOVE       "torrent-remove"
+#define METHOD_TORRENT_ADD          "torrent-add"
+#define METHOD_TORRENT_REANNOUNCE   "torrent-reannounce"
+#define METHOD_PORT_TEST            "port-test"
+#define METHOD_BLOCKLIST_UPDATE     "blocklist-update"
+#define METHOD_SESSION_STATS        "session-stats"
+#define METHOD_QUEUE_MOVE_TOP       "queue-move-top"
+#define METHOD_QUEUE_MOVE_UP        "queue-move-up"
+#define METHOD_QUEUE_MOVE_BOTTOM    "queue-move-bottom"
+#define METHOD_QUEUE_MOVE_DOWN      "queue-move-down"
+#define METHOD_TORRENT_START_NOW    "torrent-start-now"
 
 #define PARAM_IDS               "ids"
 #define PARAM_DELETE_LOCAL_DATA "delete-local-data"
@@ -148,26 +148,26 @@
 
 /* peers structure */
 
-#define TPEER_ADDRESS           "address"
-#define TPEER_CLIENT_NAME       "clientName"
-#define TPEER_PROGRESS          "progress"
-#define TPEER_RATE_TO_CLIENT    "rateToClient"
-#define TPEER_RATE_TO_PEER      "rateToPeer"
-#define TPEER_IS_ENCRYPTED      "isEncrypted"
+#define TPEER_ADDRESS             "address"
+#define TPEER_CLIENT_NAME         "clientName"
+#define TPEER_PROGRESS            "progress"
+#define TPEER_RATE_TO_CLIENT      "rateToClient"
+#define TPEER_RATE_TO_PEER        "rateToPeer"
+#define TPEER_IS_ENCRYPTED        "isEncrypted"
 #define TPEER_IS_DOWNLOADING_FROM "isDownloadingFrom"
-#define TPEER_IS_UPLOADING_TO "isUploadingTo"
-#define TPEER_FLAGSTR            "flagStr"
+#define TPEER_IS_UPLOADING_TO     "isUploadingTo"
+#define TPEER_FLAGSTR             "flagStr"
 
-#define TPEERFROM_FROMPEX        "fromPex"
-#define TPEERFROM_FROMDHT        "fromDht"
-#define TPEERFROM_FROMTRACKERS   "fromTracker"
-#define TPEERFROM_FROMLTEP       "fromLtep"
-#define TPEERFROM_FROMRESUME     "fromCache"
-#define TPEERFROM_FROMINCOMING   "fromIncoming"
-#define TPEERFROM_FROMLPD        "fromLpd"
+#define TPEERFROM_FROMPEX      "fromPex"
+#define TPEERFROM_FROMDHT      "fromDht"
+#define TPEERFROM_FROMTRACKERS "fromTracker"
+#define TPEERFROM_FROMLTEP     "fromLtep"
+#define TPEERFROM_FROMRESUME   "fromCache"
+#define TPEERFROM_FROMINCOMING "fromIncoming"
+#define TPEERFROM_FROMLPD      "fromLpd"
 
 /* The rpc-version >= that the status field of torrent-get changed */
-#define NEW_STATUS_RPC_VERSION  14
+#define NEW_STATUS_RPC_VERSION 14
 
 typedef enum {
     OLD_STATUS_WAITING_TO_CHECK = 1,
@@ -178,25 +178,25 @@ typedef enum {
 } trg_old_status;
 
 typedef enum {
-    TR_STATUS_STOPPED = 0,      /* Torrent is stopped */
-    TR_STATUS_CHECK_WAIT = 1,   /* Queued to check files */
-    TR_STATUS_CHECK = 2,        /* Checking files */
-    TR_STATUS_DOWNLOAD_WAIT = 3,        /* Queued to download */
-    TR_STATUS_DOWNLOAD = 4,     /* Downloading */
-    TR_STATUS_SEED_WAIT = 5,    /* Queued to seed */
-    TR_STATUS_SEED = 6          /* Seeding */
+    TR_STATUS_STOPPED = 0, /* Torrent is stopped */
+    TR_STATUS_CHECK_WAIT = 1, /* Queued to check files */
+    TR_STATUS_CHECK = 2, /* Checking files */
+    TR_STATUS_DOWNLOAD_WAIT = 3, /* Queued to download */
+    TR_STATUS_DOWNLOAD = 4, /* Downloading */
+    TR_STATUS_SEED_WAIT = 5, /* Queued to seed */
+    TR_STATUS_SEED = 6 /* Seeding */
 } tr_torrent_activity;
 
 enum {
-    TR_PRI_UNSET = -3,          /* Not actually in the protocol. Just used in UI. */
-    TR_PRI_MIXED = -2,          /* Neither is this. */
+    TR_PRI_UNSET = -3, /* Not actually in the protocol. Just used in UI. */
+    TR_PRI_MIXED = -2, /* Neither is this. */
     TR_PRI_LOW = -1,
-    TR_PRI_NORMAL = 0,          /* since NORMAL is 0, memset initializes nicely */
+    TR_PRI_NORMAL = 0, /* since NORMAL is 0, memset initializes nicely */
     TR_PRI_HIGH = 1
 };
 
-#define TFILE_LENGTH                            "length"
-#define TFILE_BYTES_COMPLETED                   "bytesCompleted"
-#define TFILE_NAME                              "name"
+#define TFILE_LENGTH          "length"
+#define TFILE_BYTES_COMPLETED "bytesCompleted"
+#define TFILE_NAME            "name"
 
-#endif                          /* PROTOCOL_CONSTANTS_H_ */
+#endif /* PROTOCOL_CONSTANTS_H_ */

--- a/src/remote-exec.c
+++ b/src/remote-exec.c
@@ -23,12 +23,11 @@
 #include <gtk/gtk.h>
 #include <json-glib/json-glib.h>
 
-#include "trg-torrent-model.h"
-#include "trg-client.h"
-#include "trg-prefs.h"
 #include "protocol-constants.h"
-#include "torrent.h"
 #include "remote-exec.h"
+#include "torrent.h"
+#include "trg-prefs.h"
+#include "trg-torrent-model.h"
 
 /* A few functions used to build local commands, otherwise known as actions.
  *
@@ -40,21 +39,20 @@
  * cause it to be repeated for each selection.
  */
 
-static const char json_exceptions[] = { 0x7f, 0x80, 0x81, 0x82, 0x83, 0x84,
-    0x85, 0x86, 0x87, 0x88, 0x89, 0x8a, 0x8b, 0x8c, 0x8d, 0x8e, 0x8f, 0x90,
-    0x91, 0x92, 0x93, 0x94, 0x95, 0x96, 0x97, 0x98, 0x99, 0x9a, 0x9b, 0x9c,
-    0x9d, 0x9e, 0x9f, 0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8,
-    0xa9, 0xaa, 0xab, 0xac, 0xad, 0xae, 0xaf, 0xb0, 0xb1, 0xb2, 0xb3, 0xb4,
-    0xb5, 0xb6, 0xb7, 0xb8, 0xb9, 0xba, 0xbb, 0xbc, 0xbd, 0xbe, 0xbf, 0xc0,
-    0xc1, 0xc2, 0xc3, 0xc4, 0xc5, 0xc6, 0xc7, 0xc8, 0xc9, 0xca, 0xcb, 0xcc,
-    0xcd, 0xce, 0xcf, 0xd0, 0xd1, 0xd2, 0xd3, 0xd4, 0xd5, 0xd6, 0xd7, 0xd8,
-    0xd9, 0xda, 0xdb, 0xdc, 0xdd, 0xde, 0xdf, 0xe0, 0xe1, 0xe2, 0xe3, 0xe4,
-    0xe5, 0xe6, 0xe7, 0xe8, 0xe9, 0xea, 0xeb, 0xec, 0xed, 0xee, 0xef, 0xf0,
-    0xf1, 0xf2, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7, 0xf8, 0xf9, 0xfa, 0xfb, 0xfc,
-    0xfd, 0xfe, 0xff, '\0'      /* g_strescape() expects a NUL-terminated string */
+static const char json_exceptions[] = {
+    0x7f, 0x80, 0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87, 0x88, 0x89, 0x8a, 0x8b, 0x8c, 0x8d,
+    0x8e, 0x8f, 0x90, 0x91, 0x92, 0x93, 0x94, 0x95, 0x96, 0x97, 0x98, 0x99, 0x9a, 0x9b, 0x9c,
+    0x9d, 0x9e, 0x9f, 0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8, 0xa9, 0xaa, 0xab,
+    0xac, 0xad, 0xae, 0xaf, 0xb0, 0xb1, 0xb2, 0xb3, 0xb4, 0xb5, 0xb6, 0xb7, 0xb8, 0xb9, 0xba,
+    0xbb, 0xbc, 0xbd, 0xbe, 0xbf, 0xc0, 0xc1, 0xc2, 0xc3, 0xc4, 0xc5, 0xc6, 0xc7, 0xc8, 0xc9,
+    0xca, 0xcb, 0xcc, 0xcd, 0xce, 0xcf, 0xd0, 0xd1, 0xd2, 0xd3, 0xd4, 0xd5, 0xd6, 0xd7, 0xd8,
+    0xd9, 0xda, 0xdb, 0xdc, 0xdd, 0xde, 0xdf, 0xe0, 0xe1, 0xe2, 0xe3, 0xe4, 0xe5, 0xe6, 0xe7,
+    0xe8, 0xe9, 0xea, 0xeb, 0xec, 0xed, 0xee, 0xef, 0xf0, 0xf1, 0xf2, 0xf3, 0xf4, 0xf5, 0xf6,
+    0xf7, 0xf8, 0xf9, 0xfa, 0xfb, 0xfc, 0xfd, 0xfe, 0xff, '\0' /* g_strescape() expects a
+                                                                  NUL-terminated string */
 };
 
-static gchar *dump_json_value(JsonNode * node)
+static gchar *dump_json_value(JsonNode *node)
 {
     GValue value = G_VALUE_INIT;
     GString *buffer;
@@ -65,32 +63,23 @@ static gchar *dump_json_value(JsonNode * node)
 
     switch (G_VALUE_TYPE(&value)) {
     case G_TYPE_INT64:
-        g_string_append_printf(buffer, "%" G_GINT64_FORMAT,
-                               g_value_get_int64(&value));
+        g_string_append_printf(buffer, "%" G_GINT64_FORMAT, g_value_get_int64(&value));
         break;
-    case G_TYPE_STRING:
-        {
-            gchar *tmp;
+    case G_TYPE_STRING: {
+        gchar *tmp;
 
-            tmp = g_strescape(g_value_get_string(&value), json_exceptions);
-            g_string_append(buffer, tmp);
+        tmp = g_strescape(g_value_get_string(&value), json_exceptions);
+        g_string_append(buffer, tmp);
 
-            g_free(tmp);
-        }
-        break;
-    case G_TYPE_DOUBLE:
-        {
-            gchar buf[G_ASCII_DTOSTR_BUF_SIZE];
+        g_free(tmp);
+    } break;
+    case G_TYPE_DOUBLE: {
+        gchar buf[G_ASCII_DTOSTR_BUF_SIZE];
 
-            g_string_append(buffer,
-                            g_ascii_dtostr(buf, sizeof(buf),
-                                           g_value_get_double(&value)));
-        }
-        break;
+        g_string_append(buffer, g_ascii_dtostr(buf, sizeof(buf), g_value_get_double(&value)));
+    } break;
     case G_TYPE_BOOLEAN:
-        g_string_append_printf(buffer, "%s",
-                               g_value_get_boolean(&value) ? "true" :
-                               "false");
+        g_string_append_printf(buffer, "%s", g_value_get_boolean(&value) ? "true" : "false");
         break;
     default:
         break;
@@ -101,8 +90,8 @@ static gchar *dump_json_value(JsonNode * node)
     return g_string_free(buffer, FALSE);
 }
 
-gchar *build_remote_exec_cmd(TrgClient * tc, GtkTreeModel * model,
-                             GList * selection, const gchar * input)
+gchar *build_remote_exec_cmd(TrgClient *tc, GtkTreeModel *model, GList *selection,
+                             const gchar *input)
 {
     TrgPrefs *prefs = trg_client_get_prefs(tc);
     JsonObject *session = trg_client_get_session(tc);
@@ -148,10 +137,8 @@ gchar *build_remote_exec_cmd(TrgClient * tc, GtkTreeModel * model,
 
                 for (li = selection; li; li = g_list_next(li)) {
                     piece = NULL;
-                    gtk_tree_model_get_iter(model, &iter,
-                                            (GtkTreePath *) li->data);
-                    gtk_tree_model_get(model, &iter, TORRENT_COLUMN_JSON,
-                                       &json, -1);
+                    gtk_tree_model_get_iter(model, &iter, (GtkTreePath *)li->data);
+                    gtk_tree_model_get(model, &iter, TORRENT_COLUMN_JSON, &json, -1);
                     if (json_object_has_member(json, id)) {
                         replacement = json_object_get_member(json, id);
                         if (JSON_NODE_HOLDS_VALUE(replacement)) {
@@ -189,8 +176,7 @@ gchar *build_remote_exec_cmd(TrgClient * tc, GtkTreeModel * model,
                 // Values are not guaranteed to be shell safe
                 valueEscaped = g_shell_quote(valuestr);
 
-                tmp = g_regex_replace(replacerx, work, -1, 0, valueEscaped, 0,
-                                      NULL);
+                tmp = g_regex_replace(replacerx, work, -1, 0, valueEscaped, 0, NULL);
                 g_free(work);
                 work = tmp;
                 g_free(valuestr);

--- a/src/remote-exec.h
+++ b/src/remote-exec.h
@@ -20,7 +20,9 @@
 #ifndef REMOTE_EXEC_H_
 #define REMOTE_EXEC_H_
 
-gchar *build_remote_exec_cmd(TrgClient * tc, GtkTreeModel * model,
-                             GList * selection, const gchar * input);
+#include "trg-client.h"
 
-#endif                          /* REMOTE_EXEC_H_ */
+gchar *build_remote_exec_cmd(TrgClient *tc, GtkTreeModel *model, GList *selection,
+                             const gchar *input);
+
+#endif /* REMOTE_EXEC_H_ */

--- a/src/requests.c
+++ b/src/requests.c
@@ -21,23 +21,23 @@
 
 #include <stdio.h>
 
-#include <glib/gstdio.h>
 #include <glib-object.h>
+#include <glib/gstdio.h>
 #include <json-glib/json-glib.h>
 
-#include "protocol-constants.h"
 #include "json.h"
+#include "protocol-constants.h"
+#include "requests.h"
 #include "torrent.h"
 #include "util.h"
-#include "requests.h"
 
 /* A bunch of functions for creating the various requests, in the form of a
  * JsonNode ready for dispatch.
  */
 
-static JsonNode *base_request(gchar * method);
+static JsonNode *base_request(gchar *method);
 
-JsonNode *generic_request(gchar * method, JsonArray * ids)
+JsonNode *generic_request(gchar *method, JsonArray *ids)
 {
     JsonNode *root = base_request(method);
 
@@ -70,8 +70,7 @@ JsonNode *session_get(void)
     return base_request(METHOD_SESSION_GET);
 }
 
-JsonNode *torrent_set_location(JsonArray * array, gchar * location,
-                               gboolean move)
+JsonNode *torrent_set_location(JsonArray *array, gchar *location, gboolean move)
 {
     JsonNode *req = generic_request(METHOD_TORRENT_SET_LOCATION, array);
     JsonObject *args = node_get_arguments(req);
@@ -80,8 +79,7 @@ JsonNode *torrent_set_location(JsonArray * array, gchar * location,
     return req;
 }
 
-JsonNode *torrent_rename_path(JsonArray * array, const gchar * path,
-                              const gchar * name)
+JsonNode *torrent_rename_path(JsonArray *array, const gchar *path, const gchar *name)
 {
     JsonNode *req = generic_request(METHOD_TORRENT_RENAME_PATH, array);
     JsonObject *args = node_get_arguments(req);
@@ -90,47 +88,47 @@ JsonNode *torrent_rename_path(JsonArray * array, const gchar * path,
     return req;
 }
 
-JsonNode *torrent_start(JsonArray * array)
+JsonNode *torrent_start(JsonArray *array)
 {
     return generic_request(METHOD_TORRENT_START, array);
 }
 
-JsonNode *torrent_pause(JsonArray * array)
+JsonNode *torrent_pause(JsonArray *array)
 {
     return generic_request(METHOD_TORRENT_STOP, array);
 }
 
-JsonNode *torrent_reannounce(JsonArray * array)
+JsonNode *torrent_reannounce(JsonArray *array)
 {
     return generic_request(METHOD_TORRENT_REANNOUNCE, array);
 }
 
-JsonNode *torrent_verify(JsonArray * array)
+JsonNode *torrent_verify(JsonArray *array)
 {
     return generic_request(METHOD_TORRENT_VERIFY, array);
 }
 
-JsonNode *torrent_queue_move_up(JsonArray * array)
+JsonNode *torrent_queue_move_up(JsonArray *array)
 {
     return generic_request(METHOD_QUEUE_MOVE_UP, array);
 }
 
-JsonNode *torrent_queue_move_down(JsonArray * array)
+JsonNode *torrent_queue_move_down(JsonArray *array)
 {
     return generic_request(METHOD_QUEUE_MOVE_DOWN, array);
 }
 
-JsonNode *torrent_start_now(JsonArray * array)
+JsonNode *torrent_start_now(JsonArray *array)
 {
     return generic_request(METHOD_TORRENT_START_NOW, array);
 }
 
-JsonNode *torrent_queue_move_bottom(JsonArray * array)
+JsonNode *torrent_queue_move_bottom(JsonArray *array)
 {
     return generic_request(METHOD_QUEUE_MOVE_BOTTOM, array);
 }
 
-JsonNode *torrent_queue_move_top(JsonArray * array)
+JsonNode *torrent_queue_move_top(JsonArray *array)
 {
     return generic_request(METHOD_QUEUE_MOVE_TOP, array);
 }
@@ -140,19 +138,18 @@ JsonNode *session_set(void)
     return generic_request(METHOD_SESSION_SET, NULL);
 }
 
-JsonNode *torrent_set(JsonArray * array)
+JsonNode *torrent_set(JsonArray *array)
 {
     return generic_request(METHOD_TORRENT_SET, array);
 }
 
-JsonNode *torrent_remove(JsonArray * array, gboolean removeData)
+JsonNode *torrent_remove(JsonArray *array, gboolean removeData)
 {
     JsonNode *root = base_request(METHOD_TORRENT_REMOVE);
     JsonObject *args = node_get_arguments(root);
 
     json_object_set_array_member(args, PARAM_IDS, array);
-    json_object_set_boolean_member(args, PARAM_DELETE_LOCAL_DATA,
-                                   removeData);
+    json_object_set_boolean_member(args, PARAM_DELETE_LOCAL_DATA, removeData);
 
     request_set_tag(root, TORRENT_GET_TAG_MODE_FULL);
 
@@ -166,8 +163,7 @@ JsonNode *torrent_get(gint64 id)
     JsonArray *fields = json_array_new();
 
     if (id == TORRENT_GET_TAG_MODE_UPDATE) {
-        json_object_set_string_member(args, PARAM_IDS,
-                                      FIELD_RECENTLY_ACTIVE);
+        json_object_set_string_member(args, PARAM_IDS, FIELD_RECENTLY_ACTIVE);
     } else if (id >= 0) {
         JsonArray *ids = json_array_new();
         json_array_add_int_element(ids, id);
@@ -230,7 +226,7 @@ JsonNode *torrent_get(gint64 id)
     return root;
 }
 
-JsonNode *torrent_add_url(const gchar * url, gboolean paused)
+JsonNode *torrent_add_url(const gchar *url, gboolean paused)
 {
     JsonNode *root = base_request(METHOD_TORRENT_ADD);
     JsonObject *args = node_get_arguments(root);
@@ -241,22 +237,21 @@ JsonNode *torrent_add_url(const gchar * url, gboolean paused)
     return root;
 }
 
-JsonNode *torrent_add_from_response(trg_response *response, gint flags) {
+JsonNode *torrent_add_from_response(trg_response *response, gint flags)
+{
     JsonNode *root = base_request(METHOD_TORRENT_ADD);
     JsonObject *args = node_get_arguments(root);
     gchar *encoded = g_base64_encode((guchar *)response->raw, response->size);
 
-    json_object_set_string_member(args, PARAM_METAINFO,
-                                  encoded);
+    json_object_set_string_member(args, PARAM_METAINFO, encoded);
     g_free(encoded);
 
-    json_object_set_boolean_member(args, PARAM_PAUSED,
-                                   (flags & TORRENT_ADD_FLAG_PAUSED));
+    json_object_set_boolean_member(args, PARAM_PAUSED, (flags & TORRENT_ADD_FLAG_PAUSED));
 
     return root;
 }
 
-JsonNode *torrent_add_from_file(gchar * target, gint flags)
+JsonNode *torrent_add_from_file(gchar *target, gint flags)
 {
     JsonNode *root;
     JsonObject *args;
@@ -277,8 +272,7 @@ JsonNode *torrent_add_from_file(gchar * target, gint flags)
     } else {
         encodedFile = trg_base64encode(target);
         if (encodedFile) {
-            json_object_set_string_member(args, PARAM_METAINFO,
-                                          encodedFile);
+            json_object_set_string_member(args, PARAM_METAINFO, encodedFile);
             g_free(encodedFile);
         } else {
             g_error("unable to base64 encode file \"%s\".", target);
@@ -286,8 +280,7 @@ JsonNode *torrent_add_from_file(gchar * target, gint flags)
         }
     }
 
-    json_object_set_boolean_member(args, PARAM_PAUSED,
-                                   (flags & TORRENT_ADD_FLAG_PAUSED));
+    json_object_set_boolean_member(args, PARAM_PAUSED, (flags & TORRENT_ADD_FLAG_PAUSED));
 
     if ((flags & TORRENT_ADD_FLAG_DELETE))
         g_unlink(target);
@@ -295,7 +288,7 @@ JsonNode *torrent_add_from_file(gchar * target, gint flags)
     return root;
 }
 
-static JsonNode *base_request(gchar * method)
+static JsonNode *base_request(gchar *method)
 {
     JsonNode *root = json_node_new(JSON_NODE_OBJECT);
     JsonObject *object = json_object_new();
@@ -308,15 +301,14 @@ static JsonNode *base_request(gchar * method)
     return root;
 }
 
-void request_set_tag(JsonNode * req, gint64 tag)
+void request_set_tag(JsonNode *req, gint64 tag)
 {
     json_object_set_int_member(json_node_get_object(req), PARAM_TAG, tag);
 }
 
-void request_set_tag_from_ids(JsonNode * req, JsonArray * ids)
+void request_set_tag_from_ids(JsonNode *req, JsonArray *ids)
 {
-    gint64 id =
-        json_array_get_length(ids) == 1 ?
-        json_array_get_int_element(ids, 0) : TORRENT_GET_TAG_MODE_FULL;
+    gint64 id = json_array_get_length(ids) == 1 ? json_array_get_int_element(ids, 0)
+                                                : TORRENT_GET_TAG_MODE_FULL;
     request_set_tag(req, id);
 }

--- a/src/requests.h
+++ b/src/requests.h
@@ -25,34 +25,32 @@
 
 #include "trg-client.h"
 
-JsonNode *generic_request(gchar * method, JsonArray * array);
+JsonNode *generic_request(gchar *method, JsonArray *array);
 
 JsonNode *session_set(void);
 JsonNode *session_get(void);
 JsonNode *torrent_get(gint64 id);
-JsonNode *torrent_set(JsonArray * array);
-JsonNode *torrent_pause(JsonArray * array);
-JsonNode *torrent_start(JsonArray * array);
-JsonNode *torrent_verify(JsonArray * array);
-JsonNode *torrent_reannounce(JsonArray * array);
-JsonNode *torrent_remove(JsonArray * array, int removeData);
+JsonNode *torrent_set(JsonArray *array);
+JsonNode *torrent_pause(JsonArray *array);
+JsonNode *torrent_start(JsonArray *array);
+JsonNode *torrent_verify(JsonArray *array);
+JsonNode *torrent_reannounce(JsonArray *array);
+JsonNode *torrent_remove(JsonArray *array, int removeData);
 JsonNode *torrent_add_from_response(trg_response *response, gint flags);
-JsonNode *torrent_add_from_file(gchar * filename, gint flags);
-JsonNode *torrent_add_url(const gchar * url, gboolean paused);
-JsonNode *torrent_set_location(JsonArray * array, gchar * location,
-                               gboolean move);
-JsonNode *torrent_rename_path(JsonArray * array, const gchar * path,
-                              const gchar * name);
+JsonNode *torrent_add_from_file(gchar *filename, gint flags);
+JsonNode *torrent_add_url(const gchar *url, gboolean paused);
+JsonNode *torrent_set_location(JsonArray *array, gchar *location, gboolean move);
+JsonNode *torrent_rename_path(JsonArray *array, const gchar *path, const gchar *name);
 JsonNode *blocklist_update(void);
 JsonNode *port_test(void);
 JsonNode *session_stats(void);
-JsonNode *torrent_queue_move_down(JsonArray * array);
-JsonNode *torrent_queue_move_up(JsonArray * array);
-JsonNode *torrent_queue_move_bottom(JsonArray * array);
-JsonNode *torrent_queue_move_top(JsonArray * array);
-JsonNode *torrent_start_now(JsonArray * array);
+JsonNode *torrent_queue_move_down(JsonArray *array);
+JsonNode *torrent_queue_move_up(JsonArray *array);
+JsonNode *torrent_queue_move_bottom(JsonArray *array);
+JsonNode *torrent_queue_move_top(JsonArray *array);
+JsonNode *torrent_start_now(JsonArray *array);
 
-void request_set_tag(JsonNode * req, gint64 tag);
-void request_set_tag_from_ids(JsonNode * req, JsonArray * ids);
+void request_set_tag(JsonNode *req, gint64 tag);
+void request_set_tag_from_ids(JsonNode *req, JsonArray *ids);
 
-#endif                          /* REQUESTS_H_ */
+#endif /* REQUESTS_H_ */

--- a/src/session-get.c
+++ b/src/session-get.c
@@ -23,66 +23,65 @@
 
 #include <json-glib/json-glib.h>
 
-#include "protocol-constants.h"
 #include "json.h"
+#include "protocol-constants.h"
 #include "session-get.h"
 
 /* Just some functions to get fields out of a session-get response. */
 
-const gchar *session_get_version_string(JsonObject * s)
+const gchar *session_get_version_string(JsonObject *s)
 {
     return json_object_get_string_member(s, SGET_VERSION);
 }
 
-gdouble session_get_version(JsonObject * s)
+gdouble session_get_version(JsonObject *s)
 {
     const gchar *versionString = session_get_version_string(s);
     gchar *spaceChar = g_strrstr(" ", versionString);
     return g_ascii_strtod(versionString, &spaceChar);
 }
 
-gint64 session_get_download_dir_free_space(JsonObject * s)
+gint64 session_get_download_dir_free_space(JsonObject *s)
 {
     return json_object_get_int_member(s, SGET_DOWNLOAD_DIR_FREE_SPACE);
 }
 
-gint64 session_get_rpc_version(JsonObject * s)
+gint64 session_get_rpc_version(JsonObject *s)
 {
     return json_object_get_int_member(s, SGET_RPC_VERSION);
 }
 
-gboolean session_get_pex_enabled(JsonObject * s)
+gboolean session_get_pex_enabled(JsonObject *s)
 {
     return json_object_get_boolean_member(s, SGET_PEX_ENABLED);
 }
 
-gboolean session_get_lpd_enabled(JsonObject * s)
+gboolean session_get_lpd_enabled(JsonObject *s)
 {
     return json_object_get_boolean_member(s, SGET_LPD_ENABLED);
 }
 
-const gchar *session_get_download_dir(JsonObject * s)
+const gchar *session_get_download_dir(JsonObject *s)
 {
     return json_object_get_string_member(s, SGET_DOWNLOAD_DIR);
 }
 
-gboolean session_get_peer_port_random(JsonObject * s)
+gboolean session_get_peer_port_random(JsonObject *s)
 {
-    return json_object_get_boolean_member(s,
-                                          SGET_PEER_PORT_RANDOM_ON_START);
+    return json_object_get_boolean_member(s, SGET_PEER_PORT_RANDOM_ON_START);
 }
 
-gint64 session_get_peer_port(JsonObject * s)
+gint64 session_get_peer_port(JsonObject *s)
 {
     return json_object_get_int_member(s, SGET_PEER_PORT);
 }
 
-gboolean session_get_port_forwarding_enabled(JsonObject * s)
+gboolean session_get_port_forwarding_enabled(JsonObject *s)
 {
     return json_object_get_boolean_member(s, SGET_PORT_FORWARDING_ENABLED);
 }
 
-const gchar *session_get_blocklist_url(JsonObject * s)
+const gchar *session_get_blocklist_url(JsonObject *s)
 {
     if (json_object_has_member(s, SGET_BLOCKLIST_URL))
         return json_object_get_string_member(s, SGET_BLOCKLIST_URL);
@@ -90,79 +89,77 @@ const gchar *session_get_blocklist_url(JsonObject * s)
         return NULL;
 }
 
-gint64 session_get_blocklist_size(JsonObject * s)
+gint64 session_get_blocklist_size(JsonObject *s)
 {
     return json_object_get_int_member(s, SGET_BLOCKLIST_SIZE);
 }
 
-gboolean session_get_blocklist_enabled(JsonObject * s)
+gboolean session_get_blocklist_enabled(JsonObject *s)
 {
     return json_object_get_boolean_member(s, SGET_BLOCKLIST_ENABLED);
 }
 
-gboolean session_get_rename_partial_files(JsonObject * s)
+gboolean session_get_rename_partial_files(JsonObject *s)
 {
     return json_object_get_boolean_member(s, SGET_RENAME_PARTIAL_FILES);
 }
 
-const gchar *session_get_encryption(JsonObject * s)
+const gchar *session_get_encryption(JsonObject *s)
 {
     return json_object_get_string_member(s, SGET_ENCRYPTION);
 }
 
-const gchar *session_get_incomplete_dir(JsonObject * s)
+const gchar *session_get_incomplete_dir(JsonObject *s)
 {
     return json_object_get_string_member(s, SGET_INCOMPLETE_DIR);
 }
 
-gboolean session_get_incomplete_dir_enabled(JsonObject * s)
+gboolean session_get_incomplete_dir_enabled(JsonObject *s)
 {
     return json_object_get_boolean_member(s, SGET_INCOMPLETE_DIR_ENABLED);
 }
 
-gboolean session_get_alt_speed_enabled(JsonObject * s)
+gboolean session_get_alt_speed_enabled(JsonObject *s)
 {
     return json_object_get_boolean_member(s, SGET_ALT_SPEED_ENABLED);
 }
 
-gboolean session_get_seed_ratio_limited(JsonObject * s)
+gboolean session_get_seed_ratio_limited(JsonObject *s)
 {
     return json_object_get_boolean_member(s, SGET_SEED_RATIO_LIMITED);
 }
 
-gboolean session_get_download_queue_enabled(JsonObject * s)
+gboolean session_get_download_queue_enabled(JsonObject *s)
 {
     return json_object_get_boolean_member(s, SGET_DOWNLOAD_QUEUE_ENABLED);
 }
 
-gint64 session_get_download_queue_size(JsonObject * s)
+gint64 session_get_download_queue_size(JsonObject *s)
 {
     return json_object_get_int_member(s, SGET_DOWNLOAD_QUEUE_SIZE);
 }
 
-gboolean session_get_seed_queue_enabled(JsonObject * s)
+gboolean session_get_seed_queue_enabled(JsonObject *s)
 {
     return json_object_get_boolean_member(s, SGET_SEED_QUEUE_ENABLED);
 }
 
-gint64 session_get_seed_queue_size(JsonObject * s)
+gint64 session_get_seed_queue_size(JsonObject *s)
 {
     return json_object_get_int_member(s, SGET_SEED_QUEUE_SIZE);
 }
 
-const gchar *session_get_torrent_done_filename(JsonObject * s)
+const gchar *session_get_torrent_done_filename(JsonObject *s)
 {
-    return json_object_get_string_member(s,
-                                         SGET_SCRIPT_TORRENT_DONE_FILENAME);
+    return json_object_get_string_member(s, SGET_SCRIPT_TORRENT_DONE_FILENAME);
 }
 
-gboolean session_get_torrent_done_enabled(JsonObject * s)
+gboolean session_get_torrent_done_enabled(JsonObject *s)
 {
-    return json_object_get_boolean_member(s,
-                                          SGET_SCRIPT_TORRENT_DONE_ENABLED);
+    return json_object_get_boolean_member(s, SGET_SCRIPT_TORRENT_DONE_ENABLED);
 }
 
-gint64 session_get_cache_size_mb(JsonObject * s)
+gint64 session_get_cache_size_mb(JsonObject *s)
 {
     if (json_object_has_member(s, SGET_CACHE_SIZE_MB))
         return json_object_get_int_member(s, SGET_CACHE_SIZE_MB);
@@ -170,71 +167,67 @@ gint64 session_get_cache_size_mb(JsonObject * s)
         return -1;
 }
 
-gdouble session_get_seed_ratio_limit(JsonObject * s)
+gdouble session_get_seed_ratio_limit(JsonObject *s)
 {
-    return
-        json_node_really_get_double(json_object_get_member
-                                    (s, SGET_SEED_RATIO_LIMIT));
+    return json_node_really_get_double(json_object_get_member(s, SGET_SEED_RATIO_LIMIT));
 }
 
-gboolean session_get_start_added_torrents(JsonObject * s)
+gboolean session_get_start_added_torrents(JsonObject *s)
 {
     return json_object_get_boolean_member(s, SGET_START_ADDED_TORRENTS);
 }
 
-gboolean session_get_trash_original_torrent_files(JsonObject * s)
+gboolean session_get_trash_original_torrent_files(JsonObject *s)
 {
-    return json_object_get_boolean_member(s,
-                                          SGET_TRASH_ORIGINAL_TORRENT_FILES);
+    return json_object_get_boolean_member(s, SGET_TRASH_ORIGINAL_TORRENT_FILES);
 }
 
-gboolean session_get_speed_limit_alt_enabled(JsonObject * s)
+gboolean session_get_speed_limit_alt_enabled(JsonObject *s)
 {
     return json_object_get_boolean_member(s, SGET_ALT_SPEED_ENABLED);
 }
 
-gboolean session_get_speed_limit_up_enabled(JsonObject * s)
+gboolean session_get_speed_limit_up_enabled(JsonObject *s)
 {
     return json_object_get_boolean_member(s, SGET_SPEED_LIMIT_UP_ENABLED);
 }
 
-gint64 session_get_peer_limit_per_torrent(JsonObject * s)
+gint64 session_get_peer_limit_per_torrent(JsonObject *s)
 {
     return json_object_get_int_member(s, SGET_PEER_LIMIT_PER_TORRENT);
 }
 
-gint64 session_get_peer_limit_global(JsonObject * s)
+gint64 session_get_peer_limit_global(JsonObject *s)
 {
     return json_object_get_int_member(s, SGET_PEER_LIMIT_GLOBAL);
 }
 
-gint64 session_get_alt_speed_limit_up(JsonObject * s)
+gint64 session_get_alt_speed_limit_up(JsonObject *s)
 {
     return json_object_get_int_member(s, SGET_ALT_SPEED_UP);
 }
 
-gint64 session_get_speed_limit_up(JsonObject * s)
+gint64 session_get_speed_limit_up(JsonObject *s)
 {
     return json_object_get_int_member(s, SGET_SPEED_LIMIT_UP);
 }
 
-gboolean session_get_speed_limit_down_enabled(JsonObject * s)
+gboolean session_get_speed_limit_down_enabled(JsonObject *s)
 {
-    return json_object_get_boolean_member(s,
-                                          SGET_SPEED_LIMIT_DOWN_ENABLED);
+    return json_object_get_boolean_member(s, SGET_SPEED_LIMIT_DOWN_ENABLED);
 }
 
-gint64 session_get_alt_speed_limit_down(JsonObject * s)
+gint64 session_get_alt_speed_limit_down(JsonObject *s)
 {
     return json_object_get_int_member(s, SGET_ALT_SPEED_DOWN);
 }
 
-gint64 session_get_speed_limit_down(JsonObject * s)
+gint64 session_get_speed_limit_down(JsonObject *s)
 {
     return json_object_get_int_member(s, SGET_SPEED_LIMIT_DOWN);
 }
 
-gboolean session_get_dht_enabled(JsonObject * s)
+gboolean session_get_dht_enabled(JsonObject *s)
 {
     return json_object_get_boolean_member(s, SGET_DHT_ENABLED);
 }

--- a/src/session-get.h
+++ b/src/session-get.h
@@ -22,47 +22,47 @@
 
 #include <glib-object.h>
 
-#define SGET_DOWNLOAD_DIR_FREE_SPACE            "download-dir-free-space"
-#define SGET_BLOCKLIST_ENABLED                  "blocklist-enabled"
-#define SGET_BLOCKLIST_URL                      "blocklist-url"
-#define SGET_BLOCKLIST_SIZE                     "blocklist-size"
-#define SGET_DHT_ENABLED                        "dht-enabled"
-#define SGET_LPD_ENABLED                        "lpd-enabled"
-#define SGET_DOWNLOAD_DIR                       "download-dir"
-#define SGET_INCOMPLETE_DIR                     "incomplete-dir"
-#define SGET_INCOMPLETE_DIR_ENABLED             "incomplete-dir-enabled"
-#define SGET_ENCRYPTION                         "encryption"
-#define SGET_PEER_LIMIT_GLOBAL                  "peer-limit-global"
-#define SGET_PEER_LIMIT_PER_TORRENT             "peer-limit-per-torrent"
-#define SGET_PEER_PORT                          "peer-port"
-#define SGET_PEER_PORT_RANDOM_ON_START          "peer-port-random-on-start"
-#define SGET_PEX_ENABLED                        "pex-enabled"
-#define SGET_PORT_FORWARDING_ENABLED            "port-forwarding-enabled"
-#define SGET_RPC_VERSION                        "rpc-version"
-#define SGET_RPC_VERSION_MINIMUM                "rpc-version-minimum"
-#define SGET_SEED_RATIO_LIMIT                   "seedRatioLimit"
-#define SGET_SEED_RATIO_LIMITED                 "seedRatioLimited"
-#define SGET_SPEED_LIMIT_DOWN                   "speed-limit-down"
-#define SGET_SPEED_LIMIT_DOWN_ENABLED           "speed-limit-down-enabled"
-#define SGET_SPEED_LIMIT_UP                     "speed-limit-up"
-#define SGET_SPEED_LIMIT_UP_ENABLED             "speed-limit-up-enabled"
-#define SGET_VERSION                            "version"
-#define SGET_RPC_VERSION                        "rpc-version"
-#define SGET_TRASH_ORIGINAL_TORRENT_FILES       "trash-original-torrent-files"
-#define SGET_START_ADDED_TORRENTS               "start-added-torrents"
-#define SGET_RENAME_PARTIAL_FILES               "rename-partial-files"
-#define SGET_CACHE_SIZE_MB                      "cache-size-mb"
-#define SGET_SCRIPT_TORRENT_DONE_FILENAME       "script-torrent-done-filename"
-#define SGET_SCRIPT_TORRENT_DONE_ENABLED        "script-torrent-done-enabled"
-#define SGET_BLOCKLIST_URL                     "blocklist-url"
-#define SGET_BLOCKLIST_ENABLED                 "blocklist-enabled"
-#define SGET_BLOCKLIST_SIZE                    "blocklist-size"
-#define SGET_DOWNLOAD_QUEUE_ENABLED            "download-queue-enabled"
-#define SGET_DOWNLOAD_QUEUE_SIZE            "download-queue-size"
-#define SGET_SEED_QUEUE_ENABLED            "seed-queue-enabled"
-#define SGET_SEED_QUEUE_SIZE            "seed-queue-size"
-#define SGET_QUEUE_STALLED_ENABLED "queue-stalled-enabled"
-#define SGET_QUEUE_STALLED_MINUTES "queue-stalled-minutes"
+#define SGET_DOWNLOAD_DIR_FREE_SPACE      "download-dir-free-space"
+#define SGET_BLOCKLIST_ENABLED            "blocklist-enabled"
+#define SGET_BLOCKLIST_URL                "blocklist-url"
+#define SGET_BLOCKLIST_SIZE               "blocklist-size"
+#define SGET_DHT_ENABLED                  "dht-enabled"
+#define SGET_LPD_ENABLED                  "lpd-enabled"
+#define SGET_DOWNLOAD_DIR                 "download-dir"
+#define SGET_INCOMPLETE_DIR               "incomplete-dir"
+#define SGET_INCOMPLETE_DIR_ENABLED       "incomplete-dir-enabled"
+#define SGET_ENCRYPTION                   "encryption"
+#define SGET_PEER_LIMIT_GLOBAL            "peer-limit-global"
+#define SGET_PEER_LIMIT_PER_TORRENT       "peer-limit-per-torrent"
+#define SGET_PEER_PORT                    "peer-port"
+#define SGET_PEER_PORT_RANDOM_ON_START    "peer-port-random-on-start"
+#define SGET_PEX_ENABLED                  "pex-enabled"
+#define SGET_PORT_FORWARDING_ENABLED      "port-forwarding-enabled"
+#define SGET_RPC_VERSION                  "rpc-version"
+#define SGET_RPC_VERSION_MINIMUM          "rpc-version-minimum"
+#define SGET_SEED_RATIO_LIMIT             "seedRatioLimit"
+#define SGET_SEED_RATIO_LIMITED           "seedRatioLimited"
+#define SGET_SPEED_LIMIT_DOWN             "speed-limit-down"
+#define SGET_SPEED_LIMIT_DOWN_ENABLED     "speed-limit-down-enabled"
+#define SGET_SPEED_LIMIT_UP               "speed-limit-up"
+#define SGET_SPEED_LIMIT_UP_ENABLED       "speed-limit-up-enabled"
+#define SGET_VERSION                      "version"
+#define SGET_RPC_VERSION                  "rpc-version"
+#define SGET_TRASH_ORIGINAL_TORRENT_FILES "trash-original-torrent-files"
+#define SGET_START_ADDED_TORRENTS         "start-added-torrents"
+#define SGET_RENAME_PARTIAL_FILES         "rename-partial-files"
+#define SGET_CACHE_SIZE_MB                "cache-size-mb"
+#define SGET_SCRIPT_TORRENT_DONE_FILENAME "script-torrent-done-filename"
+#define SGET_SCRIPT_TORRENT_DONE_ENABLED  "script-torrent-done-enabled"
+#define SGET_BLOCKLIST_URL                "blocklist-url"
+#define SGET_BLOCKLIST_ENABLED            "blocklist-enabled"
+#define SGET_BLOCKLIST_SIZE               "blocklist-size"
+#define SGET_DOWNLOAD_QUEUE_ENABLED       "download-queue-enabled"
+#define SGET_DOWNLOAD_QUEUE_SIZE          "download-queue-size"
+#define SGET_SEED_QUEUE_ENABLED           "seed-queue-enabled"
+#define SGET_SEED_QUEUE_SIZE              "seed-queue-size"
+#define SGET_QUEUE_STALLED_ENABLED        "queue-stalled-enabled"
+#define SGET_QUEUE_STALLED_MINUTES        "queue-stalled-minutes"
 
 #define SGET_ALT_SPEED_DOWN         "alt-speed-down"
 #define SGET_ALT_SPEED_ENABLED      "alt-speed-enabled"
@@ -72,44 +72,44 @@
 #define SGET_ALT_SPEED_TIME_DAY     "alt-speed-time-day"
 #define SGET_ALT_SPEED_UP           "alt-speed-up"
 
-const gchar *session_get_torrent_done_filename(JsonObject * s);
-gboolean session_get_torrent_done_enabled(JsonObject * s);
-gint64 session_get_cache_size_mb(JsonObject * s);
-const gchar *session_get_version_string(JsonObject * s);
-gdouble session_get_version(JsonObject * s);
-gboolean session_get_pex_enabled(JsonObject * s);
-gboolean session_get_lpd_enabled(JsonObject * s);
-const gchar *session_get_download_dir(JsonObject * s);
-gboolean session_get_peer_port_random(JsonObject * s);
-gint64 session_get_peer_port(JsonObject * s);
-gint64 session_get_peer_limit_global(JsonObject * s);
-gint64 session_get_peer_limit_per_torrent(JsonObject * s);
-gboolean session_get_port_forwarding_enabled(JsonObject * s);
-const gchar *session_get_blocklist_url(JsonObject * s);
-gboolean session_get_blocklist_enabled(JsonObject * s);
-gint64 session_get_blocklist_size(JsonObject * s);
-gboolean session_get_rename_partial_files(JsonObject * s);
-const gchar *session_get_encryption(JsonObject * s);
-const gchar *session_get_incomplete_dir(JsonObject * s);
-gboolean session_get_incomplete_dir_enabled(JsonObject * s);
-gboolean session_get_seed_ratio_limited(JsonObject * s);
-gdouble session_get_seed_ratio_limit(JsonObject * s);
-gboolean session_get_start_added_torrents(JsonObject * s);
-gboolean session_get_trash_original_torrent_files(JsonObject * s);
-gboolean session_get_speed_limit_up_enabled(JsonObject * s);
-gboolean session_get_speed_limit_alt_enabled(JsonObject * s);
-gint64 session_get_speed_limit_up(JsonObject * s);
-gboolean session_get_speed_limit_down_enabled(JsonObject * s);
-gint64 session_get_speed_limit_down(JsonObject * s);
-gboolean session_get_download_queue_enabled(JsonObject * s);
-gint64 session_get_download_queue_size(JsonObject * s);
-gboolean session_get_seed_queue_enabled(JsonObject * s);
-gint64 session_get_seed_queue_size(JsonObject * s);
-gint64 session_get_rpc_version(JsonObject * s);
-gint64 session_get_download_dir_free_space(JsonObject * s);
-gboolean session_get_dht_enabled(JsonObject * s);
-gboolean session_get_alt_speed_enabled(JsonObject * s);
-gint64 session_get_alt_speed_limit_up(JsonObject * s);
-gint64 session_get_alt_speed_limit_down(JsonObject * s);
+const gchar *session_get_torrent_done_filename(JsonObject *s);
+gboolean session_get_torrent_done_enabled(JsonObject *s);
+gint64 session_get_cache_size_mb(JsonObject *s);
+const gchar *session_get_version_string(JsonObject *s);
+gdouble session_get_version(JsonObject *s);
+gboolean session_get_pex_enabled(JsonObject *s);
+gboolean session_get_lpd_enabled(JsonObject *s);
+const gchar *session_get_download_dir(JsonObject *s);
+gboolean session_get_peer_port_random(JsonObject *s);
+gint64 session_get_peer_port(JsonObject *s);
+gint64 session_get_peer_limit_global(JsonObject *s);
+gint64 session_get_peer_limit_per_torrent(JsonObject *s);
+gboolean session_get_port_forwarding_enabled(JsonObject *s);
+const gchar *session_get_blocklist_url(JsonObject *s);
+gboolean session_get_blocklist_enabled(JsonObject *s);
+gint64 session_get_blocklist_size(JsonObject *s);
+gboolean session_get_rename_partial_files(JsonObject *s);
+const gchar *session_get_encryption(JsonObject *s);
+const gchar *session_get_incomplete_dir(JsonObject *s);
+gboolean session_get_incomplete_dir_enabled(JsonObject *s);
+gboolean session_get_seed_ratio_limited(JsonObject *s);
+gdouble session_get_seed_ratio_limit(JsonObject *s);
+gboolean session_get_start_added_torrents(JsonObject *s);
+gboolean session_get_trash_original_torrent_files(JsonObject *s);
+gboolean session_get_speed_limit_up_enabled(JsonObject *s);
+gboolean session_get_speed_limit_alt_enabled(JsonObject *s);
+gint64 session_get_speed_limit_up(JsonObject *s);
+gboolean session_get_speed_limit_down_enabled(JsonObject *s);
+gint64 session_get_speed_limit_down(JsonObject *s);
+gboolean session_get_download_queue_enabled(JsonObject *s);
+gint64 session_get_download_queue_size(JsonObject *s);
+gboolean session_get_seed_queue_enabled(JsonObject *s);
+gint64 session_get_seed_queue_size(JsonObject *s);
+gint64 session_get_rpc_version(JsonObject *s);
+gint64 session_get_download_dir_free_space(JsonObject *s);
+gboolean session_get_dht_enabled(JsonObject *s);
+gboolean session_get_alt_speed_enabled(JsonObject *s);
+gint64 session_get_alt_speed_limit_up(JsonObject *s);
+gint64 session_get_alt_speed_limit_down(JsonObject *s);
 
-#endif                          /* SESSION_GET_H_ */
+#endif /* SESSION_GET_H_ */

--- a/src/torrent-cell-renderer.c
+++ b/src/torrent-cell-renderer.c
@@ -15,16 +15,16 @@
 
 #include "config.h"
 
-#include <gtk/gtk.h>
 #include <gdk/gdk.h>
 #include <glib/gi18n.h>
+#include <gtk/gtk.h>
 
 #include "hig.h"
 #include "icons.h"
-#include "trg-client.h"
-#include "torrent.h"
-#include "util.h"
 #include "torrent-cell-renderer.h"
+#include "torrent.h"
+#include "trg-client.h"
+#include "util.h"
 
 enum {
     P_STATUS = 1,
@@ -56,9 +56,9 @@ enum {
 };
 
 #define DEFAULT_BAR_HEIGHT 12
-#define SMALL_SCALE 0.9
-#define COMPACT_ICON_SIZE GTK_ICON_SIZE_MENU
-#define FULL_ICON_SIZE GTK_ICON_SIZE_DND
+#define SMALL_SCALE        0.9
+#define COMPACT_ICON_SIZE  GTK_ICON_SIZE_MENU
+#define FULL_ICON_SIZE     GTK_ICON_SIZE_DND
 
 #define FOREGROUND_COLOR_KEY "foreground-rgba"
 typedef GdkRGBA GtrColor;
@@ -69,19 +69,13 @@ typedef GtkRequisition GtrRequisition;
 ****
 ***/
 
-static void
-render_compact(TorrentCellRenderer * cell,
-               GtrDrawable * window,
-               GtkWidget * widget,
-               const GdkRectangle * background_area,
-               const GdkRectangle * cell_area, GtkCellRendererState flags);
+static void render_compact(TorrentCellRenderer *cell, GtrDrawable *window, GtkWidget *widget,
+                           const GdkRectangle *background_area, const GdkRectangle *cell_area,
+                           GtkCellRendererState flags);
 
-static void
-render_full(TorrentCellRenderer * cell,
-            GtrDrawable * window,
-            GtkWidget * widget,
-            const GdkRectangle * background_area,
-            const GdkRectangle * cell_area, GtkCellRendererState flags);
+static void render_full(TorrentCellRenderer *cell, GtrDrawable *window, GtkWidget *widget,
+                        const GdkRectangle *background_area, const GdkRectangle *cell_area,
+                        GtkCellRendererState flags);
 
 struct TorrentCellRendererPrivate {
     GtkCellRenderer *text_renderer;
@@ -118,12 +112,11 @@ struct TorrentCellRendererPrivate {
     gboolean compact;
 };
 
-static gboolean getSeedRatio(TorrentCellRenderer * r, gdouble * ratio)
+static gboolean getSeedRatio(TorrentCellRenderer *r, gdouble *ratio)
 {
     struct TorrentCellRendererPrivate *p = r->priv;
 
-    if ((p->seedRatioMode == 0)
-        && (trg_client_get_seed_ratio_limited(p->client) == TRUE)) {
+    if ((p->seedRatioMode == 0) && (trg_client_get_seed_ratio_limited(p->client) == TRUE)) {
         *ratio = trg_client_get_seed_ratio_limit(p->client);
         return TRUE;
     } else if (p->seedRatioMode == 1) {
@@ -134,7 +127,7 @@ static gboolean getSeedRatio(TorrentCellRenderer * r, gdouble * ratio)
     return FALSE;
 }
 
-static void getProgressString(GString * gstr, TorrentCellRenderer * r)
+static void getProgressString(GString *gstr, TorrentCellRenderer *r)
 {
     struct TorrentCellRendererPrivate *p = r->priv;
 
@@ -144,75 +137,49 @@ static void getProgressString(GString * gstr, TorrentCellRenderer * r)
     double seedRatio;
     const gboolean hasSeedRatio = getSeedRatio(r, &seedRatio);
 
-    if (p->flags & TORRENT_FLAG_DOWNLOADING) {  /* downloading */
+    if (p->flags & TORRENT_FLAG_DOWNLOADING) { /* downloading */
         g_string_append_printf(gstr,
                                /* %1$s is how much we've got,
                                   %2$s is how much we'll have when done,
                                   %3$s%% is a percentage of the two */
-                               _("%1$s of %2$s (%3$s)"),
-                               tr_strlsize(buf1, haveTotal, sizeof(buf1)),
-                               tr_strlsize(buf2, p->sizeWhenDone,
-                                           sizeof(buf2)),
-                               tr_strlpercent(buf3, p->done,
-                                              sizeof(buf3)));
-    } else if (!isSeed) {       /* Partial seed */
+                               _("%1$s of %2$s (%3$s)"), tr_strlsize(buf1, haveTotal, sizeof(buf1)),
+                               tr_strlsize(buf2, p->sizeWhenDone, sizeof(buf2)),
+                               tr_strlpercent(buf3, p->done, sizeof(buf3)));
+    } else if (!isSeed) { /* Partial seed */
         if (hasSeedRatio) {
             g_string_append_printf(gstr,
-                                   _
-                                   ("%1$s of %2$s (%3$s), uploaded %4$s (Ratio: %5$s Goal: %6$s)"),
-                                   tr_strlsize(buf1, haveTotal,
-                                               sizeof(buf1)),
-                                   tr_strlsize(buf2, p->totalSize,
-                                               sizeof(buf2)),
-                                   tr_strlpercent(buf3, p->done,
-                                                  sizeof(buf3)),
-                                   tr_strlsize(buf4, p->uploadedEver,
-                                               sizeof(buf4)),
-                                   tr_strlratio(buf5, p->ratio,
-                                                sizeof(buf5)),
-                                   tr_strlratio(buf6, seedRatio,
-                                                sizeof(buf6)));
+                                   _("%1$s of %2$s (%3$s), uploaded %4$s (Ratio: %5$s Goal: %6$s)"),
+                                   tr_strlsize(buf1, haveTotal, sizeof(buf1)),
+                                   tr_strlsize(buf2, p->totalSize, sizeof(buf2)),
+                                   tr_strlpercent(buf3, p->done, sizeof(buf3)),
+                                   tr_strlsize(buf4, p->uploadedEver, sizeof(buf4)),
+                                   tr_strlratio(buf5, p->ratio, sizeof(buf5)),
+                                   tr_strlratio(buf6, seedRatio, sizeof(buf6)));
         } else {
-            g_string_append_printf(gstr,
-                                   _
-                                   ("%1$s of %2$s (%3$s), uploaded %4$s (Ratio: %5$s)"),
-                                   tr_strlsize(buf1, haveTotal,
-                                               sizeof(buf1)),
-                                   tr_strlsize(buf2, p->totalSize,
-                                               sizeof(buf2)),
-                                   tr_strlpercent(buf3, p->done,
-                                                  sizeof(buf3)),
-                                   tr_strlsize(buf4, p->uploadedEver,
-                                               sizeof(buf4)),
-                                   tr_strlratio(buf5, p->ratio,
-                                                sizeof(buf5)));
+            g_string_append_printf(gstr, _("%1$s of %2$s (%3$s), uploaded %4$s (Ratio: %5$s)"),
+                                   tr_strlsize(buf1, haveTotal, sizeof(buf1)),
+                                   tr_strlsize(buf2, p->totalSize, sizeof(buf2)),
+                                   tr_strlpercent(buf3, p->done, sizeof(buf3)),
+                                   tr_strlsize(buf4, p->uploadedEver, sizeof(buf4)),
+                                   tr_strlratio(buf5, p->ratio, sizeof(buf5)));
         }
-    } else {                    /* seeding */
+    } else { /* seeding */
 
         if (hasSeedRatio) {
-            g_string_append_printf(gstr,
-                                   _
-                                   ("%1$s, uploaded %2$s (Ratio: %3$s Goal: %4$s)"),
-                                   tr_strlsize(buf1, p->totalSize,
-                                               sizeof(buf1)),
-                                   tr_strlsize(buf2, p->uploadedEver,
-                                               sizeof(buf2)),
-                                   tr_strlratio(buf3, p->ratio,
-                                                sizeof(buf3)),
-                                   tr_strlratio(buf4, seedRatio,
-                                                sizeof(buf4)));
+            g_string_append_printf(gstr, _("%1$s, uploaded %2$s (Ratio: %3$s Goal: %4$s)"),
+                                   tr_strlsize(buf1, p->totalSize, sizeof(buf1)),
+                                   tr_strlsize(buf2, p->uploadedEver, sizeof(buf2)),
+                                   tr_strlratio(buf3, p->ratio, sizeof(buf3)),
+                                   tr_strlratio(buf4, seedRatio, sizeof(buf4)));
         } else {
             g_string_append_printf(gstr,
                                    /* %1$s is the torrent's total size,
                                       %2$s is how much we've uploaded,
                                       %3$s is our upload-to-download ratio */
                                    _("%1$s, uploaded %2$s (Ratio: %3$s)"),
-                                   tr_strlsize(buf1, p->sizeWhenDone,
-                                               sizeof(buf1)),
-                                   tr_strlsize(buf2, p->uploadedEver,
-                                               sizeof(buf2)),
-                                   tr_strlratio(buf3, p->ratio,
-                                                sizeof(buf3)));
+                                   tr_strlsize(buf1, p->sizeWhenDone, sizeof(buf1)),
+                                   tr_strlsize(buf2, p->uploadedEver, sizeof(buf2)),
+                                   tr_strlratio(buf3, p->ratio, sizeof(buf3)));
         }
     }
 
@@ -232,8 +199,7 @@ static void getProgressString(GString * gstr, TorrentCellRenderer * r)
     }
 }
 
-static char *getShortTransferString(TorrentCellRenderer * r,
-                                    char *buf, size_t buflen)
+static char *getShortTransferString(TorrentCellRenderer *r, char *buf, size_t buflen)
 {
     struct TorrentCellRendererPrivate *priv = r->priv;
 
@@ -243,16 +209,14 @@ static char *getShortTransferString(TorrentCellRenderer * r,
     const gboolean haveDown = haveMeta && priv->peersToUs > 0;
 
     if (haveDown)
-        tr_formatter_speed_KBps(downStr, priv->downSpeed / speed_K,
-                                sizeof(downStr));
+        tr_formatter_speed_KBps(downStr, priv->downSpeed / speed_K, sizeof(downStr));
     if (haveUp)
-        tr_formatter_speed_KBps(upStr, priv->upSpeed / speed_K,
-                                sizeof(upStr));
+        tr_formatter_speed_KBps(upStr, priv->upSpeed / speed_K, sizeof(upStr));
 
     if (haveDown && haveUp)
         /* 1==down arrow, 2==down speed, 3==up arrow, 4==down speed */
-        g_snprintf(buf, buflen, _("%1$s %2$s, %3$s %4$s"),
-                   GTR_UNICODE_DOWN, downStr, GTR_UNICODE_UP, upStr);
+        g_snprintf(buf, buflen, _("%1$s %2$s, %3$s %4$s"), GTR_UNICODE_DOWN, downStr,
+                   GTR_UNICODE_UP, upStr);
     else if (haveDown)
         /* bandwidth speed + unicode arrow */
         g_snprintf(buf, buflen, _("%1$s %2$s"), GTR_UNICODE_DOWN, downStr);
@@ -269,15 +233,13 @@ static char *getShortTransferString(TorrentCellRenderer * r,
     return buf;
 }
 
-static void getShortStatusString(GString * gstr, TorrentCellRenderer * r)
+static void getShortStatusString(GString *gstr, TorrentCellRenderer *r)
 {
     struct TorrentCellRendererPrivate *priv = r->priv;
     guint flags = priv->flags;
 
     if (flags & TORRENT_FLAG_PAUSED) {
-        g_string_append(gstr,
-                        (flags & TORRENT_FLAG_COMPLETE) ? _("Finished") :
-                        _("Paused"));
+        g_string_append(gstr, (flags & TORRENT_FLAG_COMPLETE) ? _("Finished") : _("Paused"));
     } else if (flags & TORRENT_FLAG_WAITING_CHECK) {
         g_string_append(gstr, _("Queued for verification"));
     } else if (flags & TORRENT_FLAG_DOWNLOADING_WAIT) {
@@ -287,10 +249,8 @@ static void getShortStatusString(GString * gstr, TorrentCellRenderer * r)
     } else if (flags & TORRENT_FLAG_CHECKING) {
         char buf1[32];
         g_string_append_printf(gstr, _("Verifying data (%1$s tested)"),
-                               tr_strlpercent(buf1, priv->done,
-                                              sizeof(buf1)));
-    } else if ((flags & TORRENT_FLAG_DOWNLOADING)
-               || (flags & TORRENT_FLAG_SEEDING)) {
+                               tr_strlpercent(buf1, priv->done, sizeof(buf1)));
+    } else if ((flags & TORRENT_FLAG_DOWNLOADING) || (flags & TORRENT_FLAG_SEEDING)) {
         char buf[512];
         if (flags & ~TORRENT_FLAG_DOWNLOADING) {
             tr_strlratio(buf, priv->ratio, sizeof(buf));
@@ -302,7 +262,7 @@ static void getShortStatusString(GString * gstr, TorrentCellRenderer * r)
     }
 }
 
-static void getStatusString(GString * gstr, TorrentCellRenderer * r)
+static void getStatusString(GString *gstr, TorrentCellRenderer *r)
 {
     struct TorrentCellRendererPrivate *priv = r->priv;
     char buf[256];
@@ -311,26 +271,19 @@ static void getStatusString(GString * gstr, TorrentCellRenderer * r)
     if (priv->error) {
         errstr = torrent_get_errorstr(priv->json);
         switch (priv->error) {
-            case 0: /* OK */
-                break;
-            case 1: /* Tracking Warning */
-                g_string_append_printf(gstr,
-                                       _("Tracker gave a warning: \"%s\""),
-                                       errstr);
-                break;
-            case 2: /* Tracker Error */
-                g_string_append_printf(gstr,
-                                       _("Tracker gave an error: \"%s\""),
-                                       errstr);
-                break;
-            case 3: /* Local Error */
-                g_string_append_printf(gstr,
-                                       _("Error: \"%s\""),
-                                       errstr);
-                break;
+        case 0: /* OK */
+            break;
+        case 1: /* Tracking Warning */
+            g_string_append_printf(gstr, _("Tracker gave a warning: \"%s\""), errstr);
+            break;
+        case 2: /* Tracker Error */
+            g_string_append_printf(gstr, _("Tracker gave an error: \"%s\""), errstr);
+            break;
+        case 3: /* Local Error */
+            g_string_append_printf(gstr, _("Error: \"%s\""), errstr);
+            break;
         }
-    } else if ((priv->flags & TORRENT_FLAG_PAUSED)
-               || (priv->flags & TORRENT_FLAG_WAITING_CHECK)
+    } else if ((priv->flags & TORRENT_FLAG_PAUSED) || (priv->flags & TORRENT_FLAG_WAITING_CHECK)
                || (priv->flags & TORRENT_FLAG_CHECKING)
                || (priv->flags & TORRENT_FLAG_DOWNLOADING_WAIT)
                || (priv->flags & TORRENT_FLAG_SEEDING_WAIT)) {
@@ -338,37 +291,35 @@ static void getStatusString(GString * gstr, TorrentCellRenderer * r)
     } else if (priv->flags & TORRENT_FLAG_DOWNLOADING) {
         if (priv->fileCount > 0) {
             g_string_append_printf(gstr,
-                                   ngettext
-                                   ("Downloading from %1$"G_GUINT64_FORMAT" of %2$"G_GUINT64_FORMAT" connected peer",
-                                    "Downloading from %1$"G_GUINT64_FORMAT" of %2$"G_GUINT64_FORMAT" connected peers",
-                                    priv->webSeedsToUs + priv->peersToUs),
+                                   ngettext("Downloading from %1$" G_GUINT64_FORMAT
+                                            " of %2$" G_GUINT64_FORMAT " connected peer",
+                                            "Downloading from %1$" G_GUINT64_FORMAT
+                                            " of %2$" G_GUINT64_FORMAT " connected peers",
+                                            priv->webSeedsToUs + priv->peersToUs),
                                    priv->webSeedsToUs + priv->peersToUs,
                                    priv->webSeedsToUs + priv->connected);
         } else {
-            g_string_append_printf(gstr,
-                                   ngettext
-                                   ("Downloading metadata from %1$"G_GUINT64_FORMAT" peer (%2$s done)",
-                                    "Downloading metadata from %1$"G_GUINT64_FORMAT" peers (%2$s done)",
-                                    priv->connected + priv->webSeedsToUs),
-                                   priv->connected + priv->webSeedsToUs,
-                                   tr_strlpercent(buf,
-                                                  priv->metadataPercentComplete,
-                                                  sizeof(buf)));
+            g_string_append_printf(
+                gstr,
+                ngettext("Downloading metadata from %1$" G_GUINT64_FORMAT " peer (%2$s done)",
+                         "Downloading metadata from %1$" G_GUINT64_FORMAT " peers (%2$s done)",
+                         priv->connected + priv->webSeedsToUs),
+                priv->connected + priv->webSeedsToUs,
+                tr_strlpercent(buf, priv->metadataPercentComplete, sizeof(buf)));
         }
     } else if (priv->flags & TORRENT_FLAG_SEEDING) {
         g_string_append_printf(gstr,
-                               ngettext
-                               ("Seeding to %1$"G_GUINT64_FORMAT" of %2$"G_GUINT64_FORMAT" connected peer",
-                                "Seeding to %1$"G_GUINT64_FORMAT" of %2$"G_GUINT64_FORMAT" connected peers",
-                                priv->connected), priv->peersFromUs,
-                               priv->connected);
+                               ngettext("Seeding to %1$" G_GUINT64_FORMAT " of %2$" G_GUINT64_FORMAT
+                                        " connected peer",
+                                        "Seeding to %1$" G_GUINT64_FORMAT " of %2$" G_GUINT64_FORMAT
+                                        " connected peers",
+                                        priv->connected),
+                               priv->peersFromUs, priv->connected);
     }
 
-    if ((priv->flags & ~TORRENT_FLAG_WAITING_CHECK) &&
-        (priv->flags & ~TORRENT_FLAG_CHECKING) &&
-        (priv->flags & ~TORRENT_FLAG_DOWNLOADING_WAIT) &&
-        (priv->flags & ~TORRENT_FLAG_SEEDING_WAIT) &&
-        (priv->flags & ~TORRENT_FLAG_PAUSED)) {
+    if ((priv->flags & ~TORRENT_FLAG_WAITING_CHECK) && (priv->flags & ~TORRENT_FLAG_CHECKING)
+        && (priv->flags & ~TORRENT_FLAG_DOWNLOADING_WAIT)
+        && (priv->flags & ~TORRENT_FLAG_SEEDING_WAIT) && (priv->flags & ~TORRENT_FLAG_PAUSED)) {
         getShortTransferString(r, buf, sizeof(buf));
         if (*buf)
             g_string_append_printf(gstr, " - %s", buf);
@@ -379,8 +330,7 @@ static void getStatusString(GString * gstr, TorrentCellRenderer * r)
 ****
 ***/
 
-static GdkPixbuf *get_icon(TorrentCellRenderer * r, GtkIconSize icon_size,
-                           GtkWidget * for_widget)
+static GdkPixbuf *get_icon(TorrentCellRenderer *r, GtkIconSize icon_size, GtkWidget *for_widget)
 {
     struct TorrentCellRendererPrivate *p = r->priv;
 
@@ -397,7 +347,7 @@ static GdkPixbuf *get_icon(TorrentCellRenderer * r, GtkIconSize icon_size,
     else
         mime_type = FILE_MIME_TYPE;
 
-    //return NULL;
+    // return NULL;
     return gtr_get_mime_type_icon(mime_type, icon_size, for_widget);
 }
 
@@ -405,19 +355,15 @@ static GdkPixbuf *get_icon(TorrentCellRenderer * r, GtkIconSize icon_size,
 ****
 ***/
 
-static void
-gtr_cell_renderer_get_preferred_size(GtkCellRenderer * renderer,
-                                     GtkWidget * widget,
-                                     GtkRequisition * minimum_size,
-                                     GtkRequisition * natural_size)
+static void gtr_cell_renderer_get_preferred_size(GtkCellRenderer *renderer, GtkWidget *widget,
+                                                 GtkRequisition *minimum_size,
+                                                 GtkRequisition *natural_size)
 {
-    gtk_cell_renderer_get_preferred_size(renderer, widget, minimum_size,
-                                         natural_size);
+    gtk_cell_renderer_get_preferred_size(renderer, widget, minimum_size, natural_size);
 }
 
-static void
-get_size_compact(TorrentCellRenderer * cell,
-                 GtkWidget * widget, gint * width, gint * height)
+static void get_size_compact(TorrentCellRenderer *cell, GtkWidget *widget, gint *width,
+                             gint *height)
 {
     int xpad, ypad;
     GtkRequisition icon_size;
@@ -435,16 +381,12 @@ get_size_compact(TorrentCellRenderer * cell,
 
     /* get the idealized cell dimensions */
     g_object_set(p->icon_renderer, "pixbuf", icon, NULL);
-    gtr_cell_renderer_get_preferred_size(p->icon_renderer, widget, NULL,
-                                         &icon_size);
-    g_object_set(p->text_renderer, "text", torrent_get_name(p->json),
-                 "ellipsize", PANGO_ELLIPSIZE_NONE, "scale", 1.0, NULL);
-    gtr_cell_renderer_get_preferred_size(p->text_renderer, widget, NULL,
-                                         &name_size);
-    g_object_set(p->text_renderer, "text", gstr_stat->str, "scale",
-                 SMALL_SCALE, NULL);
-    gtr_cell_renderer_get_preferred_size(p->text_renderer, widget, NULL,
-                                         &stat_size);
+    gtr_cell_renderer_get_preferred_size(p->icon_renderer, widget, NULL, &icon_size);
+    g_object_set(p->text_renderer, "text", torrent_get_name(p->json), "ellipsize",
+                 PANGO_ELLIPSIZE_NONE, "scale", 1.0, NULL);
+    gtr_cell_renderer_get_preferred_size(p->text_renderer, widget, NULL, &name_size);
+    g_object_set(p->text_renderer, "text", gstr_stat->str, "scale", SMALL_SCALE, NULL);
+    gtr_cell_renderer_get_preferred_size(p->text_renderer, widget, NULL, &stat_size);
 
     /**
     *** LAYOUT
@@ -452,9 +394,8 @@ get_size_compact(TorrentCellRenderer * cell,
 
 #define BAR_WIDTH 50
     if (width != NULL)
-        *width =
-            xpad * 2 + icon_size.width + GUI_PAD + name_size.width +
-            GUI_PAD + BAR_WIDTH + GUI_PAD + stat_size.width;
+        *width = xpad * 2 + icon_size.width + GUI_PAD + name_size.width + GUI_PAD + BAR_WIDTH
+            + GUI_PAD + stat_size.width;
     if (height != NULL)
         *height = ypad * 2 + MAX(name_size.height, p->bar_height);
 
@@ -462,9 +403,7 @@ get_size_compact(TorrentCellRenderer * cell,
     g_object_unref(icon);
 }
 
-static void
-get_size_full(TorrentCellRenderer * cell,
-              GtkWidget * widget, gint * width, gint * height)
+static void get_size_full(TorrentCellRenderer *cell, GtkWidget *widget, gint *width, gint *height)
 {
     int xpad, ypad;
     GtkRequisition icon_size;
@@ -487,47 +426,34 @@ get_size_full(TorrentCellRenderer * cell,
 
     /* get the idealized cell dimensions */
     g_object_set(p->icon_renderer, "pixbuf", icon, NULL);
-    gtr_cell_renderer_get_preferred_size(p->icon_renderer, widget, NULL,
-                                         &icon_size);
-    g_object_set(p->text_renderer, "text", torrent_get_name(p->json),
-                 "weight", PANGO_WEIGHT_BOLD, "scale", 1.0, "ellipsize",
-                 PANGO_ELLIPSIZE_NONE, NULL);
-    gtr_cell_renderer_get_preferred_size(p->text_renderer, widget, NULL,
-                                         &name_size);
-    g_object_set(p->text_renderer, "text", gstr_prog->str, "weight",
-                 PANGO_WEIGHT_NORMAL, "scale", SMALL_SCALE, NULL);
-    gtr_cell_renderer_get_preferred_size(p->text_renderer, widget, NULL,
-                                         &prog_size);
+    gtr_cell_renderer_get_preferred_size(p->icon_renderer, widget, NULL, &icon_size);
+    g_object_set(p->text_renderer, "text", torrent_get_name(p->json), "weight", PANGO_WEIGHT_BOLD,
+                 "scale", 1.0, "ellipsize", PANGO_ELLIPSIZE_NONE, NULL);
+    gtr_cell_renderer_get_preferred_size(p->text_renderer, widget, NULL, &name_size);
+    g_object_set(p->text_renderer, "text", gstr_prog->str, "weight", PANGO_WEIGHT_NORMAL, "scale",
+                 SMALL_SCALE, NULL);
+    gtr_cell_renderer_get_preferred_size(p->text_renderer, widget, NULL, &prog_size);
     g_object_set(p->text_renderer, "text", gstr_stat->str, NULL);
-    gtr_cell_renderer_get_preferred_size(p->text_renderer, widget, NULL,
-                                         &stat_size);
+    gtr_cell_renderer_get_preferred_size(p->text_renderer, widget, NULL, &stat_size);
 
     /**
     *** LAYOUT
     **/
 
     if (width != NULL)
-        *width =
-            xpad * 2 + icon_size.width + GUI_PAD + MAX3(name_size.width,
-                                                        prog_size.width,
-                                                        stat_size.width);
+        *width = xpad * 2 + icon_size.width + GUI_PAD
+            + MAX3(name_size.width, prog_size.width, stat_size.width);
     if (height != NULL)
-        *height =
-            ypad * 2 + name_size.height + prog_size.height +
-            GUI_PAD_SMALL + p->bar_height + GUI_PAD_SMALL +
-            stat_size.height;
+        *height = ypad * 2 + name_size.height + prog_size.height + GUI_PAD_SMALL + p->bar_height
+            + GUI_PAD_SMALL + stat_size.height;
 
     /* cleanup */
     g_object_unref(icon);
 }
 
-
-static void
-torrent_cell_renderer_get_size(GtkCellRenderer * cell, GtkWidget * widget,
-                               const GdkRectangle * cell_area,
-                               gint * x_offset,
-                               gint * y_offset,
-                               gint * width, gint * height)
+static void torrent_cell_renderer_get_size(GtkCellRenderer *cell, GtkWidget *widget,
+                                           const GdkRectangle *cell_area, gint *x_offset,
+                                           gint *y_offset, gint *width, gint *height)
 {
     TorrentCellRenderer *self = TORRENT_CELL_RENDERER(cell);
 
@@ -552,16 +478,12 @@ torrent_cell_renderer_get_size(GtkCellRenderer * cell, GtkWidget * widget,
         if (y_offset) {
             int xpad, ypad;
             gtk_cell_renderer_get_padding(cell, &xpad, &ypad);
-            *y_offset =
-                cell_area ? (int) ((cell_area->height - (ypad * 2 + h)) /
-                                   2.0) : 0;
+            *y_offset = cell_area ? (int)((cell_area->height - (ypad * 2 + h)) / 2.0) : 0;
         }
     }
 }
 
-static void
-get_text_color(TorrentCellRenderer * r, GtkWidget * widget,
-               GtrColor * setme)
+static void get_text_color(TorrentCellRenderer *r, GtkWidget *widget, GtrColor *setme)
 {
     struct TorrentCellRendererPrivate *p = r->priv;
     static const GdkRGBA red = { 1.0, 0, 0, 0 };
@@ -572,23 +494,21 @@ get_text_color(TorrentCellRenderer * r, GtkWidget * widget,
         gtk_style_context_get_color(gtk_widget_get_style_context(widget),
                                     GTK_STATE_FLAG_INSENSITIVE, setme);
     else
-        gtk_style_context_get_color(gtk_widget_get_style_context(widget),
-                                    GTK_STATE_FLAG_NORMAL, setme);
+        gtk_style_context_get_color(gtk_widget_get_style_context(widget), GTK_STATE_FLAG_NORMAL,
+                                    setme);
 }
 
-static double get_percent_done(TorrentCellRenderer * r, gboolean * seed)
+static double get_percent_done(TorrentCellRenderer *r, gboolean *seed)
 {
     struct TorrentCellRendererPrivate *priv = r->priv;
     gdouble d;
 
     if ((priv->flags & TORRENT_FLAG_SEEDING) && getSeedRatio(r, &d)) {
         *seed = TRUE;
-        const gint64 baseline =
-            priv->downloaded ? priv->downloaded : priv->sizeWhenDone;
+        const gint64 baseline = priv->downloaded ? priv->downloaded : priv->sizeWhenDone;
         const gint64 goal = baseline * priv->seedRatioLimit;
-        const gint64 bytesLeft =
-            goal > priv->uploadedEver ? goal - priv->uploadedEver : 0;
-        float seedRatioPercentDone = (gdouble) (goal - bytesLeft) / goal;
+        const gint64 bytesLeft = goal > priv->uploadedEver ? goal - priv->uploadedEver : 0;
+        float seedRatioPercentDone = (gdouble)(goal - bytesLeft) / goal;
 
         d = MAX(0.0, seedRatioPercentDone * 100.0);
     } else {
@@ -599,41 +519,30 @@ static double get_percent_done(TorrentCellRenderer * r, gboolean * seed)
     return d;
 }
 
-static void
-gtr_cell_renderer_render(GtkCellRenderer * renderer,
-                         GtrDrawable * drawable,
-                         GtkWidget * widget,
-                         const GdkRectangle * area,
-                         GtkCellRendererState flags)
+static void gtr_cell_renderer_render(GtkCellRenderer *renderer, GtrDrawable *drawable,
+                                     GtkWidget *widget, const GdkRectangle *area,
+                                     GtkCellRendererState flags)
 {
-    gtk_cell_renderer_render(renderer, drawable, widget, area, area,
-                             flags);
+    gtk_cell_renderer_render(renderer, drawable, widget, area, area, flags);
 }
 
-static void
-torrent_cell_renderer_render(GtkCellRenderer * cell,
-                             GtrDrawable * window, GtkWidget * widget,
-                             const GdkRectangle * background_area,
-                             const GdkRectangle * cell_area,
-                             GtkCellRendererState flags)
+static void torrent_cell_renderer_render(GtkCellRenderer *cell, GtrDrawable *window,
+                                         GtkWidget *widget, const GdkRectangle *background_area,
+                                         const GdkRectangle *cell_area, GtkCellRendererState flags)
 {
     TorrentCellRenderer *self = TORRENT_CELL_RENDERER(cell);
 
     if (self) {
         struct TorrentCellRendererPrivate *p = self->priv;
         if (p->compact)
-            render_compact(self, window, widget, background_area,
-                           cell_area, flags);
+            render_compact(self, window, widget, background_area, cell_area, flags);
         else
-            render_full(self, window, widget, background_area, cell_area,
-                        flags);
+            render_full(self, window, widget, background_area, cell_area, flags);
     }
 }
 
-static void torrent_cell_renderer_set_property(GObject * object,
-                                               guint property_id,
-                                               const GValue * v,
-                                               GParamSpec * pspec)
+static void torrent_cell_renderer_set_property(GObject *object, guint property_id, const GValue *v,
+                                               GParamSpec *pspec)
 {
     TorrentCellRenderer *self = TORRENT_CELL_RENDERER(object);
     struct TorrentCellRendererPrivate *p = self->priv;
@@ -723,18 +632,15 @@ static void torrent_cell_renderer_set_property(GObject * object,
     }
 }
 
-static void
-torrent_cell_renderer_get_property(GObject * object,
-                                   guint property_id,
-                                   GValue * v, GParamSpec * pspec)
+static void torrent_cell_renderer_get_property(GObject *object, guint property_id, GValue *v,
+                                               GParamSpec *pspec)
 {
     G_OBJECT_WARN_INVALID_PROPERTY_ID(object, property_id, pspec);
 }
 
-G_DEFINE_TYPE(TorrentCellRenderer, torrent_cell_renderer,
-              GTK_TYPE_CELL_RENDERER)
+G_DEFINE_TYPE(TorrentCellRenderer, torrent_cell_renderer, GTK_TYPE_CELL_RENDERER)
 
-static void torrent_cell_renderer_dispose(GObject * o)
+static void torrent_cell_renderer_dispose(GObject *o)
 {
     TorrentCellRenderer *r = TORRENT_CELL_RENDERER(o);
 
@@ -750,14 +656,12 @@ static void torrent_cell_renderer_dispose(GObject * o)
     G_OBJECT_CLASS(torrent_cell_renderer_parent_class)->dispose(o);
 }
 
-static void
-torrent_cell_renderer_class_init(TorrentCellRendererClass * klass)
+static void torrent_cell_renderer_class_init(TorrentCellRendererClass *klass)
 {
     GObjectClass *gobject_class = G_OBJECT_CLASS(klass);
     GtkCellRendererClass *cell_class = GTK_CELL_RENDERER_CLASS(klass);
 
-    g_type_class_add_private(klass,
-                             sizeof(struct TorrentCellRendererPrivate));
+    g_type_class_add_private(klass, sizeof(struct TorrentCellRendererPrivate));
 
     cell_class->render = torrent_cell_renderer_render;
     cell_class->get_size = torrent_cell_renderer_get_size;
@@ -766,175 +670,115 @@ torrent_cell_renderer_class_init(TorrentCellRendererClass * klass)
     gobject_class->dispose = torrent_cell_renderer_dispose;
 
     g_object_class_install_property(gobject_class, P_JSON,
-                                    g_param_spec_pointer("json", NULL,
-                                                         "json",
-                                                         G_PARAM_READWRITE));
+                                    g_param_spec_pointer("json", NULL, "json", G_PARAM_READWRITE));
 
-    g_object_class_install_property(gobject_class, P_CLIENT,
-                                    g_param_spec_pointer("client", NULL,
-                                                         "client",
-                                                         G_PARAM_READWRITE));
+    g_object_class_install_property(
+        gobject_class, P_CLIENT, g_param_spec_pointer("client", NULL, "client", G_PARAM_READWRITE));
 
-    g_object_class_install_property(gobject_class, P_OWNER,
-                                    g_param_spec_pointer("owner", NULL,
-                                                         "owner",
-                                                         G_PARAM_READWRITE));
+    g_object_class_install_property(
+        gobject_class, P_OWNER, g_param_spec_pointer("owner", NULL, "owner", G_PARAM_READWRITE));
 
-    g_object_class_install_property(gobject_class, P_RATIO,
-                                    g_param_spec_double("ratio", NULL,
-                                                        "ratio",
-                                                        0, G_MAXDOUBLE, 0,
-                                                        G_PARAM_READWRITE));
+    g_object_class_install_property(
+        gobject_class, P_RATIO,
+        g_param_spec_double("ratio", NULL, "ratio", 0, G_MAXDOUBLE, 0, G_PARAM_READWRITE));
 
     g_object_class_install_property(gobject_class, P_SEEDRATIOLIMIT,
-                                    g_param_spec_double("seedRatioLimit",
-                                                        NULL,
-                                                        "seedRatioLimit",
-                                                        0, G_MAXDOUBLE, 0,
-                                                        G_PARAM_READWRITE));
+                                    g_param_spec_double("seedRatioLimit", NULL, "seedRatioLimit", 0,
+                                                        G_MAXDOUBLE, 0, G_PARAM_READWRITE));
 
-    g_object_class_install_property(gobject_class, P_SEEDRATIOMODE,
-                                    g_param_spec_int64("seedRatioMode",
-                                                       NULL,
-                                                       "seedRatioMode", 0,
-                                                       2, 0,
-                                                       G_PARAM_READWRITE));
+    g_object_class_install_property(
+        gobject_class, P_SEEDRATIOMODE,
+        g_param_spec_int64("seedRatioMode", NULL, "seedRatioMode", 0, 2, 0, G_PARAM_READWRITE));
 
     g_object_class_install_property(gobject_class, P_PERCENTCOMPLETE,
-                                    g_param_spec_double("percentComplete",
-                                                        NULL,
-                                                        "percentComplete",
-                                                        0, 100.00, 0,
+                                    g_param_spec_double("percentComplete", NULL, "percentComplete",
+                                                        0, 100.00, 0, G_PARAM_READWRITE));
+
+    g_object_class_install_property(gobject_class, P_METADATAPERCENTCOMPLETE,
+                                    g_param_spec_double("metadataPercentComplete", NULL,
+                                                        "metadataPercentComplete", 0, 100.00, 0,
                                                         G_PARAM_READWRITE));
 
-    g_object_class_install_property(gobject_class,
-                                    P_METADATAPERCENTCOMPLETE,
-                                    g_param_spec_double
-                                    ("metadataPercentComplete", NULL,
-                                     "metadataPercentComplete", 0, 100.00,
-                                     0, G_PARAM_READWRITE));
-
-    g_object_class_install_property(gobject_class, P_TOTALSIZE,
-                                    g_param_spec_int64("totalSize", NULL,
-                                                       "totalSize",
-                                                       0, G_MAXINT64, 0,
-                                                       G_PARAM_READWRITE));
+    g_object_class_install_property(
+        gobject_class, P_TOTALSIZE,
+        g_param_spec_int64("totalSize", NULL, "totalSize", 0, G_MAXINT64, 0, G_PARAM_READWRITE));
 
     g_object_class_install_property(gobject_class, P_SIZEWHENDONE,
-                                    g_param_spec_int64("sizeWhenDone",
-                                                       NULL,
-                                                       "sizeWhenDone", 0,
-                                                       G_MAXINT64, 0,
-                                                       G_PARAM_READWRITE));
+                                    g_param_spec_int64("sizeWhenDone", NULL, "sizeWhenDone", 0,
+                                                       G_MAXINT64, 0, G_PARAM_READWRITE));
 
-    g_object_class_install_property(gobject_class, P_STATUS,
-                                    g_param_spec_uint("status", NULL,
-                                                      "status",
-                                                      0, G_MAXUINT, 0,
-                                                      G_PARAM_READWRITE));
+    g_object_class_install_property(
+        gobject_class, P_STATUS,
+        g_param_spec_uint("status", NULL, "status", 0, G_MAXUINT, 0, G_PARAM_READWRITE));
 
-    g_object_class_install_property(gobject_class, P_FILECOUNT,
-                                    g_param_spec_uint("fileCount", NULL,
-                                                      "fileCount",
-                                                      0, G_MAXUINT, 0,
-                                                      G_PARAM_READWRITE));
+    g_object_class_install_property(
+        gobject_class, P_FILECOUNT,
+        g_param_spec_uint("fileCount", NULL, "fileCount", 0, G_MAXUINT, 0, G_PARAM_READWRITE));
 
-    g_object_class_install_property(gobject_class, P_ERROR,
-                                    g_param_spec_int64("error", NULL,
-                                                       "error",
-                                                       0, G_MAXINT64, 0,
-                                                       G_PARAM_READWRITE));
+    g_object_class_install_property(
+        gobject_class, P_ERROR,
+        g_param_spec_int64("error", NULL, "error", 0, G_MAXINT64, 0, G_PARAM_READWRITE));
 
-    g_object_class_install_property(gobject_class, P_UPSPEED,
-                                    g_param_spec_int64("upSpeed", NULL,
-                                                       "upSpeed",
-                                                       0, G_MAXINT64, 0,
-                                                       G_PARAM_READWRITE));
+    g_object_class_install_property(
+        gobject_class, P_UPSPEED,
+        g_param_spec_int64("upSpeed", NULL, "upSpeed", 0, G_MAXINT64, 0, G_PARAM_READWRITE));
 
-    g_object_class_install_property(gobject_class, P_DOWNSPEED,
-                                    g_param_spec_int64("downSpeed", NULL,
-                                                       "downSpeed",
-                                                       0, G_MAXINT64, 0,
-                                                       G_PARAM_READWRITE));
+    g_object_class_install_property(
+        gobject_class, P_DOWNSPEED,
+        g_param_spec_int64("downSpeed", NULL, "downSpeed", 0, G_MAXINT64, 0, G_PARAM_READWRITE));
 
-    g_object_class_install_property(gobject_class, P_DOWNLOADED,
-                                    g_param_spec_int64("downloaded", NULL,
-                                                       "downloaded",
-                                                       0, G_MAXINT64, 0,
-                                                       G_PARAM_READWRITE));
+    g_object_class_install_property(
+        gobject_class, P_DOWNLOADED,
+        g_param_spec_int64("downloaded", NULL, "downloaded", 0, G_MAXINT64, 0, G_PARAM_READWRITE));
 
-    g_object_class_install_property(gobject_class, P_HAVEVALID,
-                                    g_param_spec_int64("haveValid", NULL,
-                                                       "haveValid",
-                                                       0, G_MAXINT64, 0,
-                                                       G_PARAM_READWRITE));
+    g_object_class_install_property(
+        gobject_class, P_HAVEVALID,
+        g_param_spec_int64("haveValid", NULL, "haveValid", 0, G_MAXINT64, 0, G_PARAM_READWRITE));
 
     g_object_class_install_property(gobject_class, P_HAVEUNCHECKED,
-                                    g_param_spec_int64("haveUnchecked",
-                                                       NULL,
-                                                       "haveUnchecked", 0,
-                                                       G_MAXINT64, 0,
-                                                       G_PARAM_READWRITE));
+                                    g_param_spec_int64("haveUnchecked", NULL, "haveUnchecked", 0,
+                                                       G_MAXINT64, 0, G_PARAM_READWRITE));
 
-    g_object_class_install_property(gobject_class, P_UPLOADED,
-                                    g_param_spec_int64("uploaded", NULL,
-                                                       "uploaded",
-                                                       0, G_MAXINT64, 0,
-                                                       G_PARAM_READWRITE));
+    g_object_class_install_property(
+        gobject_class, P_UPLOADED,
+        g_param_spec_int64("uploaded", NULL, "uploaded", 0, G_MAXINT64, 0, G_PARAM_READWRITE));
 
     g_object_class_install_property(gobject_class, P_PEERSGETTINGFROMUS,
-                                    g_param_spec_int64
-                                    ("peersGettingFromUs", NULL,
-                                     "peersGettingFromUs", -1, G_MAXINT64,
-                                     0, G_PARAM_READWRITE));
-
-    g_object_class_install_property(gobject_class, P_PEERSTOUS,
-                                    g_param_spec_int64("peersToUs", NULL,
-                                                       "peersToUs",
-                                                       -1, G_MAXINT64, 0,
+                                    g_param_spec_int64("peersGettingFromUs", NULL,
+                                                       "peersGettingFromUs", -1, G_MAXINT64, 0,
                                                        G_PARAM_READWRITE));
+
+    g_object_class_install_property(
+        gobject_class, P_PEERSTOUS,
+        g_param_spec_int64("peersToUs", NULL, "peersToUs", -1, G_MAXINT64, 0, G_PARAM_READWRITE));
 
     g_object_class_install_property(gobject_class, P_WEBSEEDSTOUS,
-                                    g_param_spec_int64("webSeedsToUs",
-                                                       NULL,
-                                                       "webSeedsToUs", 0,
-                                                       G_MAXINT64, 0,
-                                                       G_PARAM_READWRITE));
+                                    g_param_spec_int64("webSeedsToUs", NULL, "webSeedsToUs", 0,
+                                                       G_MAXINT64, 0, G_PARAM_READWRITE));
 
-    g_object_class_install_property(gobject_class, P_ETA,
-                                    g_param_spec_int64("eta", NULL,
-                                                       "eta",
-                                                       -2, G_MAXINT64, 0,
-                                                       G_PARAM_READWRITE));
+    g_object_class_install_property(
+        gobject_class, P_ETA,
+        g_param_spec_int64("eta", NULL, "eta", -2, G_MAXINT64, 0, G_PARAM_READWRITE));
 
-    g_object_class_install_property(gobject_class, P_CONNECTED,
-                                    g_param_spec_int64("connected", NULL,
-                                                       "connected",
-                                                       0, G_MAXINT64, 0,
-                                                       G_PARAM_READWRITE));
+    g_object_class_install_property(
+        gobject_class, P_CONNECTED,
+        g_param_spec_int64("connected", NULL, "connected", 0, G_MAXINT64, 0, G_PARAM_READWRITE));
 
     g_object_class_install_property(gobject_class, P_BAR_HEIGHT,
-                                    g_param_spec_int("bar-height", NULL,
-                                                     "Bar Height",
-                                                     1, INT_MAX,
-                                                     DEFAULT_BAR_HEIGHT,
-                                                     G_PARAM_READWRITE));
+                                    g_param_spec_int("bar-height", NULL, "Bar Height", 1, INT_MAX,
+                                                     DEFAULT_BAR_HEIGHT, G_PARAM_READWRITE));
 
-    g_object_class_install_property(gobject_class, P_COMPACT,
-                                    g_param_spec_boolean("compact", NULL,
-                                                         "Compact Mode",
-                                                         FALSE,
-                                                         G_PARAM_READWRITE));
+    g_object_class_install_property(
+        gobject_class, P_COMPACT,
+        g_param_spec_boolean("compact", NULL, "Compact Mode", FALSE, G_PARAM_READWRITE));
 }
 
-static void torrent_cell_renderer_init(TorrentCellRenderer * self)
+static void torrent_cell_renderer_init(TorrentCellRenderer *self)
 {
     struct TorrentCellRendererPrivate *p;
 
-    p = self->priv = G_TYPE_INSTANCE_GET_PRIVATE(self,
-                                                 TORRENT_CELL_RENDERER_TYPE,
-                                                 struct
-                                                 TorrentCellRendererPrivate);
+    p = self->priv = G_TYPE_INSTANCE_GET_PRIVATE(self, TORRENT_CELL_RENDERER_TYPE,
+                                                 struct TorrentCellRendererPrivate);
 
     p->gstr1 = g_string_new(NULL);
     p->gstr2 = g_string_new(NULL);
@@ -949,19 +793,14 @@ static void torrent_cell_renderer_init(TorrentCellRenderer * self)
     p->bar_height = DEFAULT_BAR_HEIGHT;
 }
 
-
 GtkCellRenderer *torrent_cell_renderer_new(void)
 {
-    return (GtkCellRenderer *) g_object_new(TORRENT_CELL_RENDERER_TYPE,
-                                            NULL);
+    return (GtkCellRenderer *)g_object_new(TORRENT_CELL_RENDERER_TYPE, NULL);
 }
 
-static void
-render_compact(TorrentCellRenderer * cell,
-               GtrDrawable * window,
-               GtkWidget * widget,
-               const GdkRectangle * background_area,
-               const GdkRectangle * cell_area, GtkCellRendererState flags)
+static void render_compact(TorrentCellRenderer *cell, GtrDrawable *window, GtkWidget *widget,
+                           const GdkRectangle *background_area, const GdkRectangle *cell_area,
+                           GtkCellRendererState flags)
 {
     int xpad, ypad;
     GtkRequisition size;
@@ -976,8 +815,7 @@ render_compact(TorrentCellRenderer * cell,
 
     struct TorrentCellRendererPrivate *p = cell->priv;
     const gboolean active = (p->flags & ~TORRENT_FLAG_PAUSED)
-        && (p->flags & ~TORRENT_FLAG_DOWNLOADING_WAIT)
-        && (p->flags & ~TORRENT_FLAG_SEEDING_WAIT);
+        && (p->flags & ~TORRENT_FLAG_DOWNLOADING_WAIT) && (p->flags & ~TORRENT_FLAG_SEEDING_WAIT);
     const double percentDone = get_percent_done(cell, &seed);
     const gboolean sensitive = active || p->error;
     GString *gstr_stat = p->gstr1;
@@ -997,18 +835,14 @@ render_compact(TorrentCellRenderer * cell,
     icon_area = name_area = stat_area = prog_area = fill_area;
 
     g_object_set(p->icon_renderer, "pixbuf", icon, NULL);
-    gtr_cell_renderer_get_preferred_size(p->icon_renderer, widget, NULL,
-                                         &size);
+    gtr_cell_renderer_get_preferred_size(p->icon_renderer, widget, NULL, &size);
     icon_area.width = size.width;
-    g_object_set(p->text_renderer, "text", torrent_get_name(p->json),
-                 "ellipsize", PANGO_ELLIPSIZE_NONE, "scale", 1.0, NULL);
-    gtr_cell_renderer_get_preferred_size(p->text_renderer, widget, NULL,
-                                         &size);
+    g_object_set(p->text_renderer, "text", torrent_get_name(p->json), "ellipsize",
+                 PANGO_ELLIPSIZE_NONE, "scale", 1.0, NULL);
+    gtr_cell_renderer_get_preferred_size(p->text_renderer, widget, NULL, &size);
     name_area.width = size.width;
-    g_object_set(p->text_renderer, "text", gstr_stat->str, "scale",
-                 SMALL_SCALE, NULL);
-    gtr_cell_renderer_get_preferred_size(p->text_renderer, widget, NULL,
-                                         &size);
+    g_object_set(p->text_renderer, "text", gstr_stat->str, "scale", SMALL_SCALE, NULL);
+    gtr_cell_renderer_get_preferred_size(p->text_renderer, widget, NULL, &size);
     stat_area.width = size.width;
 
     icon_area.x = fill_area.x;
@@ -1023,34 +857,25 @@ render_compact(TorrentCellRenderer * cell,
     *** RENDER
     **/
 
-    g_object_set(p->icon_renderer, "pixbuf", icon, "sensitive", sensitive,
-                 NULL);
-    gtr_cell_renderer_render(p->icon_renderer, window, widget, &icon_area,
-                             flags);
-    g_object_set(p->progress_renderer, "value", (gint) percentDone, "text",
-                 NULL, "sensitive", sensitive, NULL);
-    gtr_cell_renderer_render(p->progress_renderer, window, widget,
-                             &prog_area, flags);
-    g_object_set(p->text_renderer, "text", gstr_stat->str, "scale",
-                 SMALL_SCALE, "ellipsize", PANGO_ELLIPSIZE_END,
+    g_object_set(p->icon_renderer, "pixbuf", icon, "sensitive", sensitive, NULL);
+    gtr_cell_renderer_render(p->icon_renderer, window, widget, &icon_area, flags);
+    g_object_set(p->progress_renderer, "value", (gint)percentDone, "text", NULL, "sensitive",
+                 sensitive, NULL);
+    gtr_cell_renderer_render(p->progress_renderer, window, widget, &prog_area, flags);
+    g_object_set(p->text_renderer, "text", gstr_stat->str, "scale", SMALL_SCALE, "ellipsize",
+                 PANGO_ELLIPSIZE_END, FOREGROUND_COLOR_KEY, &text_color, NULL);
+    gtr_cell_renderer_render(p->text_renderer, window, widget, &stat_area, flags);
+    g_object_set(p->text_renderer, "text", torrent_get_name(p->json), "scale", 1.0,
                  FOREGROUND_COLOR_KEY, &text_color, NULL);
-    gtr_cell_renderer_render(p->text_renderer, window, widget, &stat_area,
-                             flags);
-    g_object_set(p->text_renderer, "text", torrent_get_name(p->json),
-                 "scale", 1.0, FOREGROUND_COLOR_KEY, &text_color, NULL);
-    gtr_cell_renderer_render(p->text_renderer, window, widget, &name_area,
-                             flags);
+    gtr_cell_renderer_render(p->text_renderer, window, widget, &name_area, flags);
 
     /* cleanup */
     g_object_unref(icon);
 }
 
-static void
-render_full(TorrentCellRenderer * cell,
-            GtrDrawable * window,
-            GtkWidget * widget,
-            const GdkRectangle * background_area,
-            const GdkRectangle * cell_area, GtkCellRendererState flags)
+static void render_full(TorrentCellRenderer *cell, GtrDrawable *window, GtkWidget *widget,
+                        const GdkRectangle *background_area, const GdkRectangle *cell_area,
+                        GtkCellRendererState flags)
 {
     int xpad, ypad;
     GtkRequisition size;
@@ -1066,8 +891,7 @@ render_full(TorrentCellRenderer * cell,
 
     struct TorrentCellRendererPrivate *p = cell->priv;
     const gboolean active = (p->flags & ~TORRENT_FLAG_PAUSED)
-        && (p->flags & ~TORRENT_FLAG_DOWNLOADING_WAIT)
-        && (p->flags & ~TORRENT_FLAG_SEEDING_WAIT);
+        && (p->flags & ~TORRENT_FLAG_DOWNLOADING_WAIT) && (p->flags & ~TORRENT_FLAG_SEEDING_WAIT);
     const gboolean sensitive = active || p->error;
     const double percentDone = get_percent_done(cell, &seed);
     GString *gstr_prog = p->gstr1;
@@ -1083,26 +907,21 @@ render_full(TorrentCellRenderer * cell,
 
     /* get the idealized cell dimensions */
     g_object_set(p->icon_renderer, "pixbuf", icon, NULL);
-    gtr_cell_renderer_get_preferred_size(p->icon_renderer, widget, NULL,
-                                         &size);
+    gtr_cell_renderer_get_preferred_size(p->icon_renderer, widget, NULL, &size);
     icon_area.width = size.width;
     icon_area.height = size.height;
-    g_object_set(p->text_renderer, "text", torrent_get_name(p->json),
-                 "weight", PANGO_WEIGHT_BOLD, "ellipsize",
-                 PANGO_ELLIPSIZE_NONE, "scale", 1.0, NULL);
-    gtr_cell_renderer_get_preferred_size(p->text_renderer, widget, NULL,
-                                         &size);
+    g_object_set(p->text_renderer, "text", torrent_get_name(p->json), "weight", PANGO_WEIGHT_BOLD,
+                 "ellipsize", PANGO_ELLIPSIZE_NONE, "scale", 1.0, NULL);
+    gtr_cell_renderer_get_preferred_size(p->text_renderer, widget, NULL, &size);
     name_area.width = size.width;
     name_area.height = size.height;
-    g_object_set(p->text_renderer, "text", gstr_prog->str, "weight",
-                 PANGO_WEIGHT_NORMAL, "scale", SMALL_SCALE, NULL);
-    gtr_cell_renderer_get_preferred_size(p->text_renderer, widget, NULL,
-                                         &size);
+    g_object_set(p->text_renderer, "text", gstr_prog->str, "weight", PANGO_WEIGHT_NORMAL, "scale",
+                 SMALL_SCALE, NULL);
+    gtr_cell_renderer_get_preferred_size(p->text_renderer, widget, NULL, &size);
     prog_area.width = size.width;
     prog_area.height = size.height;
     g_object_set(p->text_renderer, "text", gstr_stat->str, NULL);
-    gtr_cell_renderer_get_preferred_size(p->text_renderer, widget, NULL,
-                                         &size);
+    gtr_cell_renderer_get_preferred_size(p->text_renderer, widget, NULL, &size);
     stat_area.width = size.width;
     stat_area.height = size.height;
 
@@ -1123,8 +942,7 @@ render_full(TorrentCellRenderer * cell,
     /* name */
     name_area.x = icon_area.x + icon_area.width + GUI_PAD;
     name_area.y = fill_area.y;
-    name_area.width =
-        fill_area.width - GUI_PAD - icon_area.width - GUI_PAD_SMALL;
+    name_area.width = fill_area.width - GUI_PAD - icon_area.width - GUI_PAD_SMALL;
 
     /* prog */
     prog_area.x = name_area.x;
@@ -1146,34 +964,26 @@ render_full(TorrentCellRenderer * cell,
     *** RENDER
     **/
 
-    g_object_set(p->icon_renderer, "pixbuf", icon, "sensitive", sensitive,
-                 NULL);
-    gtr_cell_renderer_render(p->icon_renderer, window, widget, &icon_area,
-                             flags);
-    g_object_set(p->text_renderer, "text", torrent_get_name(p->json),
-                 "scale", 1.0, FOREGROUND_COLOR_KEY, &text_color,
-                 "ellipsize", PANGO_ELLIPSIZE_END, "weight",
+    g_object_set(p->icon_renderer, "pixbuf", icon, "sensitive", sensitive, NULL);
+    gtr_cell_renderer_render(p->icon_renderer, window, widget, &icon_area, flags);
+    g_object_set(p->text_renderer, "text", torrent_get_name(p->json), "scale", 1.0,
+                 FOREGROUND_COLOR_KEY, &text_color, "ellipsize", PANGO_ELLIPSIZE_END, "weight",
                  PANGO_WEIGHT_BOLD, NULL);
-    gtr_cell_renderer_render(p->text_renderer, window, widget, &name_area,
-                             flags);
-    g_object_set(p->text_renderer, "text", gstr_prog->str, "scale",
-                 SMALL_SCALE, "weight", PANGO_WEIGHT_NORMAL, NULL);
-    gtr_cell_renderer_render(p->text_renderer, window, widget, &prog_area,
-                             flags);
-    g_object_set(p->progress_renderer, "value", (gint) percentDone,
-                 "text", "", "sensitive", sensitive, NULL);
-    gtr_cell_renderer_render(p->progress_renderer, window, widget,
-                             &prct_area, flags);
-    g_object_set(p->text_renderer, "text", gstr_stat->str,
-                 FOREGROUND_COLOR_KEY, &text_color, NULL);
-    gtr_cell_renderer_render(p->text_renderer, window, widget, &stat_area,
-                             flags);
+    gtr_cell_renderer_render(p->text_renderer, window, widget, &name_area, flags);
+    g_object_set(p->text_renderer, "text", gstr_prog->str, "scale", SMALL_SCALE, "weight",
+                 PANGO_WEIGHT_NORMAL, NULL);
+    gtr_cell_renderer_render(p->text_renderer, window, widget, &prog_area, flags);
+    g_object_set(p->progress_renderer, "value", (gint)percentDone, "text", "", "sensitive",
+                 sensitive, NULL);
+    gtr_cell_renderer_render(p->progress_renderer, window, widget, &prct_area, flags);
+    g_object_set(p->text_renderer, "text", gstr_stat->str, FOREGROUND_COLOR_KEY, &text_color, NULL);
+    gtr_cell_renderer_render(p->text_renderer, window, widget, &stat_area, flags);
 
     /* cleanup */
     g_object_unref(icon);
 }
 
-GtkTreeView *torrent_cell_renderer_get_owner(TorrentCellRenderer * r)
+GtkTreeView *torrent_cell_renderer_get_owner(TorrentCellRenderer *r)
 {
     return r->priv->owner;
 }

--- a/src/torrent-cell-renderer.h
+++ b/src/torrent-cell-renderer.h
@@ -15,18 +15,16 @@
 
 #include <gtk/gtk.h>
 
-#define GTR_UNICODE_UP		"\xE2\x86\x91"
-#define GTR_UNICODE_DOWN	"\xE2\x86\x93"
+#define GTR_UNICODE_UP      "\xE2\x86\x91"
+#define GTR_UNICODE_DOWN    "\xE2\x86\x93"
 #define DIRECTORY_MIME_TYPE "folder"
-#define FILE_MIME_TYPE "file"
+#define FILE_MIME_TYPE      "file"
 #define UNKNOWN_MIME_TYPE   "unknown"
 
-#define TORRENT_CELL_RENDERER_TYPE ( torrent_cell_renderer_get_type( ) )
+#define TORRENT_CELL_RENDERER_TYPE (torrent_cell_renderer_get_type())
 
-#define TORRENT_CELL_RENDERER( o ) \
-    ( G_TYPE_CHECK_INSTANCE_CAST( ( o ), \
-                                 TORRENT_CELL_RENDERER_TYPE, \
-                                 TorrentCellRenderer ) )
+#define TORRENT_CELL_RENDERER(o)                                                                   \
+    (G_TYPE_CHECK_INSTANCE_CAST((o), TORRENT_CELL_RENDERER_TYPE, TorrentCellRenderer))
 
 typedef struct TorrentCellRenderer TorrentCellRenderer;
 
@@ -46,6 +44,6 @@ struct TorrentCellRendererClass {
 GType torrent_cell_renderer_get_type(void) G_GNUC_CONST;
 
 GtkCellRenderer *torrent_cell_renderer_new(void);
-GtkTreeView *torrent_cell_renderer_get_owner(TorrentCellRenderer * r);
+GtkTreeView *torrent_cell_renderer_get_owner(TorrentCellRenderer *r);
 
-#endif                          /* GTR_TORRENT_CELL_RENDERER_H */
+#endif /* GTR_TORRENT_CELL_RENDERER_H */

--- a/src/torrent.c
+++ b/src/torrent.c
@@ -24,217 +24,209 @@
 #include <gtk/gtk.h>
 #include <json-glib/json-glib.h>
 
-#include "trg-client.h"
 #include "json.h"
-#include "torrent.h"
 #include "protocol-constants.h"
+#include "torrent.h"
+#include "trg-client.h"
 #include "util.h"
 
 /* Just some functions to get fields out of the torrent object. */
 
-JsonArray *torrent_get_peers(JsonObject * t)
+JsonArray *torrent_get_peers(JsonObject *t)
 {
     g_assert(json_object_get_array_member(t, FIELD_PEERS));
     return json_object_get_array_member(t, FIELD_PEERS);
 }
 
-JsonObject *torrent_get_peersfrom(JsonObject * t)
+JsonObject *torrent_get_peersfrom(JsonObject *t)
 {
     return json_object_get_object_member(t, FIELD_PEERSFROM);
 }
 
-JsonArray *torrent_get_wanted(JsonObject * t)
+JsonArray *torrent_get_wanted(JsonObject *t)
 {
     g_assert(json_object_get_array_member(t, FIELD_WANTED));
     return json_object_get_array_member(t, FIELD_WANTED);
 }
 
-JsonArray *torrent_get_priorities(JsonObject * t)
+JsonArray *torrent_get_priorities(JsonObject *t)
 {
     g_assert(json_object_get_array_member(t, FIELD_PRIORITIES));
     return json_object_get_array_member(t, FIELD_PRIORITIES);
 }
 
-JsonArray *torrent_get_tracker_stats(JsonObject * t)
+JsonArray *torrent_get_tracker_stats(JsonObject *t)
 {
     g_assert(json_object_get_array_member(t, FIELD_TRACKER_STATS));
     return json_object_get_array_member(t, FIELD_TRACKER_STATS);
 }
 
-gint64 torrent_get_id(JsonObject * t)
+gint64 torrent_get_id(JsonObject *t)
 {
     return json_object_get_int_member(t, FIELD_ID);
 }
 
-const gchar *torrent_get_download_dir(JsonObject * t)
+const gchar *torrent_get_download_dir(JsonObject *t)
 {
     return json_object_get_string_member(t, FIELD_DOWNLOAD_DIR);
 }
 
-const gchar *torrent_get_comment(JsonObject * t)
+const gchar *torrent_get_comment(JsonObject *t)
 {
     return json_object_get_string_member(t, FIELD_COMMENT);
 }
 
-gdouble torrent_get_metadata_percent_complete(JsonObject * t)
+gdouble torrent_get_metadata_percent_complete(JsonObject *t)
 {
-    JsonNode *node =
-        json_object_get_member(t, FIELD_METADATAPERCENTCOMPLETE);
+    JsonNode *node = json_object_get_member(t, FIELD_METADATAPERCENTCOMPLETE);
     if (node)
         return json_double_to_progress(node);
     else
         return 100.0;
 }
 
-const gchar *torrent_get_name(JsonObject * t)
+const gchar *torrent_get_name(JsonObject *t)
 {
     return json_object_get_string_member(t, FIELD_NAME);
 }
 
-gint64 torrent_get_added_date(JsonObject * t)
+gint64 torrent_get_added_date(JsonObject *t)
 {
     return json_object_get_int_member(t, FIELD_ADDED_DATE);
 }
 
-gboolean torrent_get_honors_session_limits(JsonObject * t)
+gboolean torrent_get_honors_session_limits(JsonObject *t)
 {
     return json_object_get_boolean_member(t, FIELD_HONORS_SESSION_LIMITS);
 }
 
-gint64 torrent_get_bandwidth_priority(JsonObject * t)
+gint64 torrent_get_bandwidth_priority(JsonObject *t)
 {
     return json_object_get_int_member(t, FIELD_BANDWIDTH_PRIORITY);
 }
 
-const gchar *torrent_get_magnetlink(JsonObject * t)
+const gchar *torrent_get_magnetlink(JsonObject *t)
 {
     return json_object_get_string_member(t, FIELD_MAGNETLINK);
 }
 
-gint64 torrent_get_upload_limit(JsonObject * t)
+gint64 torrent_get_upload_limit(JsonObject *t)
 {
     return json_object_get_int_member(t, FIELD_UPLOAD_LIMIT);
 }
 
-gint64 torrent_get_peer_limit(JsonObject * t)
+gint64 torrent_get_peer_limit(JsonObject *t)
 {
     return json_object_get_int_member(t, FIELD_PEER_LIMIT);
 }
 
-gboolean torrent_get_upload_limited(JsonObject * t)
+gboolean torrent_get_upload_limited(JsonObject *t)
 {
     return json_object_get_boolean_member(t, FIELD_UPLOAD_LIMITED);
 }
 
-gint64 torrent_get_seed_ratio_mode(JsonObject * t)
+gint64 torrent_get_seed_ratio_mode(JsonObject *t)
 {
     return json_object_get_int_member(t, FIELD_SEED_RATIO_MODE);
 }
 
-gdouble torrent_get_seed_ratio_limit(JsonObject * t)
+gdouble torrent_get_seed_ratio_limit(JsonObject *t)
 {
-    return
-        json_node_really_get_double(json_object_get_member
-                                    (t, FIELD_SEED_RATIO_LIMIT));
+    return json_node_really_get_double(json_object_get_member(t, FIELD_SEED_RATIO_LIMIT));
 }
 
-gint64 torrent_get_download_limit(JsonObject * t)
+gint64 torrent_get_download_limit(JsonObject *t)
 {
     return json_object_get_int_member(t, FIELD_DOWNLOAD_LIMIT);
 }
 
-gboolean torrent_get_download_limited(JsonObject * t)
+gboolean torrent_get_download_limited(JsonObject *t)
 {
     return json_object_get_boolean_member(t, FIELD_DOWNLOAD_LIMITED);
 }
 
-gint64 torrent_get_total_size(JsonObject * t)
+gint64 torrent_get_total_size(JsonObject *t)
 {
     return json_object_get_int_member(t, FIELD_TOTAL_SIZE);
 }
 
-gint64 torrent_get_size_when_done(JsonObject * t)
+gint64 torrent_get_size_when_done(JsonObject *t)
 {
     return json_object_get_int_member(t, FIELD_SIZEWHENDONE);
 }
 
-gint64 torrent_get_rate_down(JsonObject * t)
+gint64 torrent_get_rate_down(JsonObject *t)
 {
     return json_object_get_int_member(t, FIELD_RATEDOWNLOAD);
 }
 
-gint64 torrent_get_rate_up(JsonObject * t)
+gint64 torrent_get_rate_up(JsonObject *t)
 {
     return json_object_get_int_member(t, FIELD_RATEUPLOAD);
 }
 
-gint64 torrent_get_eta(JsonObject * t)
+gint64 torrent_get_eta(JsonObject *t)
 {
     return json_object_get_int_member(t, FIELD_ETA);
 }
 
-gint64 torrent_get_downloaded(JsonObject * t)
+gint64 torrent_get_downloaded(JsonObject *t)
 {
     return json_object_get_int_member(t, FIELD_DOWNLOADEDEVER);
 }
 
-gint64 torrent_get_uploaded(JsonObject * t)
+gint64 torrent_get_uploaded(JsonObject *t)
 {
     return json_object_get_int_member(t, FIELD_UPLOADEDEVER);
 }
 
-gint64 torrent_get_corrupted(JsonObject * t)
+gint64 torrent_get_corrupted(JsonObject *t)
 {
     return json_object_get_int_member(t, FIELD_CORRUPTEVER);
 }
 
-gint64 torrent_get_have_valid(JsonObject * t)
+gint64 torrent_get_have_valid(JsonObject *t)
 {
     return json_object_get_int_member(t, FIELD_HAVEVALID);
 }
 
-gint64 torrent_get_have_unchecked(JsonObject * t)
+gint64 torrent_get_have_unchecked(JsonObject *t)
 {
     return json_object_get_int_member(t, FIELD_HAVEUNCHECKED);
 }
 
-gint64 torrent_get_status(JsonObject * t)
+gint64 torrent_get_status(JsonObject *t)
 {
     return json_object_get_int_member(t, FIELD_STATUS);
 }
 
-gboolean torrent_get_is_finished(JsonObject * t)
+gboolean torrent_get_is_finished(JsonObject *t)
 {
     return torrent_get_left_until_done(t) <= 0;
 }
 
-gboolean torrent_get_is_private(JsonObject * t)
+gboolean torrent_get_is_private(JsonObject *t)
 {
     return json_object_get_boolean_member(t, FIELD_ISPRIVATE);
 }
 
-gdouble torrent_get_percent_done(JsonObject * t)
+gdouble torrent_get_percent_done(JsonObject *t)
 {
-    return
-        json_double_to_progress(json_object_get_member
-                                (t, FIELD_PERCENTDONE));
+    return json_double_to_progress(json_object_get_member(t, FIELD_PERCENTDONE));
 }
 
-gdouble torrent_get_recheck_progress(JsonObject * t)
+gdouble torrent_get_recheck_progress(JsonObject *t)
 {
-    return
-        json_double_to_progress(json_object_get_member
-                                (t, FIELD_RECHECK_PROGRESS));
+    return json_double_to_progress(json_object_get_member(t, FIELD_RECHECK_PROGRESS));
 }
 
-gint64 torrent_get_activity_date(JsonObject * t)
+gint64 torrent_get_activity_date(JsonObject *t)
 {
     return json_object_get_int_member(t, FIELD_ACTIVITY_DATE);
 }
 
-guint32
-torrent_get_flags(JsonObject * t, gint64 rpcv, gint64 status,
-                  gint64 fileCount, gint64 downRate, gint64 upRate)
+guint32 torrent_get_flags(JsonObject *t, gint64 rpcv, gint64 status, gint64 fileCount,
+                          gint64 downRate, gint64 upRate)
 {
     guint32 flags = 0;
 
@@ -330,17 +322,17 @@ gchar *torrent_get_status_icon(gint64 rpcv, guint flags)
         return g_strdup("dialog-question");
 }
 
-gint64 torrent_get_done_date(JsonObject * t)
+gint64 torrent_get_done_date(JsonObject *t)
 {
     return json_object_get_int_member(t, FIELD_DONE_DATE);
 }
 
-const gchar *torrent_get_errorstr(JsonObject * t)
+const gchar *torrent_get_errorstr(JsonObject *t)
 {
     return json_object_get_string_member(t, FIELD_ERROR_STRING);
 }
 
-gint64 torrent_get_error(JsonObject * t)
+gint64 torrent_get_error(JsonObject *t)
 {
     if (!json_object_has_member(t, FIELD_ERROR))
         return 0;
@@ -348,17 +340,17 @@ gint64 torrent_get_error(JsonObject * t)
         return json_object_get_int_member(t, FIELD_ERROR);
 }
 
-const gchar *torrent_get_creator(JsonObject * t)
+const gchar *torrent_get_creator(JsonObject *t)
 {
     return json_object_get_string_member(t, FIELD_CREATOR);
 }
 
-gint64 torrent_get_date_created(JsonObject * t)
+gint64 torrent_get_date_created(JsonObject *t)
 {
     return json_object_get_int_member(t, FIELD_DATE_CREATED);
 }
 
-const gchar *torrent_get_hash(JsonObject * t)
+const gchar *torrent_get_hash(JsonObject *t)
 {
     return json_object_get_string_member(t, FIELD_HASH_STRING);
 }
@@ -406,7 +398,7 @@ gchar *torrent_get_status_string(gint64 rpcv, gint64 value, guint flags)
     return g_strdup(_("Unknown"));
 }
 
-gboolean torrent_has_tracker(JsonObject * t, GRegex * rx, gchar * search)
+gboolean torrent_has_tracker(JsonObject *t, GRegex *rx, gchar *search)
 {
     GList *trackers;
     GList *li;
@@ -415,10 +407,9 @@ gboolean torrent_has_tracker(JsonObject * t, GRegex * rx, gchar * search)
     trackers = json_array_get_elements(torrent_get_tracker_stats(t));
 
     for (li = trackers; li; li = g_list_next(li)) {
-        JsonObject *tracker = json_node_get_object((JsonNode *) li->data);
+        JsonObject *tracker = json_node_get_object((JsonNode *)li->data);
         const gchar *trackerAnnounce = tracker_stats_get_announce(tracker);
-        gchar *trackerAnnounceHost =
-            trg_gregex_get_first(rx, trackerAnnounce);
+        gchar *trackerAnnounceHost = trg_gregex_get_first(rx, trackerAnnounce);
         int cmpResult = g_strcmp0(trackerAnnounceHost, search);
         g_free(trackerAnnounceHost);
         if (!cmpResult) {
@@ -432,22 +423,22 @@ gboolean torrent_has_tracker(JsonObject * t, GRegex * rx, gchar * search)
     return ret;
 }
 
-gint64 torrent_get_left_until_done(JsonObject * t)
+gint64 torrent_get_left_until_done(JsonObject *t)
 {
     return json_object_get_int_member(t, FIELD_LEFTUNTILDONE);
 }
 
-const gchar *tracker_stats_get_announce(JsonObject * t)
+const gchar *tracker_stats_get_announce(JsonObject *t)
 {
     return json_object_get_string_member(t, FIELD_ANNOUNCE);
 }
 
-const gchar *tracker_stats_get_scrape(JsonObject * t)
+const gchar *tracker_stats_get_scrape(JsonObject *t)
 {
     return json_object_get_string_member(t, FIELD_SCRAPE);
 }
 
-JsonArray *get_torrents_removed(JsonObject * response)
+JsonArray *get_torrents_removed(JsonObject *response)
 {
     if (G_UNLIKELY(json_object_has_member(response, FIELD_REMOVED)))
         return json_object_get_array_member(response, FIELD_REMOVED);
@@ -455,38 +446,38 @@ JsonArray *get_torrents_removed(JsonObject * response)
         return NULL;
 }
 
-JsonArray *get_torrents(JsonObject * response)
+JsonArray *get_torrents(JsonObject *response)
 {
     g_assert(json_object_get_array_member(response, FIELD_TORRENTS));
     return json_object_get_array_member(response, FIELD_TORRENTS);
 }
 
-JsonArray *torrent_get_files(JsonObject * args)
+JsonArray *torrent_get_files(JsonObject *args)
 {
     return json_object_get_array_member(args, FIELD_FILES);
 }
 
-gint64 torrent_get_peers_connected(JsonObject * args)
+gint64 torrent_get_peers_connected(JsonObject *args)
 {
     return json_object_get_int_member(args, FIELD_PEERS_CONNECTED);
 }
 
-gint64 torrent_get_peers_sending_to_us(JsonObject * args)
+gint64 torrent_get_peers_sending_to_us(JsonObject *args)
 {
     return json_object_get_int_member(args, FIELD_PEERS_SENDING_TO_US);
 }
 
-gint64 torrent_get_peers_getting_from_us(JsonObject * args)
+gint64 torrent_get_peers_getting_from_us(JsonObject *args)
 {
     return json_object_get_int_member(args, FIELD_PEERS_GETTING_FROM_US);
 }
 
-gint64 torrent_get_web_seeds_sending_to_us(JsonObject * args)
+gint64 torrent_get_web_seeds_sending_to_us(JsonObject *args)
 {
     return json_object_get_int_member(args, FIELD_WEB_SEEDS_SENDING_TO_US);
 }
 
-gint64 torrent_get_queue_position(JsonObject * args)
+gint64 torrent_get_queue_position(JsonObject *args)
 {
     if (json_object_has_member(args, FIELD_QUEUE_POSITION))
         return json_object_get_int_member(args, FIELD_QUEUE_POSITION);
@@ -496,65 +487,64 @@ gint64 torrent_get_queue_position(JsonObject * args)
 
 /* tracker stats */
 
-gint64 tracker_stats_get_id(JsonObject * t)
+gint64 tracker_stats_get_id(JsonObject *t)
 {
     return json_object_get_int_member(t, FIELD_ID);
 }
 
-gint64 tracker_stats_get_tier(JsonObject * t)
+gint64 tracker_stats_get_tier(JsonObject *t)
 {
     return json_object_get_int_member(t, FIELD_TIER);
 }
 
-gint64 tracker_stats_get_last_announce_peer_count(JsonObject * t)
+gint64 tracker_stats_get_last_announce_peer_count(JsonObject *t)
 {
     return json_object_get_int_member(t, FIELD_LAST_ANNOUNCE_PEER_COUNT);
 }
 
-gint64 tracker_stats_get_last_announce_time(JsonObject * t)
+gint64 tracker_stats_get_last_announce_time(JsonObject *t)
 {
     return json_object_get_int_member(t, FIELD_LAST_ANNOUNCE_TIME);
 }
 
-gint64 tracker_stats_get_last_scrape_time(JsonObject * t)
+gint64 tracker_stats_get_last_scrape_time(JsonObject *t)
 {
     return json_object_get_int_member(t, FIELD_LAST_SCRAPE_TIME);
 }
 
-gint64 tracker_stats_get_seeder_count(JsonObject * t)
+gint64 tracker_stats_get_seeder_count(JsonObject *t)
 {
     return json_object_get_int_member(t, FIELD_SEEDERCOUNT);
 }
 
-gint64 tracker_stats_get_leecher_count(JsonObject * t)
+gint64 tracker_stats_get_leecher_count(JsonObject *t)
 {
     return json_object_get_int_member(t, FIELD_LEECHERCOUNT);
 }
 
-gint64 tracker_stats_get_download_count(JsonObject * t)
+gint64 tracker_stats_get_download_count(JsonObject *t)
 {
     return json_object_get_int_member(t, FIELD_DOWNLOADCOUNT);
 }
 
-const gchar *tracker_stats_get_announce_result(JsonObject * t)
+const gchar *tracker_stats_get_announce_result(JsonObject *t)
 {
     return json_object_get_string_member(t, FIELD_LAST_ANNOUNCE_RESULT);
 }
 
-const gchar *tracker_stats_get_host(JsonObject * t)
+const gchar *tracker_stats_get_host(JsonObject *t)
 {
     return json_object_get_string_member(t, FIELD_HOST);
 }
 
-gchar *torrent_get_full_path(JsonObject * obj)
+gchar *torrent_get_full_path(JsonObject *obj)
 {
-    const gchar *location =
-        json_object_get_string_member(obj, FIELD_DOWNLOAD_DIR);
+    const gchar *location = json_object_get_string_member(obj, FIELD_DOWNLOAD_DIR);
     const gchar *name = json_object_get_string_member(obj, FIELD_NAME);
     return g_strdup_printf("%s/%s", location, name);
 }
 
-gchar *torrent_get_full_dir(JsonObject * obj)
+gchar *torrent_get_full_dir(JsonObject *obj)
 {
     gchar *containing_path, *name, *delim;
     const gchar *location;
@@ -578,87 +568,86 @@ gchar *torrent_get_full_dir(JsonObject * obj)
 
 /* peers */
 
-const gchar *peer_get_address(JsonObject * p)
+const gchar *peer_get_address(JsonObject *p)
 {
     return json_object_get_string_member(p, TPEER_ADDRESS);
 }
 
-const gchar *peer_get_flagstr(JsonObject * p)
+const gchar *peer_get_flagstr(JsonObject *p)
 {
     return json_object_get_string_member(p, TPEER_FLAGSTR);
 }
 
-const gchar *peer_get_client_name(JsonObject * p)
+const gchar *peer_get_client_name(JsonObject *p)
 {
     return json_object_get_string_member(p, TPEER_CLIENT_NAME);
 }
 
-gboolean peer_get_is_encrypted(JsonObject * p)
+gboolean peer_get_is_encrypted(JsonObject *p)
 {
     return json_object_get_boolean_member(p, TPEER_IS_ENCRYPTED);
 }
 
-gboolean peer_get_is_uploading_to(JsonObject * p)
+gboolean peer_get_is_uploading_to(JsonObject *p)
 {
     return json_object_get_boolean_member(p, TPEER_IS_UPLOADING_TO);
 }
 
-gboolean peer_get_is_downloading_from(JsonObject * p)
+gboolean peer_get_is_downloading_from(JsonObject *p)
 {
     return json_object_get_boolean_member(p, TPEER_IS_DOWNLOADING_FROM);
 }
 
-gdouble peer_get_progress(JsonObject * p)
+gdouble peer_get_progress(JsonObject *p)
 {
-    return
-        json_double_to_progress(json_object_get_member(p, TPEER_PROGRESS));
+    return json_double_to_progress(json_object_get_member(p, TPEER_PROGRESS));
 }
 
-gint64 peer_get_rate_to_client(JsonObject * p)
+gint64 peer_get_rate_to_client(JsonObject *p)
 {
     return json_object_get_int_member(p, TPEER_RATE_TO_CLIENT);
 }
 
-gint64 peer_get_rate_to_peer(JsonObject * p)
+gint64 peer_get_rate_to_peer(JsonObject *p)
 {
     return json_object_get_int_member(p, TPEER_RATE_TO_PEER);
 }
 
-gint64 peerfrom_get_pex(JsonObject * pf)
+gint64 peerfrom_get_pex(JsonObject *pf)
 {
     return json_object_get_int_member(pf, TPEERFROM_FROMPEX);
 }
 
-gint64 peerfrom_get_dht(JsonObject * pf)
+gint64 peerfrom_get_dht(JsonObject *pf)
 {
     return json_object_get_int_member(pf, TPEERFROM_FROMDHT);
 }
 
-gint64 peerfrom_get_trackers(JsonObject * pf)
+gint64 peerfrom_get_trackers(JsonObject *pf)
 {
     return json_object_get_int_member(pf, TPEERFROM_FROMTRACKERS);
 }
 
-gint64 peerfrom_get_ltep(JsonObject * pf)
+gint64 peerfrom_get_ltep(JsonObject *pf)
 {
     return json_object_get_int_member(pf, TPEERFROM_FROMLTEP);
 }
 
-gint64 peerfrom_get_resume(JsonObject * pf)
+gint64 peerfrom_get_resume(JsonObject *pf)
 {
     return json_object_get_int_member(pf, TPEERFROM_FROMRESUME);
 }
 
-gint64 peerfrom_get_incoming(JsonObject * pf)
+gint64 peerfrom_get_incoming(JsonObject *pf)
 {
     return json_object_get_int_member(pf, TPEERFROM_FROMINCOMING);
 }
 
-
-gint64 peerfrom_get_lpd(JsonObject * pf)
+gint64 peerfrom_get_lpd(JsonObject *pf)
 {
-    return json_object_has_member(pf, TPEERFROM_FROMLPD) ?
-        json_object_get_int_member(pf, TPEERFROM_FROMLPD) : -1;
+    return json_object_has_member(pf, TPEERFROM_FROMLPD)
+        ? json_object_get_int_member(pf, TPEERFROM_FROMLPD)
+        : -1;
 }
 
 /* files */
@@ -666,8 +655,7 @@ gint64 peerfrom_get_lpd(JsonObject * pf)
 gdouble file_get_progress(gint64 length, gint64 completed)
 {
     if (length > 0) {
-        gdouble progress =
-            ((gdouble) completed / (gdouble) length) * 100.0;
+        gdouble progress = ((gdouble)completed / (gdouble)length) * 100.0;
         if (progress > 100.0)
             return 100.0;
         else
@@ -677,17 +665,17 @@ gdouble file_get_progress(gint64 length, gint64 completed)
     }
 }
 
-gint64 file_get_length(JsonObject * f)
+gint64 file_get_length(JsonObject *f)
 {
     return json_object_get_int_member(f, TFILE_LENGTH);
 }
 
-gint64 file_get_bytes_completed(JsonObject * f)
+gint64 file_get_bytes_completed(JsonObject *f)
 {
     return json_object_get_int_member(f, TFILE_BYTES_COMPLETED);
 }
 
-const gchar *file_get_name(JsonObject * f)
+const gchar *file_get_name(JsonObject *f)
 {
     return json_object_get_string_member(f, TFILE_NAME);
 }

--- a/src/torrent.h
+++ b/src/torrent.h
@@ -24,129 +24,128 @@
 
 #include "trg-client.h"
 
-#define TORRENT_FLAG_ERROR             (1 << 0)
-#define TORRENT_FLAG_COMPLETE          (1 << 1)
-#define TORRENT_FLAG_INCOMPLETE        (1 << 2)
-#define TORRENT_FLAG_SEEDING           (1 << 3)
-#define TORRENT_FLAG_SEEDING_WAIT      (1 << 4)
-#define TORRENT_FLAG_CHECKING          (1 << 5)
-#define TORRENT_FLAG_WAITING_CHECK     (1 << 6)
-#define TORRENT_FLAG_CHECKING_ANY      (1 << 7)
-#define TORRENT_FLAG_DOWNLOADING       (1 << 8)
-#define TORRENT_FLAG_DOWNLOADING_WAIT  (1 << 9)
-#define TORRENT_FLAG_PAUSED            (1 << 10)
-#define TORRENT_FLAG_QUEUED            (1 << 11)
-#define TORRENT_FLAG_ACTIVE            (1 << 12)
+#define TORRENT_FLAG_ERROR                (1 << 0)
+#define TORRENT_FLAG_COMPLETE             (1 << 1)
+#define TORRENT_FLAG_INCOMPLETE           (1 << 2)
+#define TORRENT_FLAG_SEEDING              (1 << 3)
+#define TORRENT_FLAG_SEEDING_WAIT         (1 << 4)
+#define TORRENT_FLAG_CHECKING             (1 << 5)
+#define TORRENT_FLAG_WAITING_CHECK        (1 << 6)
+#define TORRENT_FLAG_CHECKING_ANY         (1 << 7)
+#define TORRENT_FLAG_DOWNLOADING          (1 << 8)
+#define TORRENT_FLAG_DOWNLOADING_WAIT     (1 << 9)
+#define TORRENT_FLAG_PAUSED               (1 << 10)
+#define TORRENT_FLAG_QUEUED               (1 << 11)
+#define TORRENT_FLAG_ACTIVE               (1 << 12)
 #define TORRENT_FLAG_DOWNLOADING_METADATA (1 << 13)
-#define FILTER_FLAG_TRACKER            (1 << 14)
-#define FILTER_FLAG_DIR                (1 << 15)
+#define FILTER_FLAG_TRACKER               (1 << 14)
+#define FILTER_FLAG_DIR                   (1 << 15)
 
-#define TORRENT_ADD_FLAG_PAUSED        (1 << 0) /* 0x01 */
-#define TORRENT_ADD_FLAG_DELETE        (1 << 1) /* 0x02 */
+#define TORRENT_ADD_FLAG_PAUSED (1 << 0) /* 0x01 */
+#define TORRENT_ADD_FLAG_DELETE (1 << 1) /* 0x02 */
 
-gint64 torrent_get_total_size(JsonObject * t);
-gint64 torrent_get_size_when_done(JsonObject * t);
-const gchar *torrent_get_name(JsonObject * t);
-gint64 torrent_get_rate_down(JsonObject * t);
-gint64 torrent_get_rate_up(JsonObject * t);
-gint64 torrent_get_eta(JsonObject * t);
-gint64 torrent_get_uploaded(JsonObject * t);
-gint64 torrent_get_corrupted(JsonObject * t);
-gint64 torrent_get_downloaded(JsonObject * t);
-const gchar *torrent_get_errorstr(JsonObject * t);
-gint64 torrent_get_error(JsonObject * t);
-const gchar *torrent_get_download_dir(JsonObject * t);
-const gchar *torrent_get_comment(JsonObject * t);
-gint64 torrent_get_have_unchecked(JsonObject * t);
-gint64 torrent_get_have_valid(JsonObject * t);
-gint64 torrent_get_status(JsonObject * t);
-const gchar *torrent_get_creator(JsonObject * t);
-gint64 torrent_get_date_created(JsonObject * t);
-const gchar *torrent_get_hash(JsonObject * t);
+gint64 torrent_get_total_size(JsonObject *t);
+gint64 torrent_get_size_when_done(JsonObject *t);
+const gchar *torrent_get_name(JsonObject *t);
+gint64 torrent_get_rate_down(JsonObject *t);
+gint64 torrent_get_rate_up(JsonObject *t);
+gint64 torrent_get_eta(JsonObject *t);
+gint64 torrent_get_uploaded(JsonObject *t);
+gint64 torrent_get_corrupted(JsonObject *t);
+gint64 torrent_get_downloaded(JsonObject *t);
+const gchar *torrent_get_errorstr(JsonObject *t);
+gint64 torrent_get_error(JsonObject *t);
+const gchar *torrent_get_download_dir(JsonObject *t);
+const gchar *torrent_get_comment(JsonObject *t);
+gint64 torrent_get_have_unchecked(JsonObject *t);
+gint64 torrent_get_have_valid(JsonObject *t);
+gint64 torrent_get_status(JsonObject *t);
+const gchar *torrent_get_creator(JsonObject *t);
+gint64 torrent_get_date_created(JsonObject *t);
+const gchar *torrent_get_hash(JsonObject *t);
 gchar *torrent_get_status_string(gint64 rpcv, gint64 value, guint flags);
 gchar *torrent_get_status_icon(gint64 rpcv, guint flags);
-guint32 torrent_get_flags(JsonObject * t, gint64 rpcv, gint64 status,
-                          gint64 fileCount, gint64 downRate,
-                          gint64 upRate);
-JsonArray *torrent_get_peers(JsonObject * t);
-JsonObject *torrent_get_peersfrom(JsonObject * t);
-JsonArray *torrent_get_tracker_stats(JsonObject * t);
-JsonArray *torrent_get_wanted(JsonObject * t);
-JsonArray *torrent_get_priorities(JsonObject * t);
-gint64 torrent_get_id(JsonObject * t);
-JsonArray *torrent_get_files(JsonObject * args);
-gint64 torrent_get_peers_getting_from_us(JsonObject * args);
-gint64 torrent_get_peers_sending_to_us(JsonObject * args);
-gint64 torrent_get_web_seeds_sending_to_us(JsonObject * args);
-gint64 torrent_get_peers_connected(JsonObject * args);
-gdouble torrent_get_percent_done(JsonObject * t);
-gdouble torrent_get_recheck_progress(JsonObject * t);
-gint64 torrent_get_left_until_done(JsonObject * t);
-gboolean torrent_get_is_finished(JsonObject * t);
-gboolean torrent_get_is_private(JsonObject * t);
-gboolean torrent_get_honors_session_limits(JsonObject * t);
-gint64 torrent_get_bandwidth_priority(JsonObject * t);
-gint64 torrent_get_upload_limit(JsonObject * t);
-const gchar *torrent_get_magnetlink(JsonObject * t);
-gint64 torrent_get_added_date(JsonObject * t);
-gint64 torrent_get_done_date(JsonObject * t);
-gboolean torrent_get_upload_limited(JsonObject * t);
-gint64 torrent_get_download_limit(JsonObject * t);
-gboolean torrent_get_download_limited(JsonObject * t);
-gdouble torrent_get_seed_ratio_limit(JsonObject * t);
-gint64 torrent_get_seed_ratio_mode(JsonObject * t);
-gint64 torrent_get_peer_limit(JsonObject * t);
-gboolean torrent_has_tracker(JsonObject * t, GRegex * rx, gchar * search);
-gint64 torrent_get_queue_position(JsonObject * args);
-gint64 torrent_get_activity_date(JsonObject * t);
-gchar *torrent_get_full_dir(JsonObject * obj);
-gchar *torrent_get_full_path(JsonObject * obj);
-gdouble torrent_get_metadata_percent_complete(JsonObject * t);
+guint32 torrent_get_flags(JsonObject *t, gint64 rpcv, gint64 status, gint64 fileCount,
+                          gint64 downRate, gint64 upRate);
+JsonArray *torrent_get_peers(JsonObject *t);
+JsonObject *torrent_get_peersfrom(JsonObject *t);
+JsonArray *torrent_get_tracker_stats(JsonObject *t);
+JsonArray *torrent_get_wanted(JsonObject *t);
+JsonArray *torrent_get_priorities(JsonObject *t);
+gint64 torrent_get_id(JsonObject *t);
+JsonArray *torrent_get_files(JsonObject *args);
+gint64 torrent_get_peers_getting_from_us(JsonObject *args);
+gint64 torrent_get_peers_sending_to_us(JsonObject *args);
+gint64 torrent_get_web_seeds_sending_to_us(JsonObject *args);
+gint64 torrent_get_peers_connected(JsonObject *args);
+gdouble torrent_get_percent_done(JsonObject *t);
+gdouble torrent_get_recheck_progress(JsonObject *t);
+gint64 torrent_get_left_until_done(JsonObject *t);
+gboolean torrent_get_is_finished(JsonObject *t);
+gboolean torrent_get_is_private(JsonObject *t);
+gboolean torrent_get_honors_session_limits(JsonObject *t);
+gint64 torrent_get_bandwidth_priority(JsonObject *t);
+gint64 torrent_get_upload_limit(JsonObject *t);
+const gchar *torrent_get_magnetlink(JsonObject *t);
+gint64 torrent_get_added_date(JsonObject *t);
+gint64 torrent_get_done_date(JsonObject *t);
+gboolean torrent_get_upload_limited(JsonObject *t);
+gint64 torrent_get_download_limit(JsonObject *t);
+gboolean torrent_get_download_limited(JsonObject *t);
+gdouble torrent_get_seed_ratio_limit(JsonObject *t);
+gint64 torrent_get_seed_ratio_mode(JsonObject *t);
+gint64 torrent_get_peer_limit(JsonObject *t);
+gboolean torrent_has_tracker(JsonObject *t, GRegex *rx, gchar *search);
+gint64 torrent_get_queue_position(JsonObject *args);
+gint64 torrent_get_activity_date(JsonObject *t);
+gchar *torrent_get_full_dir(JsonObject *obj);
+gchar *torrent_get_full_path(JsonObject *obj);
+gdouble torrent_get_metadata_percent_complete(JsonObject *t);
 
 /* outer response object */
 
-JsonArray *get_torrents(JsonObject * response);
-JsonArray *get_torrents_removed(JsonObject * response);
+JsonArray *get_torrents(JsonObject *response);
+JsonArray *get_torrents_removed(JsonObject *response);
 
 /* tracker stats */
 
-const gchar *tracker_stats_get_announce(JsonObject * t);
-const gchar *tracker_stats_get_scrape(JsonObject * t);
-gint64 tracker_stats_get_tier(JsonObject * t);
-gint64 tracker_stats_get_id(JsonObject * t);
-gint64 tracker_stats_get_last_announce_peer_count(JsonObject * t);
-gint64 tracker_stats_get_last_announce_time(JsonObject * t);
-gint64 tracker_stats_get_seeder_count(JsonObject * t);
-gint64 tracker_stats_get_leecher_count(JsonObject * t);
-gint64 tracker_stats_get_download_count(JsonObject * t);
-const gchar *tracker_stats_get_announce_result(JsonObject * t);
-const gchar *tracker_stats_get_host(JsonObject * t);
-gint64 tracker_stats_get_last_scrape_time(JsonObject * t);
+const gchar *tracker_stats_get_announce(JsonObject *t);
+const gchar *tracker_stats_get_scrape(JsonObject *t);
+gint64 tracker_stats_get_tier(JsonObject *t);
+gint64 tracker_stats_get_id(JsonObject *t);
+gint64 tracker_stats_get_last_announce_peer_count(JsonObject *t);
+gint64 tracker_stats_get_last_announce_time(JsonObject *t);
+gint64 tracker_stats_get_seeder_count(JsonObject *t);
+gint64 tracker_stats_get_leecher_count(JsonObject *t);
+gint64 tracker_stats_get_download_count(JsonObject *t);
+const gchar *tracker_stats_get_announce_result(JsonObject *t);
+const gchar *tracker_stats_get_host(JsonObject *t);
+gint64 tracker_stats_get_last_scrape_time(JsonObject *t);
 
 /* files */
 
-gint64 file_get_length(JsonObject * f);
-gint64 file_get_bytes_completed(JsonObject * f);
-const gchar *file_get_name(JsonObject * f);
+gint64 file_get_length(JsonObject *f);
+gint64 file_get_bytes_completed(JsonObject *f);
+const gchar *file_get_name(JsonObject *f);
 gdouble file_get_progress(gint64 length, gint64 completed);
 
 /* peers */
 
-const gchar *peer_get_address(JsonObject * p);
-const gchar *peer_get_client_name(JsonObject * p);
-gboolean peer_get_is_encrypted(JsonObject * p);
-gdouble peer_get_progress(JsonObject * p);
-const gchar *peer_get_flagstr(JsonObject * p);
-gint64 peer_get_rate_to_client(JsonObject * p);
-gint64 peer_get_rate_to_peer(JsonObject * p);
-gboolean peer_get_is_uploading_to(JsonObject * p);
-gboolean peer_get_is_downloading_from(JsonObject * p);
+const gchar *peer_get_address(JsonObject *p);
+const gchar *peer_get_client_name(JsonObject *p);
+gboolean peer_get_is_encrypted(JsonObject *p);
+gdouble peer_get_progress(JsonObject *p);
+const gchar *peer_get_flagstr(JsonObject *p);
+gint64 peer_get_rate_to_client(JsonObject *p);
+gint64 peer_get_rate_to_peer(JsonObject *p);
+gboolean peer_get_is_uploading_to(JsonObject *p);
+gboolean peer_get_is_downloading_from(JsonObject *p);
 
-gint64 peerfrom_get_pex(JsonObject * pf);
-gint64 peerfrom_get_dht(JsonObject * pf);
-gint64 peerfrom_get_trackers(JsonObject * pf);
-gint64 peerfrom_get_ltep(JsonObject * pf);
-gint64 peerfrom_get_resume(JsonObject * pf);
-gint64 peerfrom_get_incoming(JsonObject * pf);
-gint64 peerfrom_get_lpd(JsonObject * pf);
-#endif                          /* TORRENT_H_ */
+gint64 peerfrom_get_pex(JsonObject *pf);
+gint64 peerfrom_get_dht(JsonObject *pf);
+gint64 peerfrom_get_trackers(JsonObject *pf);
+gint64 peerfrom_get_ltep(JsonObject *pf);
+gint64 peerfrom_get_resume(JsonObject *pf);
+gint64 peerfrom_get_incoming(JsonObject *pf);
+gint64 peerfrom_get_lpd(JsonObject *pf);
+#endif /* TORRENT_H_ */

--- a/src/trg-about-window.c
+++ b/src/trg-about-window.c
@@ -24,7 +24,7 @@
 
 #include "trg-about-window.h"
 
-GtkWidget *trg_about_window_new(GtkWindow * parent)
+GtkWidget *trg_about_window_new(GtkWindow *parent)
 {
     GtkWidget *dialog;
     GdkPixbuf *logo;
@@ -34,32 +34,28 @@ GtkWidget *trg_about_window_new(GtkWindow * parent)
     gtk_window_set_transient_for(GTK_WINDOW(dialog), parent);
     gtk_window_set_destroy_with_parent(GTK_WINDOW(dialog), TRUE);
 
-    logo =
-        gtk_icon_theme_load_icon(gtk_icon_theme_get_default(),
-                                 PACKAGE_NAME, 48,
-                                 GTK_ICON_LOOKUP_USE_BUILTIN, NULL);
+    logo = gtk_icon_theme_load_icon(gtk_icon_theme_get_default(), PACKAGE_NAME, 48,
+                                    GTK_ICON_LOOKUP_USE_BUILTIN, NULL);
 
     if (logo != NULL) {
         gtk_about_dialog_set_logo(GTK_ABOUT_DIALOG(dialog), logo);
         g_object_unref(logo);
     }
 
-	gtk_about_dialog_set_license_type (GTK_ABOUT_DIALOG(dialog), GTK_LICENSE_GPL_2_0);
+    gtk_about_dialog_set_license_type(GTK_ABOUT_DIALOG(dialog), GTK_LICENSE_GPL_2_0);
 
-    gtk_about_dialog_set_program_name(GTK_ABOUT_DIALOG(dialog),
-                                      PACKAGE_NAME);
-    gtk_about_dialog_set_version(GTK_ABOUT_DIALOG(dialog),
-                                 PACKAGE_VERSION);
-    gtk_about_dialog_set_copyright(GTK_ABOUT_DIALOG(dialog),
-                                   "(C) 2011-2013 Alan Fitton");
+    gtk_about_dialog_set_program_name(GTK_ABOUT_DIALOG(dialog), PACKAGE_NAME);
+    gtk_about_dialog_set_version(GTK_ABOUT_DIALOG(dialog), PACKAGE_VERSION);
+    gtk_about_dialog_set_copyright(GTK_ABOUT_DIALOG(dialog), "(C) 2011-2013 Alan Fitton");
     gtk_about_dialog_set_comments(GTK_ABOUT_DIALOG(dialog),
-                                  _
-                                  ("A remote client to transmission-daemon."));
+                                  _("A remote client to transmission-daemon."));
 
-    gtk_about_dialog_set_website(GTK_ABOUT_DIALOG(dialog),
-                                 "https://github.com/transmission-remote-gtk/transmission-remote-gtk");
-    gtk_about_dialog_set_website_label(GTK_ABOUT_DIALOG(dialog),
-                                       "https://github.com/transmission-remote-gtk/transmission-remote-gtk");
+    gtk_about_dialog_set_website(
+        GTK_ABOUT_DIALOG(dialog),
+        "https://github.com/transmission-remote-gtk/transmission-remote-gtk");
+    gtk_about_dialog_set_website_label(
+        GTK_ABOUT_DIALOG(dialog),
+        "https://github.com/transmission-remote-gtk/transmission-remote-gtk");
 
     gtk_about_dialog_set_authors(GTK_ABOUT_DIALOG(dialog), trgAuthors);
     /*gtk_about_dialog_set_documenters(GTK_ABOUT_DIALOG(dialog), documenters); */
@@ -74,7 +70,6 @@ GtkWidget *trg_about_window_new(GtkWindow * parent)
                                             "* aspidzent (Spanish)\n"
                                             "* Åke Svensson (Swedish)\n"
                                             "* ROR191 (Ukranian)\n");
-
 
     return dialog;
 }

--- a/src/trg-about-window.h
+++ b/src/trg-about-window.h
@@ -22,6 +22,6 @@
 
 #include <gtk/gtk.h>
 
-GtkWidget *trg_about_window_new(GtkWindow * parent);
+GtkWidget *trg_about_window_new(GtkWindow *parent);
 
-#endif                          /* ABOUT_WINDOW_H_ */
+#endif /* ABOUT_WINDOW_H_ */

--- a/src/trg-cell-renderer-counter.c
+++ b/src/trg-cell-renderer-counter.c
@@ -23,36 +23,30 @@
 
 #include "trg-cell-renderer-counter.h"
 
-enum
-{
-	PROP_0,
-	PROP_STATE_LABEL,
-	PROP_STATE_COUNT,
-	N_PROPS,
+enum {
+    PROP_0,
+    PROP_STATE_LABEL,
+    PROP_STATE_COUNT,
+    N_PROPS,
 };
 
-struct _TrgCellRendererCounter
-{
-	GtkCellRendererText parent;
+struct _TrgCellRendererCounter {
+    GtkCellRendererText parent;
 };
 
-typedef struct
-{
-	gint count;
+typedef struct {
+    gint count;
     gchar *originalLabel;
 } TrgCellRendererCounterPrivate;
 
 G_DEFINE_TYPE_WITH_PRIVATE(TrgCellRendererCounter, trg_cell_renderer_counter,
-              GTK_TYPE_CELL_RENDERER_TEXT)
+                           GTK_TYPE_CELL_RENDERER_TEXT)
 
-
-static void trg_cell_renderer_counter_get_property(GObject * object,
-                                                   guint property_id,
-                                                   GValue * value,
-                                                   GParamSpec * pspec)
+static void trg_cell_renderer_counter_get_property(GObject *object, guint property_id,
+                                                   GValue *value, GParamSpec *pspec)
 {
-    TrgCellRendererCounterPrivate *priv =
-        trg_cell_renderer_counter_get_instance_private(TRG_CELL_RENDERER_COUNTER(object));
+    TrgCellRendererCounterPrivate *priv
+        = trg_cell_renderer_counter_get_instance_private(TRG_CELL_RENDERER_COUNTER(object));
     switch (property_id) {
     case PROP_STATE_COUNT:
         g_value_set_int(value, priv->count);
@@ -63,15 +57,12 @@ static void trg_cell_renderer_counter_get_property(GObject * object,
     }
 }
 
-static void trg_cell_renderer_counter_refresh(TrgCellRendererCounter * cr)
+static void trg_cell_renderer_counter_refresh(TrgCellRendererCounter *cr)
 {
-    TrgCellRendererCounterPrivate *priv =
-        trg_cell_renderer_counter_get_instance_private(cr);
+    TrgCellRendererCounterPrivate *priv = trg_cell_renderer_counter_get_instance_private(cr);
     if (priv->originalLabel && priv->count > 0) {
-        gchar *counterLabel =
-            g_markup_printf_escaped("%s <span size=\"small\">(%d)</span>",
-                                    priv->originalLabel,
-                                    priv->count);
+        gchar *counterLabel = g_markup_printf_escaped("%s <span size=\"small\">(%d)</span>",
+                                                      priv->originalLabel, priv->count);
         g_object_set(cr, "markup", counterLabel, NULL);
         g_free(counterLabel);
     } else {
@@ -79,42 +70,36 @@ static void trg_cell_renderer_counter_refresh(TrgCellRendererCounter * cr)
     }
 }
 
-static void
-trg_cell_renderer_counter_set_property(GObject * object,
-                                       guint property_id,
-                                       const GValue * value,
-                                       GParamSpec * pspec)
+static void trg_cell_renderer_counter_set_property(GObject *object, guint property_id,
+                                                   const GValue *value, GParamSpec *pspec)
 {
-    TrgCellRendererCounterPrivate *priv =
-        trg_cell_renderer_counter_get_instance_private(TRG_CELL_RENDERER_COUNTER(object));
+    TrgCellRendererCounterPrivate *priv
+        = trg_cell_renderer_counter_get_instance_private(TRG_CELL_RENDERER_COUNTER(object));
 
     if (property_id == PROP_STATE_LABEL) {
         g_free(priv->originalLabel);
         priv->originalLabel = g_strdup(g_value_get_string(value));
-        trg_cell_renderer_counter_refresh(TRG_CELL_RENDERER_COUNTER
-                                          (object));
+        trg_cell_renderer_counter_refresh(TRG_CELL_RENDERER_COUNTER(object));
     } else if (property_id == PROP_STATE_COUNT) {
         gint newCount = g_value_get_int(value);
         if (priv->count != newCount) {
             priv->count = newCount;
-            trg_cell_renderer_counter_refresh(TRG_CELL_RENDERER_COUNTER
-                                              (object));
+            trg_cell_renderer_counter_refresh(TRG_CELL_RENDERER_COUNTER(object));
         }
     } else {
         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, property_id, pspec);
     }
 }
 
-static void trg_cell_renderer_counter_dispose(GObject * object)
+static void trg_cell_renderer_counter_dispose(GObject *object)
 {
-    TrgCellRendererCounterPrivate *priv =
-        trg_cell_renderer_counter_get_instance_private(TRG_CELL_RENDERER_COUNTER(object));
+    TrgCellRendererCounterPrivate *priv
+        = trg_cell_renderer_counter_get_instance_private(TRG_CELL_RENDERER_COUNTER(object));
     g_free(priv->originalLabel);
     G_OBJECT_CLASS(trg_cell_renderer_counter_parent_class)->dispose(object);
 }
 
-static void
-trg_cell_renderer_counter_class_init(TrgCellRendererCounterClass * klass)
+static void trg_cell_renderer_counter_class_init(TrgCellRendererCounterClass *klass)
 {
     GObjectClass *object_class = G_OBJECT_CLASS(klass);
 
@@ -122,32 +107,22 @@ trg_cell_renderer_counter_class_init(TrgCellRendererCounterClass * klass)
     object_class->set_property = trg_cell_renderer_counter_set_property;
     object_class->dispose = trg_cell_renderer_counter_dispose;
 
-    g_object_class_install_property(object_class,
-                                    PROP_STATE_COUNT,
-                                    g_param_spec_int("state-count",
-                                                     "State Count",
-                                                     "State Count",
-                                                     -1,
-                                                     INT_MAX,
-                                                     -1,
-                                                     G_PARAM_READWRITE |
-                                                     G_PARAM_STATIC_STRINGS));
+    g_object_class_install_property(object_class, PROP_STATE_COUNT,
+                                    g_param_spec_int("state-count", "State Count", "State Count",
+                                                     -1, INT_MAX, -1,
+                                                     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
-    g_object_class_install_property(object_class,
-                                    PROP_STATE_LABEL,
-                                    g_param_spec_string("state-label",
-                                                        "State Label",
-                                                        "State Label",
-                                                        NULL,
-                                                        G_PARAM_READWRITE |
-                                                        G_PARAM_STATIC_STRINGS));
+    g_object_class_install_property(
+        object_class, PROP_STATE_LABEL,
+        g_param_spec_string("state-label", "State Label", "State Label", NULL,
+                            G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 }
 
-static void trg_cell_renderer_counter_init(TrgCellRendererCounter * self)
+static void trg_cell_renderer_counter_init(TrgCellRendererCounter *self)
 {
 }
 
 GtkCellRenderer *trg_cell_renderer_counter_new(void)
 {
-    return g_object_new (TRG_TYPE_CELL_RENDERER_COUNTER, NULL);
+    return g_object_new(TRG_TYPE_CELL_RENDERER_COUNTER, NULL);
 }

--- a/src/trg-cell-renderer-counter.h
+++ b/src/trg-cell-renderer-counter.h
@@ -24,9 +24,9 @@
 G_BEGIN_DECLS
 
 #define TRG_TYPE_CELL_RENDERER_COUNTER (trg_cell_renderer_counter_get_type())
-G_DECLARE_FINAL_TYPE (TrgCellRendererCounter, trg_cell_renderer_counter, TRG, CELL_RENDERER_COUNTER, GtkCellRendererText)
+G_DECLARE_FINAL_TYPE(TrgCellRendererCounter, trg_cell_renderer_counter, TRG, CELL_RENDERER_COUNTER,
+                     GtkCellRendererText)
 
 GtkCellRenderer *trg_cell_renderer_counter_new(void);
 
 G_END_DECLS
-

--- a/src/trg-cell-renderer-epoch.c
+++ b/src/trg-cell-renderer-epoch.c
@@ -19,9 +19,9 @@
 
 #include "config.h"
 
+#include <gtk/gtk.h>
 #include <stdint.h>
 #include <time.h>
-#include <gtk/gtk.h>
 
 #include "trg-cell-renderer-epoch.h"
 #include "util.h"
@@ -31,23 +31,19 @@ enum {
     PROP_EPOCH_VALUE
 };
 
-G_DEFINE_TYPE(TrgCellRendererEpoch, trg_cell_renderer_epoch,
-              GTK_TYPE_CELL_RENDERER_TEXT)
-#define TRG_CELL_RENDERER_EPOCH_GET_PRIVATE(o) \
-  (G_TYPE_INSTANCE_GET_PRIVATE ((o), TRG_TYPE_CELL_RENDERER_EPOCH, TrgCellRendererEpochPrivate))
+G_DEFINE_TYPE(TrgCellRendererEpoch, trg_cell_renderer_epoch, GTK_TYPE_CELL_RENDERER_TEXT)
+#define TRG_CELL_RENDERER_EPOCH_GET_PRIVATE(o)                                                     \
+    (G_TYPE_INSTANCE_GET_PRIVATE((o), TRG_TYPE_CELL_RENDERER_EPOCH, TrgCellRendererEpochPrivate))
 typedef struct _TrgCellRendererEpochPrivate TrgCellRendererEpochPrivate;
 
 struct _TrgCellRendererEpochPrivate {
     gdouble epoch_value;
 };
 
-static void
-trg_cell_renderer_epoch_get_property(GObject * object,
-                                     guint property_id,
-                                     GValue * value, GParamSpec * pspec)
+static void trg_cell_renderer_epoch_get_property(GObject *object, guint property_id, GValue *value,
+                                                 GParamSpec *pspec)
 {
-    TrgCellRendererEpochPrivate *priv =
-        TRG_CELL_RENDERER_EPOCH_GET_PRIVATE(object);
+    TrgCellRendererEpochPrivate *priv = TRG_CELL_RENDERER_EPOCH_GET_PRIVATE(object);
     switch (property_id) {
     case PROP_EPOCH_VALUE:
         g_value_set_int64(value, priv->epoch_value);
@@ -58,13 +54,10 @@ trg_cell_renderer_epoch_get_property(GObject * object,
     }
 }
 
-static void
-trg_cell_renderer_epoch_set_property(GObject * object, guint property_id,
-                                     const GValue * value,
-                                     GParamSpec * pspec)
+static void trg_cell_renderer_epoch_set_property(GObject *object, guint property_id,
+                                                 const GValue *value, GParamSpec *pspec)
 {
-    TrgCellRendererEpochPrivate *priv =
-        TRG_CELL_RENDERER_EPOCH_GET_PRIVATE(object);
+    TrgCellRendererEpochPrivate *priv = TRG_CELL_RENDERER_EPOCH_GET_PRIVATE(object);
 
     if (property_id == PROP_EPOCH_VALUE) {
         gint64 new_value = g_value_get_int64(value);
@@ -83,41 +76,27 @@ trg_cell_renderer_epoch_set_property(GObject * object, guint property_id,
     }
 }
 
-static void
-trg_cell_renderer_epoch_class_init(TrgCellRendererEpochClass * klass)
+static void trg_cell_renderer_epoch_class_init(TrgCellRendererEpochClass *klass)
 {
     GObjectClass *object_class = G_OBJECT_CLASS(klass);
 
     object_class->get_property = trg_cell_renderer_epoch_get_property;
     object_class->set_property = trg_cell_renderer_epoch_set_property;
 
-    g_object_class_install_property(object_class,
-                                    PROP_EPOCH_VALUE,
-                                    g_param_spec_int64("epoch-value",
-                                                       "Epoch Value",
-                                                       "Epoch Value",
-                                                       G_MININT64,
-                                                       G_MAXINT64,
-                                                       0,
-                                                       G_PARAM_READWRITE
-                                                       |
-                                                       G_PARAM_STATIC_NAME
-                                                       |
-                                                       G_PARAM_STATIC_NICK
-                                                       |
-                                                       G_PARAM_STATIC_BLURB));
+    g_object_class_install_property(
+        object_class, PROP_EPOCH_VALUE,
+        g_param_spec_int64("epoch-value", "Epoch Value", "Epoch Value", G_MININT64, G_MAXINT64, 0,
+                           G_PARAM_READWRITE | G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK
+                               | G_PARAM_STATIC_BLURB));
 
     g_type_class_add_private(klass, sizeof(TrgCellRendererEpochPrivate));
 }
 
-static void
-trg_cell_renderer_epoch_init(TrgCellRendererEpoch * self G_GNUC_UNUSED)
+static void trg_cell_renderer_epoch_init(TrgCellRendererEpoch *self G_GNUC_UNUSED)
 {
 }
 
 GtkCellRenderer *trg_cell_renderer_epoch_new(void)
 {
-    return
-        GTK_CELL_RENDERER(g_object_new
-                          (TRG_TYPE_CELL_RENDERER_EPOCH, NULL));
+    return GTK_CELL_RENDERER(g_object_new(TRG_TYPE_CELL_RENDERER_EPOCH, NULL));
 }

--- a/src/trg-cell-renderer-epoch.h
+++ b/src/trg-cell-renderer-epoch.h
@@ -25,17 +25,17 @@
 
 G_BEGIN_DECLS
 #define TRG_TYPE_CELL_RENDERER_EPOCH trg_cell_renderer_epoch_get_type()
-#define TRG_CELL_RENDERER_EPOCH(obj) \
-  (G_TYPE_CHECK_INSTANCE_CAST ((obj), TRG_TYPE_CELL_RENDERER_EPOCH, TrgCellRendererEpoch))
-#define TRG_CELL_RENDERER_EPOCH_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_CAST ((klass), TRG_TYPE_CELL_RENDERER_EPOCH, TrgCellRendererEpochClass))
-#define TRG_IS_CELL_RENDERER_EPOCH(obj) \
-  (G_TYPE_CHECK_INSTANCE_TYPE ((obj), TRG_TYPE_CELL_RENDERER_EPOCH))
-#define TRG_IS_CELL_RENDERER_EPOCH_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_TYPE ((klass), TRG_TYPE_CELL_RENDERER_EPOCH))
-#define TRG_CELL_RENDERER_EPOCH_GET_CLASS(obj) \
-  (G_TYPE_INSTANCE_GET_CLASS ((obj), TRG_TYPE_CELL_RENDERER_EPOCH, TrgCellRendererEpochClass))
-    typedef struct {
+#define TRG_CELL_RENDERER_EPOCH(obj)                                                               \
+    (G_TYPE_CHECK_INSTANCE_CAST((obj), TRG_TYPE_CELL_RENDERER_EPOCH, TrgCellRendererEpoch))
+#define TRG_CELL_RENDERER_EPOCH_CLASS(klass)                                                       \
+    (G_TYPE_CHECK_CLASS_CAST((klass), TRG_TYPE_CELL_RENDERER_EPOCH, TrgCellRendererEpochClass))
+#define TRG_IS_CELL_RENDERER_EPOCH(obj)                                                            \
+    (G_TYPE_CHECK_INSTANCE_TYPE((obj), TRG_TYPE_CELL_RENDERER_EPOCH))
+#define TRG_IS_CELL_RENDERER_EPOCH_CLASS(klass)                                                    \
+    (G_TYPE_CHECK_CLASS_TYPE((klass), TRG_TYPE_CELL_RENDERER_EPOCH))
+#define TRG_CELL_RENDERER_EPOCH_GET_CLASS(obj)                                                     \
+    (G_TYPE_INSTANCE_GET_CLASS((obj), TRG_TYPE_CELL_RENDERER_EPOCH, TrgCellRendererEpochClass))
+typedef struct {
     GtkCellRendererText parent;
 } TrgCellRendererEpoch;
 
@@ -48,4 +48,4 @@ GType trg_cell_renderer_epoch_get_type(void);
 GtkCellRenderer *trg_cell_renderer_epoch_new(void);
 
 G_END_DECLS
-#endif                          /* TRG_CELL_RENDERER_EPOCH_H_ */
+#endif /* TRG_CELL_RENDERER_EPOCH_H_ */

--- a/src/trg-cell-renderer-eta.c
+++ b/src/trg-cell-renderer-eta.c
@@ -19,8 +19,8 @@
 
 #include "config.h"
 
-#include <stdint.h>
 #include <gtk/gtk.h>
+#include <stdint.h>
 
 #include "trg-cell-renderer-eta.h"
 #include "util.h"
@@ -30,23 +30,19 @@ enum {
     PROP_ETA_VALUE
 };
 
-G_DEFINE_TYPE(TrgCellRendererEta, trg_cell_renderer_eta,
-              GTK_TYPE_CELL_RENDERER_TEXT)
-#define TRG_CELL_RENDERER_ETA_GET_PRIVATE(o) \
-  (G_TYPE_INSTANCE_GET_PRIVATE ((o), TRG_TYPE_CELL_RENDERER_ETA, TrgCellRendererEtaPrivate))
+G_DEFINE_TYPE(TrgCellRendererEta, trg_cell_renderer_eta, GTK_TYPE_CELL_RENDERER_TEXT)
+#define TRG_CELL_RENDERER_ETA_GET_PRIVATE(o)                                                       \
+    (G_TYPE_INSTANCE_GET_PRIVATE((o), TRG_TYPE_CELL_RENDERER_ETA, TrgCellRendererEtaPrivate))
 typedef struct _TrgCellRendererEtaPrivate TrgCellRendererEtaPrivate;
 
 struct _TrgCellRendererEtaPrivate {
     gdouble eta_value;
 };
 
-static void
-trg_cell_renderer_eta_get_property(GObject * object,
-                                   guint property_id, GValue * value,
-                                   GParamSpec * pspec)
+static void trg_cell_renderer_eta_get_property(GObject *object, guint property_id, GValue *value,
+                                               GParamSpec *pspec)
 {
-    TrgCellRendererEtaPrivate *priv =
-        TRG_CELL_RENDERER_ETA_GET_PRIVATE(object);
+    TrgCellRendererEtaPrivate *priv = TRG_CELL_RENDERER_ETA_GET_PRIVATE(object);
     switch (property_id) {
     case PROP_ETA_VALUE:
         g_value_set_int64(value, priv->eta_value);
@@ -57,20 +53,16 @@ trg_cell_renderer_eta_get_property(GObject * object,
     }
 }
 
-static void
-trg_cell_renderer_eta_set_property(GObject * object, guint property_id,
-                                   const GValue * value,
-                                   GParamSpec * pspec)
+static void trg_cell_renderer_eta_set_property(GObject *object, guint property_id,
+                                               const GValue *value, GParamSpec *pspec)
 {
-    TrgCellRendererEtaPrivate *priv =
-        TRG_CELL_RENDERER_ETA_GET_PRIVATE(object);
+    TrgCellRendererEtaPrivate *priv = TRG_CELL_RENDERER_ETA_GET_PRIVATE(object);
 
     if (property_id == PROP_ETA_VALUE) {
         priv->eta_value = g_value_get_int64(value);
         if (priv->eta_value > 0) {
             char etaString[32];
-            tr_strltime_short(etaString, priv->eta_value,
-                              sizeof(etaString));
+            tr_strltime_short(etaString, priv->eta_value, sizeof(etaString));
             g_object_set(object, "text", etaString, NULL);
         } else if (priv->eta_value == -2) {
             g_object_set(object, "text", "∞", NULL);
@@ -82,40 +74,27 @@ trg_cell_renderer_eta_set_property(GObject * object, guint property_id,
     }
 }
 
-static void
-trg_cell_renderer_eta_class_init(TrgCellRendererEtaClass * klass)
+static void trg_cell_renderer_eta_class_init(TrgCellRendererEtaClass *klass)
 {
     GObjectClass *object_class = G_OBJECT_CLASS(klass);
 
     object_class->get_property = trg_cell_renderer_eta_get_property;
     object_class->set_property = trg_cell_renderer_eta_set_property;
 
-    g_object_class_install_property(object_class,
-                                    PROP_ETA_VALUE,
-                                    g_param_spec_int64("eta-value",
-                                                       "Eta Value",
-                                                       "Eta Value",
-                                                       G_MININT64,
-                                                       G_MAXINT64,
-                                                       0,
-                                                       G_PARAM_READWRITE
-                                                       |
-                                                       G_PARAM_STATIC_NAME
-                                                       |
-                                                       G_PARAM_STATIC_NICK
-                                                       |
-                                                       G_PARAM_STATIC_BLURB));
+    g_object_class_install_property(
+        object_class, PROP_ETA_VALUE,
+        g_param_spec_int64("eta-value", "Eta Value", "Eta Value", G_MININT64, G_MAXINT64, 0,
+                           G_PARAM_READWRITE | G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK
+                               | G_PARAM_STATIC_BLURB));
 
     g_type_class_add_private(klass, sizeof(TrgCellRendererEtaPrivate));
 }
 
-static void
-trg_cell_renderer_eta_init(TrgCellRendererEta * self G_GNUC_UNUSED)
+static void trg_cell_renderer_eta_init(TrgCellRendererEta *self G_GNUC_UNUSED)
 {
 }
 
 GtkCellRenderer *trg_cell_renderer_eta_new(void)
 {
-    return
-        GTK_CELL_RENDERER(g_object_new(TRG_TYPE_CELL_RENDERER_ETA, NULL));
+    return GTK_CELL_RENDERER(g_object_new(TRG_TYPE_CELL_RENDERER_ETA, NULL));
 }

--- a/src/trg-cell-renderer-eta.h
+++ b/src/trg-cell-renderer-eta.h
@@ -25,17 +25,17 @@
 
 G_BEGIN_DECLS
 #define TRG_TYPE_CELL_RENDERER_ETA trg_cell_renderer_eta_get_type()
-#define TRG_CELL_RENDERER_ETA(obj) \
-  (G_TYPE_CHECK_INSTANCE_CAST ((obj), TRG_TYPE_CELL_RENDERER_ETA, TrgCellRendererEta))
-#define TRG_CELL_RENDERER_ETA_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_CAST ((klass), TRG_TYPE_CELL_RENDERER_ETA, TrgCellRendererEtaClass))
-#define TRG_IS_CELL_RENDERER_ETA(obj) \
-  (G_TYPE_CHECK_INSTANCE_TYPE ((obj), TRG_TYPE_CELL_RENDERER_ETA))
-#define TRG_IS_CELL_RENDERER_ETA_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_TYPE ((klass), TRG_TYPE_CELL_RENDERER_ETA))
-#define TRG_CELL_RENDERER_ETA_GET_CLASS(obj) \
-  (G_TYPE_INSTANCE_GET_CLASS ((obj), TRG_TYPE_CELL_RENDERER_ETA, TrgCellRendererEtaClass))
-    typedef struct {
+#define TRG_CELL_RENDERER_ETA(obj)                                                                 \
+    (G_TYPE_CHECK_INSTANCE_CAST((obj), TRG_TYPE_CELL_RENDERER_ETA, TrgCellRendererEta))
+#define TRG_CELL_RENDERER_ETA_CLASS(klass)                                                         \
+    (G_TYPE_CHECK_CLASS_CAST((klass), TRG_TYPE_CELL_RENDERER_ETA, TrgCellRendererEtaClass))
+#define TRG_IS_CELL_RENDERER_ETA(obj)                                                              \
+    (G_TYPE_CHECK_INSTANCE_TYPE((obj), TRG_TYPE_CELL_RENDERER_ETA))
+#define TRG_IS_CELL_RENDERER_ETA_CLASS(klass)                                                      \
+    (G_TYPE_CHECK_CLASS_TYPE((klass), TRG_TYPE_CELL_RENDERER_ETA))
+#define TRG_CELL_RENDERER_ETA_GET_CLASS(obj)                                                       \
+    (G_TYPE_INSTANCE_GET_CLASS((obj), TRG_TYPE_CELL_RENDERER_ETA, TrgCellRendererEtaClass))
+typedef struct {
     GtkCellRendererText parent;
 } TrgCellRendererEta;
 
@@ -48,4 +48,4 @@ GType trg_cell_renderer_eta_get_type(void);
 GtkCellRenderer *trg_cell_renderer_eta_new(void);
 
 G_END_DECLS
-#endif                          /* TRG_CELL_RENDERER_ETA_H_ */
+#endif /* TRG_CELL_RENDERER_ETA_H_ */

--- a/src/trg-cell-renderer-file-icon.c
+++ b/src/trg-cell-renderer-file-icon.c
@@ -19,8 +19,8 @@
 
 #include "config.h"
 
-#include <stdint.h>
 #include <gtk/gtk.h>
+#include <stdint.h>
 
 #include "trg-cell-renderer-file-icon.h"
 #include "util.h"
@@ -31,26 +31,21 @@ enum {
     PROP_FILE_NAME
 };
 
-G_DEFINE_TYPE(TrgCellRendererFileIcon, trg_cell_renderer_file_icon,
-              GTK_TYPE_CELL_RENDERER_PIXBUF)
-#define TRG_CELL_RENDERER_FILE_ICON_GET_PRIVATE(o) \
-  (G_TYPE_INSTANCE_GET_PRIVATE ((o), TRG_TYPE_CELL_RENDERER_FILE_ICON, TrgCellRendererFileIconPrivate))
-typedef struct _TrgCellRendererFileIconPrivate
- TrgCellRendererFileIconPrivate;
+G_DEFINE_TYPE(TrgCellRendererFileIcon, trg_cell_renderer_file_icon, GTK_TYPE_CELL_RENDERER_PIXBUF)
+#define TRG_CELL_RENDERER_FILE_ICON_GET_PRIVATE(o)                                                 \
+    (G_TYPE_INSTANCE_GET_PRIVATE((o), TRG_TYPE_CELL_RENDERER_FILE_ICON,                            \
+                                 TrgCellRendererFileIconPrivate))
+typedef struct _TrgCellRendererFileIconPrivate TrgCellRendererFileIconPrivate;
 
 struct _TrgCellRendererFileIconPrivate {
     gint64 file_id;
     gchar *text;
 };
 
-static void
-trg_cell_renderer_file_icon_get_property(GObject * object,
-                                         guint property_id,
-                                         GValue * value,
-                                         GParamSpec * pspec)
+static void trg_cell_renderer_file_icon_get_property(GObject *object, guint property_id,
+                                                     GValue *value, GParamSpec *pspec)
 {
-    TrgCellRendererFileIconPrivate *priv =
-        TRG_CELL_RENDERER_FILE_ICON_GET_PRIVATE(object);
+    TrgCellRendererFileIconPrivate *priv = TRG_CELL_RENDERER_FILE_ICON_GET_PRIVATE(object);
     switch (property_id) {
     case PROP_FILE_ID:
         g_value_set_int64(value, priv->file_id);
@@ -61,11 +56,9 @@ trg_cell_renderer_file_icon_get_property(GObject * object,
     }
 }
 
-static void
-trg_cell_renderer_file_icon_refresh(TrgCellRendererFileIcon * fi)
+static void trg_cell_renderer_file_icon_refresh(TrgCellRendererFileIcon *fi)
 {
-    TrgCellRendererFileIconPrivate *priv =
-        TRG_CELL_RENDERER_FILE_ICON_GET_PRIVATE(fi);
+    TrgCellRendererFileIconPrivate *priv = TRG_CELL_RENDERER_FILE_ICON_GET_PRIVATE(fi);
 
     if (priv->file_id == -2) {
         return;
@@ -74,8 +67,7 @@ trg_cell_renderer_file_icon_refresh(TrgCellRendererFileIcon * fi)
     } else if (priv->text) {
 #ifndef G_OS_WIN32
         gboolean uncertain;
-        gchar *mimetype =
-            g_content_type_guess(priv->text, NULL, 0, &uncertain);
+        gchar *mimetype = g_content_type_guess(priv->text, NULL, 0, &uncertain);
         GIcon *icon = NULL;
 
         if (!uncertain && mimetype)
@@ -95,42 +87,32 @@ trg_cell_renderer_file_icon_refresh(TrgCellRendererFileIcon * fi)
     }
 }
 
-static void
-trg_cell_renderer_file_icon_set_property(GObject * object,
-                                         guint property_id,
-                                         const GValue * value,
-                                         GParamSpec * pspec)
+static void trg_cell_renderer_file_icon_set_property(GObject *object, guint property_id,
+                                                     const GValue *value, GParamSpec *pspec)
 {
-    TrgCellRendererFileIconPrivate *priv =
-        TRG_CELL_RENDERER_FILE_ICON_GET_PRIVATE(object);
+    TrgCellRendererFileIconPrivate *priv = TRG_CELL_RENDERER_FILE_ICON_GET_PRIVATE(object);
     if (property_id == PROP_FILE_ID) {
         priv->file_id = g_value_get_int64(value);
-        trg_cell_renderer_file_icon_refresh(TRG_CELL_RENDERER_FILE_ICON
-                                            (object));
+        trg_cell_renderer_file_icon_refresh(TRG_CELL_RENDERER_FILE_ICON(object));
     } else if (property_id == PROP_FILE_NAME) {
         if (priv->file_id != -1) {
             g_free(priv->text);
             priv->text = g_strdup(g_value_get_string(value));
-            trg_cell_renderer_file_icon_refresh(TRG_CELL_RENDERER_FILE_ICON
-                                                (object));
+            trg_cell_renderer_file_icon_refresh(TRG_CELL_RENDERER_FILE_ICON(object));
         }
     } else {
         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, property_id, pspec);
     }
 }
 
-static void trg_cell_renderer_file_icon_dispose(GObject * object)
+static void trg_cell_renderer_file_icon_dispose(GObject *object)
 {
-    TrgCellRendererFileIconPrivate *priv =
-        TRG_CELL_RENDERER_FILE_ICON_GET_PRIVATE(object);
+    TrgCellRendererFileIconPrivate *priv = TRG_CELL_RENDERER_FILE_ICON_GET_PRIVATE(object);
     g_free(priv->text);
-    G_OBJECT_CLASS(trg_cell_renderer_file_icon_parent_class)->dispose
-        (object);
+    G_OBJECT_CLASS(trg_cell_renderer_file_icon_parent_class)->dispose(object);
 }
 
-static void
-trg_cell_renderer_file_icon_class_init(TrgCellRendererFileIconClass *
-                                       klass)
+static void trg_cell_renderer_file_icon_class_init(TrgCellRendererFileIconClass *klass)
 {
     GObjectClass *object_class = G_OBJECT_CLASS(klass);
 
@@ -138,48 +120,26 @@ trg_cell_renderer_file_icon_class_init(TrgCellRendererFileIconClass *
     object_class->set_property = trg_cell_renderer_file_icon_set_property;
     object_class->dispose = trg_cell_renderer_file_icon_dispose;
 
-    g_object_class_install_property(object_class,
-                                    PROP_FILE_ID,
-                                    g_param_spec_int64("file-id",
-                                                       "File ID",
-                                                       "File ID",
-                                                       -2,
-                                                       G_MAXINT64,
-                                                       -2,
-                                                       G_PARAM_READWRITE
-                                                       |
-                                                       G_PARAM_STATIC_NAME
-                                                       |
-                                                       G_PARAM_STATIC_NICK
-                                                       |
-                                                       G_PARAM_STATIC_BLURB));
+    g_object_class_install_property(
+        object_class, PROP_FILE_ID,
+        g_param_spec_int64("file-id", "File ID", "File ID", -2, G_MAXINT64, -2,
+                           G_PARAM_READWRITE | G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK
+                               | G_PARAM_STATIC_BLURB));
 
-    g_object_class_install_property(object_class,
-                                    PROP_FILE_NAME,
-                                    g_param_spec_string("file-name",
-                                                        "Filename",
-                                                        "Filename",
-                                                        NULL,
-                                                        G_PARAM_READWRITE
-                                                        |
-                                                        G_PARAM_STATIC_NAME
-                                                        |
-                                                        G_PARAM_STATIC_NICK
-                                                        |
-                                                        G_PARAM_STATIC_BLURB));
+    g_object_class_install_property(object_class, PROP_FILE_NAME,
+                                    g_param_spec_string("file-name", "Filename", "Filename", NULL,
+                                                        G_PARAM_READWRITE | G_PARAM_STATIC_NAME
+                                                            | G_PARAM_STATIC_NICK
+                                                            | G_PARAM_STATIC_BLURB));
 
-    g_type_class_add_private(klass,
-                             sizeof(TrgCellRendererFileIconPrivate));
+    g_type_class_add_private(klass, sizeof(TrgCellRendererFileIconPrivate));
 }
 
-static void
-trg_cell_renderer_file_icon_init(TrgCellRendererFileIcon * self)
+static void trg_cell_renderer_file_icon_init(TrgCellRendererFileIcon *self)
 {
 }
 
 GtkCellRenderer *trg_cell_renderer_file_icon_new(void)
 {
-    return
-        GTK_CELL_RENDERER(g_object_new
-                          (TRG_TYPE_CELL_RENDERER_FILE_ICON, NULL));
+    return GTK_CELL_RENDERER(g_object_new(TRG_TYPE_CELL_RENDERER_FILE_ICON, NULL));
 }

--- a/src/trg-cell-renderer-file-icon.h
+++ b/src/trg-cell-renderer-file-icon.h
@@ -25,17 +25,19 @@
 
 G_BEGIN_DECLS
 #define TRG_TYPE_CELL_RENDERER_FILE_ICON trg_cell_renderer_file_icon_get_type()
-#define TRG_CELL_RENDERER_FILE_ICON(obj) \
-  (G_TYPE_CHECK_INSTANCE_CAST ((obj), TRG_TYPE_CELL_RENDERER_FILE_ICON, TrgCellRendererFileIcon))
-#define TRG_CELL_RENDERER_FILE_ICON_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_CAST ((klass), TRG_TYPE_CELL_RENDERER_FILE_ICON, TrgCellRendererFileIconClass))
-#define TRG_IS_CELL_RENDERER_FILE_ICON(obj) \
-  (G_TYPE_CHECK_INSTANCE_TYPE ((obj), TRG_TYPE_CELL_RENDERER_FILE_ICON))
-#define TRG_IS_CELL_RENDERER_FILE_ICON_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_TYPE ((klass), TRG_TYPE_CELL_RENDERER_FILE_ICON))
-#define TRG_CELL_RENDERER_FILE_ICON_GET_CLASS(obj) \
-  (G_TYPE_INSTANCE_GET_CLASS ((obj), TRG_TYPE_CELL_RENDERER_FILE_ICON, TrgCellRendererFileIconClass))
-    typedef struct {
+#define TRG_CELL_RENDERER_FILE_ICON(obj)                                                           \
+    (G_TYPE_CHECK_INSTANCE_CAST((obj), TRG_TYPE_CELL_RENDERER_FILE_ICON, TrgCellRendererFileIcon))
+#define TRG_CELL_RENDERER_FILE_ICON_CLASS(klass)                                                   \
+    (G_TYPE_CHECK_CLASS_CAST((klass), TRG_TYPE_CELL_RENDERER_FILE_ICON,                            \
+                             TrgCellRendererFileIconClass))
+#define TRG_IS_CELL_RENDERER_FILE_ICON(obj)                                                        \
+    (G_TYPE_CHECK_INSTANCE_TYPE((obj), TRG_TYPE_CELL_RENDERER_FILE_ICON))
+#define TRG_IS_CELL_RENDERER_FILE_ICON_CLASS(klass)                                                \
+    (G_TYPE_CHECK_CLASS_TYPE((klass), TRG_TYPE_CELL_RENDERER_FILE_ICON))
+#define TRG_CELL_RENDERER_FILE_ICON_GET_CLASS(obj)                                                 \
+    (G_TYPE_INSTANCE_GET_CLASS((obj), TRG_TYPE_CELL_RENDERER_FILE_ICON,                            \
+                               TrgCellRendererFileIconClass))
+typedef struct {
     GtkCellRendererPixbuf parent;
 } TrgCellRendererFileIcon;
 
@@ -48,4 +50,4 @@ GType trg_cell_renderer_file_icon_get_type(void);
 GtkCellRenderer *trg_cell_renderer_file_icon_new(void);
 
 G_END_DECLS
-#endif                          /* TRG_CELL_RENDERER_FILE_ICON_H_ */
+#endif /* TRG_CELL_RENDERER_FILE_ICON_H_ */

--- a/src/trg-cell-renderer-numgteqthan.c
+++ b/src/trg-cell-renderer-numgteqthan.c
@@ -19,8 +19,8 @@
 
 #include "config.h"
 
-#include <stdint.h>
 #include <gtk/gtk.h>
+#include <stdint.h>
 
 #include "trg-cell-renderer-numgteqthan.h"
 #include "util.h"
@@ -33,24 +33,20 @@ enum {
 
 G_DEFINE_TYPE(TrgCellRendererNumGtEqThan, trg_cell_renderer_numgteqthan,
               GTK_TYPE_CELL_RENDERER_TEXT)
-#define TRG_CELL_RENDERER_NUMGTEQTHAN_GET_PRIVATE(o) \
-  (G_TYPE_INSTANCE_GET_PRIVATE ((o), TRG_TYPE_CELL_RENDERER_NUMGTEQTHAN, TrgCellRendererNumGtEqThanPrivate))
-typedef struct _TrgCellRendererNumGtEqThanPrivate
- TrgCellRendererNumGtEqThanPrivate;
+#define TRG_CELL_RENDERER_NUMGTEQTHAN_GET_PRIVATE(o)                                               \
+    (G_TYPE_INSTANCE_GET_PRIVATE((o), TRG_TYPE_CELL_RENDERER_NUMGTEQTHAN,                          \
+                                 TrgCellRendererNumGtEqThanPrivate))
+typedef struct _TrgCellRendererNumGtEqThanPrivate TrgCellRendererNumGtEqThanPrivate;
 
 struct _TrgCellRendererNumGtEqThanPrivate {
     gint64 value_value;
     gint64 minvalue;
 };
 
-static void
-trg_cell_renderer_numgteqthan_get_property(GObject * object,
-                                           guint property_id,
-                                           GValue * value,
-                                           GParamSpec * pspec)
+static void trg_cell_renderer_numgteqthan_get_property(GObject *object, guint property_id,
+                                                       GValue *value, GParamSpec *pspec)
 {
-    TrgCellRendererNumGtEqThanPrivate *priv =
-        TRG_CELL_RENDERER_NUMGTEQTHAN_GET_PRIVATE(object);
+    TrgCellRendererNumGtEqThanPrivate *priv = TRG_CELL_RENDERER_NUMGTEQTHAN_GET_PRIVATE(object);
     switch (property_id) {
     case PROP_VALUE_VALUE:
         g_value_set_int64(value, priv->value_value);
@@ -61,20 +57,15 @@ trg_cell_renderer_numgteqthan_get_property(GObject * object,
     }
 }
 
-static void
-trg_cell_renderer_numgteqthan_set_property(GObject * object,
-                                           guint property_id,
-                                           const GValue * value,
-                                           GParamSpec * pspec)
+static void trg_cell_renderer_numgteqthan_set_property(GObject *object, guint property_id,
+                                                       const GValue *value, GParamSpec *pspec)
 {
-    TrgCellRendererNumGtEqThanPrivate *priv =
-        TRG_CELL_RENDERER_NUMGTEQTHAN_GET_PRIVATE(object);
+    TrgCellRendererNumGtEqThanPrivate *priv = TRG_CELL_RENDERER_NUMGTEQTHAN_GET_PRIVATE(object);
     if (property_id == PROP_VALUE_VALUE) {
         priv->value_value = g_value_get_int64(value);
         if (priv->value_value >= priv->minvalue) {
             gchar size_text[32];
-            g_snprintf(size_text, sizeof(size_text), "%" G_GINT64_FORMAT,
-                       priv->value_value);
+            g_snprintf(size_text, sizeof(size_text), "%" G_GINT64_FORMAT, priv->value_value);
             g_object_set(object, "text", size_text, NULL);
         } else {
             g_object_set(object, "text", "", NULL);
@@ -86,63 +77,35 @@ trg_cell_renderer_numgteqthan_set_property(GObject * object,
     }
 }
 
-static void
-trg_cell_renderer_numgteqthan_class_init(TrgCellRendererNumGtEqThanClass *
-                                         klass)
+static void trg_cell_renderer_numgteqthan_class_init(TrgCellRendererNumGtEqThanClass *klass)
 {
     GObjectClass *object_class = G_OBJECT_CLASS(klass);
 
-    object_class->get_property =
-        trg_cell_renderer_numgteqthan_get_property;
-    object_class->set_property =
-        trg_cell_renderer_numgteqthan_set_property;
+    object_class->get_property = trg_cell_renderer_numgteqthan_get_property;
+    object_class->set_property = trg_cell_renderer_numgteqthan_set_property;
 
-    g_object_class_install_property(object_class,
-                                    PROP_VALUE_VALUE,
-                                    g_param_spec_int64("value",
-                                                       "Value",
-                                                       "Value",
-                                                       G_MININT64,
-                                                       G_MAXINT64,
-                                                       0,
-                                                       G_PARAM_READWRITE
-                                                       |
-                                                       G_PARAM_STATIC_NAME
-                                                       |
-                                                       G_PARAM_STATIC_NICK
-                                                       |
-                                                       G_PARAM_STATIC_BLURB));
+    g_object_class_install_property(
+        object_class, PROP_VALUE_VALUE,
+        g_param_spec_int64("value", "Value", "Value", G_MININT64, G_MAXINT64, 0,
+                           G_PARAM_READWRITE | G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK
+                               | G_PARAM_STATIC_BLURB));
 
-    g_object_class_install_property(object_class,
-                                    PROP_MINVALUE,
-                                    g_param_spec_int64("minvalue",
-                                                       "Min Value",
-                                                       "Min Value",
-                                                       G_MININT64,
-                                                       G_MAXINT64,
-                                                       1,
-                                                       G_PARAM_READWRITE
-                                                       |
-                                                       G_PARAM_STATIC_NAME
-                                                       |
-                                                       G_PARAM_STATIC_NICK
-                                                       |
-                                                       G_PARAM_STATIC_BLURB));
+    g_object_class_install_property(
+        object_class, PROP_MINVALUE,
+        g_param_spec_int64("minvalue", "Min Value", "Min Value", G_MININT64, G_MAXINT64, 1,
+                           G_PARAM_READWRITE | G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK
+                               | G_PARAM_STATIC_BLURB));
 
-    g_type_class_add_private(klass,
-                             sizeof(TrgCellRendererNumGtEqThanPrivate));
+    g_type_class_add_private(klass, sizeof(TrgCellRendererNumGtEqThanPrivate));
 }
 
-static void
-trg_cell_renderer_numgteqthan_init(TrgCellRendererNumGtEqThan * self)
+static void trg_cell_renderer_numgteqthan_init(TrgCellRendererNumGtEqThan *self)
 {
     g_object_set(self, "xalign", 1.0f, NULL);
 }
 
 GtkCellRenderer *trg_cell_renderer_numgteqthan_new(gint64 minvalue)
 {
-    return
-        GTK_CELL_RENDERER(g_object_new
-                          (TRG_TYPE_CELL_RENDERER_NUMGTEQTHAN, "minvalue",
-                           minvalue, NULL));
+    return GTK_CELL_RENDERER(
+        g_object_new(TRG_TYPE_CELL_RENDERER_NUMGTEQTHAN, "minvalue", minvalue, NULL));
 }

--- a/src/trg-cell-renderer-numgteqthan.h
+++ b/src/trg-cell-renderer-numgteqthan.h
@@ -25,17 +25,20 @@
 
 G_BEGIN_DECLS
 #define TRG_TYPE_CELL_RENDERER_NUMGTEQTHAN trg_cell_renderer_numgteqthan_get_type()
-#define TRG_CELL_RENDERER_NUMGTEQTHAN(obj) \
-  (G_TYPE_CHECK_INSTANCE_CAST ((obj), TRG_TYPE_CELL_RENDERER_NUMGTEQTHAN, TrgCellRendererNumGtEqThan))
-#define TRG_CELL_RENDERER_NUMGTEQTHAN_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_CAST ((klass), TRG_TYPE_CELL_RENDERER_NUMGTEQTHAN, TrgCellRendererNumGtEqThanClass))
-#define TRG_IS_CELL_RENDERER_NUMGTEQTHAN(obj) \
-  (G_TYPE_CHECK_INSTANCE_TYPE ((obj), TRG_TYPE_CELL_RENDERER_NUMGTEQTHAN))
-#define TRG_IS_CELL_RENDERER_NUMGTEQTHAN_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_TYPE ((klass), TRG_TYPE_CELL_RENDERER_NUMGTEQTHAN))
-#define TRG_CELL_RENDERER_NUMGTEQTHAN_GET_CLASS(obj) \
-  (G_TYPE_INSTANCE_GET_CLASS ((obj), TRG_TYPE_CELL_RENDERER_NUMGTEQTHAN, TrgCellRendererNumGtEqThanClass))
-    typedef struct {
+#define TRG_CELL_RENDERER_NUMGTEQTHAN(obj)                                                         \
+    (G_TYPE_CHECK_INSTANCE_CAST((obj), TRG_TYPE_CELL_RENDERER_NUMGTEQTHAN,                         \
+                                TrgCellRendererNumGtEqThan))
+#define TRG_CELL_RENDERER_NUMGTEQTHAN_CLASS(klass)                                                 \
+    (G_TYPE_CHECK_CLASS_CAST((klass), TRG_TYPE_CELL_RENDERER_NUMGTEQTHAN,                          \
+                             TrgCellRendererNumGtEqThanClass))
+#define TRG_IS_CELL_RENDERER_NUMGTEQTHAN(obj)                                                      \
+    (G_TYPE_CHECK_INSTANCE_TYPE((obj), TRG_TYPE_CELL_RENDERER_NUMGTEQTHAN))
+#define TRG_IS_CELL_RENDERER_NUMGTEQTHAN_CLASS(klass)                                              \
+    (G_TYPE_CHECK_CLASS_TYPE((klass), TRG_TYPE_CELL_RENDERER_NUMGTEQTHAN))
+#define TRG_CELL_RENDERER_NUMGTEQTHAN_GET_CLASS(obj)                                               \
+    (G_TYPE_INSTANCE_GET_CLASS((obj), TRG_TYPE_CELL_RENDERER_NUMGTEQTHAN,                          \
+                               TrgCellRendererNumGtEqThanClass))
+typedef struct {
     GtkCellRendererText parent;
 } TrgCellRendererNumGtEqThan;
 
@@ -48,4 +51,4 @@ GType trg_cell_renderer_numgteqthan_get_type(void);
 GtkCellRenderer *trg_cell_renderer_numgteqthan_new(gint64 minvalue);
 
 G_END_DECLS
-#endif                          /* TRG_CELL_RENDERER_NUMGTEQTHAN_H_ */
+#endif /* TRG_CELL_RENDERER_NUMGTEQTHAN_H_ */

--- a/src/trg-cell-renderer-priority.c
+++ b/src/trg-cell-renderer-priority.c
@@ -19,12 +19,12 @@
 
 #include "config.h"
 
-#include <stdint.h>
 #include <glib/gi18n.h>
 #include <gtk/gtk.h>
+#include <stdint.h>
 
-#include "trg-cell-renderer-priority.h"
 #include "protocol-constants.h"
+#include "trg-cell-renderer-priority.h"
 #include "trg-files-model.h"
 #include "util.h"
 
@@ -33,24 +33,20 @@ enum {
     PROP_PRIORITY_VALUE
 };
 
-G_DEFINE_TYPE(TrgCellRendererPriority, trg_cell_renderer_priority,
-              GTK_TYPE_CELL_RENDERER_TEXT)
-#define TRG_CELL_RENDERER_PRIORITY_GET_PRIVATE(o) \
-  (G_TYPE_INSTANCE_GET_PRIVATE ((o), TRG_TYPE_CELL_RENDERER_PRIORITY, TrgCellRendererPriorityPrivate))
-typedef struct _TrgCellRendererPriorityPrivate
- TrgCellRendererPriorityPrivate;
+G_DEFINE_TYPE(TrgCellRendererPriority, trg_cell_renderer_priority, GTK_TYPE_CELL_RENDERER_TEXT)
+#define TRG_CELL_RENDERER_PRIORITY_GET_PRIVATE(o)                                                  \
+    (G_TYPE_INSTANCE_GET_PRIVATE((o), TRG_TYPE_CELL_RENDERER_PRIORITY,                             \
+                                 TrgCellRendererPriorityPrivate))
+typedef struct _TrgCellRendererPriorityPrivate TrgCellRendererPriorityPrivate;
 
 struct _TrgCellRendererPriorityPrivate {
     gint64 priority_value;
 };
 
-static void
-trg_cell_renderer_priority_get_property(GObject * object,
-                                        guint property_id,
-                                        GValue * value, GParamSpec * pspec)
+static void trg_cell_renderer_priority_get_property(GObject *object, guint property_id,
+                                                    GValue *value, GParamSpec *pspec)
 {
-    TrgCellRendererPriorityPrivate *priv =
-        TRG_CELL_RENDERER_PRIORITY_GET_PRIVATE(object);
+    TrgCellRendererPriorityPrivate *priv = TRG_CELL_RENDERER_PRIORITY_GET_PRIVATE(object);
     switch (property_id) {
     case PROP_PRIORITY_VALUE:
         g_value_set_int64(value, priv->priority_value);
@@ -61,14 +57,10 @@ trg_cell_renderer_priority_get_property(GObject * object,
     }
 }
 
-static void
-trg_cell_renderer_priority_set_property(GObject * object,
-                                        guint property_id,
-                                        const GValue * value,
-                                        GParamSpec * pspec)
+static void trg_cell_renderer_priority_set_property(GObject *object, guint property_id,
+                                                    const GValue *value, GParamSpec *pspec)
 {
-    TrgCellRendererPriorityPrivate *priv =
-        TRG_CELL_RENDERER_PRIORITY_GET_PRIVATE(object);
+    TrgCellRendererPriorityPrivate *priv = TRG_CELL_RENDERER_PRIORITY_GET_PRIVATE(object);
 
     if (property_id == PROP_PRIORITY_VALUE) {
         priv->priority_value = g_value_get_int(value);
@@ -88,37 +80,28 @@ trg_cell_renderer_priority_set_property(GObject * object,
     }
 }
 
-static void
-trg_cell_renderer_priority_class_init(TrgCellRendererPriorityClass * klass)
+static void trg_cell_renderer_priority_class_init(TrgCellRendererPriorityClass *klass)
 {
     GObjectClass *object_class = G_OBJECT_CLASS(klass);
 
     object_class->get_property = trg_cell_renderer_priority_get_property;
     object_class->set_property = trg_cell_renderer_priority_set_property;
 
-    g_object_class_install_property(object_class,
-                                    PROP_PRIORITY_VALUE,
-                                    g_param_spec_int
-                                    ("priority-value",
-                                     "Priority Value",
-                                     "Priority Value", TR_PRI_UNSET,
-                                     TR_PRI_HIGH, TR_PRI_NORMAL,
-                                     G_PARAM_READWRITE |
-                                     G_PARAM_STATIC_NAME |
-                                     G_PARAM_STATIC_NICK |
-                                     G_PARAM_STATIC_BLURB));
+    g_object_class_install_property(
+        object_class, PROP_PRIORITY_VALUE,
+        g_param_spec_int("priority-value", "Priority Value", "Priority Value", TR_PRI_UNSET,
+                         TR_PRI_HIGH, TR_PRI_NORMAL,
+                         G_PARAM_READWRITE | G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK
+                             | G_PARAM_STATIC_BLURB));
 
-    g_type_class_add_private(klass,
-                             sizeof(TrgCellRendererPriorityPrivate));
+    g_type_class_add_private(klass, sizeof(TrgCellRendererPriorityPrivate));
 }
 
-static void trg_cell_renderer_priority_init(TrgCellRendererPriority * self)
+static void trg_cell_renderer_priority_init(TrgCellRendererPriority *self)
 {
 }
 
 GtkCellRenderer *trg_cell_renderer_priority_new(void)
 {
-    return
-        GTK_CELL_RENDERER(g_object_new
-                          (TRG_TYPE_CELL_RENDERER_PRIORITY, NULL));
+    return GTK_CELL_RENDERER(g_object_new(TRG_TYPE_CELL_RENDERER_PRIORITY, NULL));
 }

--- a/src/trg-cell-renderer-priority.h
+++ b/src/trg-cell-renderer-priority.h
@@ -25,17 +25,19 @@
 
 G_BEGIN_DECLS
 #define TRG_TYPE_CELL_RENDERER_PRIORITY trg_cell_renderer_priority_get_type()
-#define TRG_CELL_RENDERER_PRIORITY(obj) \
-  (G_TYPE_CHECK_INSTANCE_CAST ((obj), TRG_TYPE_CELL_RENDERER_PRIORITY, TrgCellRendererPriority))
-#define TRG_CELL_RENDERER_PRIORITY_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_CAST ((klass), TRG_TYPE_CELL_RENDERER_PRIORITY, TrgCellRendererPriorityClass))
-#define TRG_IS_CELL_RENDERER_PRIORITY(obj) \
-  (G_TYPE_CHECK_INSTANCE_TYPE ((obj), TRG_TYPE_CELL_RENDERER_PRIORITY))
-#define TRG_IS_CELL_RENDERER_PRIORITY_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_TYPE ((klass), TRG_TYPE_CELL_RENDERER_PRIORITY))
-#define TRG_CELL_RENDERER_PRIORITY_GET_CLASS(obj) \
-  (G_TYPE_INSTANCE_GET_CLASS ((obj), TRG_TYPE_CELL_RENDERER_PRIORITY, TrgCellRendererPriorityClass))
-    typedef struct {
+#define TRG_CELL_RENDERER_PRIORITY(obj)                                                            \
+    (G_TYPE_CHECK_INSTANCE_CAST((obj), TRG_TYPE_CELL_RENDERER_PRIORITY, TrgCellRendererPriority))
+#define TRG_CELL_RENDERER_PRIORITY_CLASS(klass)                                                    \
+    (G_TYPE_CHECK_CLASS_CAST((klass), TRG_TYPE_CELL_RENDERER_PRIORITY,                             \
+                             TrgCellRendererPriorityClass))
+#define TRG_IS_CELL_RENDERER_PRIORITY(obj)                                                         \
+    (G_TYPE_CHECK_INSTANCE_TYPE((obj), TRG_TYPE_CELL_RENDERER_PRIORITY))
+#define TRG_IS_CELL_RENDERER_PRIORITY_CLASS(klass)                                                 \
+    (G_TYPE_CHECK_CLASS_TYPE((klass), TRG_TYPE_CELL_RENDERER_PRIORITY))
+#define TRG_CELL_RENDERER_PRIORITY_GET_CLASS(obj)                                                  \
+    (G_TYPE_INSTANCE_GET_CLASS((obj), TRG_TYPE_CELL_RENDERER_PRIORITY,                             \
+                               TrgCellRendererPriorityClass))
+typedef struct {
     GtkCellRendererText parent;
 } TrgCellRendererPriority;
 
@@ -48,4 +50,4 @@ GType trg_cell_renderer_priority_get_type(void);
 GtkCellRenderer *trg_cell_renderer_priority_new(void);
 
 G_END_DECLS
-#endif                          /* TRG_CELL_RENDERER_PRIORITY_H_ */
+#endif /* TRG_CELL_RENDERER_PRIORITY_H_ */

--- a/src/trg-cell-renderer-ratio.c
+++ b/src/trg-cell-renderer-ratio.c
@@ -19,8 +19,8 @@
 
 #include "config.h"
 
-#include <limits.h>
 #include <gtk/gtk.h>
+#include <limits.h>
 
 #include "trg-cell-renderer-ratio.h"
 #include "util.h"
@@ -30,23 +30,19 @@ enum {
     PROP_RATIO_VALUE
 };
 
-G_DEFINE_TYPE(TrgCellRendererRatio, trg_cell_renderer_ratio,
-              GTK_TYPE_CELL_RENDERER_TEXT)
-#define TRG_CELL_RENDERER_RATIO_GET_PRIVATE(o) \
-  (G_TYPE_INSTANCE_GET_PRIVATE ((o), TRG_TYPE_CELL_RENDERER_RATIO, TrgCellRendererRatioPrivate))
+G_DEFINE_TYPE(TrgCellRendererRatio, trg_cell_renderer_ratio, GTK_TYPE_CELL_RENDERER_TEXT)
+#define TRG_CELL_RENDERER_RATIO_GET_PRIVATE(o)                                                     \
+    (G_TYPE_INSTANCE_GET_PRIVATE((o), TRG_TYPE_CELL_RENDERER_RATIO, TrgCellRendererRatioPrivate))
 typedef struct _TrgCellRendererRatioPrivate TrgCellRendererRatioPrivate;
 
 struct _TrgCellRendererRatioPrivate {
     gdouble ratio_value;
 };
 
-static void
-trg_cell_renderer_ratio_get_property(GObject * object,
-                                     guint property_id,
-                                     GValue * value, GParamSpec * pspec)
+static void trg_cell_renderer_ratio_get_property(GObject *object, guint property_id, GValue *value,
+                                                 GParamSpec *pspec)
 {
-    TrgCellRendererRatioPrivate *priv =
-        TRG_CELL_RENDERER_RATIO_GET_PRIVATE(object);
+    TrgCellRendererRatioPrivate *priv = TRG_CELL_RENDERER_RATIO_GET_PRIVATE(object);
     switch (property_id) {
     case PROP_RATIO_VALUE:
         g_value_set_double(value, priv->ratio_value);
@@ -56,13 +52,10 @@ trg_cell_renderer_ratio_get_property(GObject * object,
     }
 }
 
-static void
-trg_cell_renderer_ratio_set_property(GObject * object, guint property_id,
-                                     const GValue * value,
-                                     GParamSpec * pspec)
+static void trg_cell_renderer_ratio_set_property(GObject *object, guint property_id,
+                                                 const GValue *value, GParamSpec *pspec)
 {
-    TrgCellRendererRatioPrivate *priv =
-        TRG_CELL_RENDERER_RATIO_GET_PRIVATE(object);
+    TrgCellRendererRatioPrivate *priv = TRG_CELL_RENDERER_RATIO_GET_PRIVATE(object);
     if (property_id == PROP_RATIO_VALUE) {
         priv->ratio_value = g_value_get_double(value);
         if (priv->ratio_value > 0) {
@@ -77,41 +70,28 @@ trg_cell_renderer_ratio_set_property(GObject * object, guint property_id,
     }
 }
 
-static void
-trg_cell_renderer_ratio_class_init(TrgCellRendererRatioClass * klass)
+static void trg_cell_renderer_ratio_class_init(TrgCellRendererRatioClass *klass)
 {
     GObjectClass *object_class = G_OBJECT_CLASS(klass);
 
     object_class->get_property = trg_cell_renderer_ratio_get_property;
     object_class->set_property = trg_cell_renderer_ratio_set_property;
 
-    g_object_class_install_property(object_class,
-                                    PROP_RATIO_VALUE,
-                                    g_param_spec_double("ratio-value",
-                                                        "Ratio Value",
-                                                        "Ratio Value",
-                                                        0,
-                                                        DBL_MAX,
-                                                        0,
-                                                        G_PARAM_READWRITE
-                                                        |
-                                                        G_PARAM_STATIC_NAME
-                                                        |
-                                                        G_PARAM_STATIC_NICK
-                                                        |
-                                                        G_PARAM_STATIC_BLURB));
+    g_object_class_install_property(
+        object_class, PROP_RATIO_VALUE,
+        g_param_spec_double("ratio-value", "Ratio Value", "Ratio Value", 0, DBL_MAX, 0,
+                            G_PARAM_READWRITE | G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK
+                                | G_PARAM_STATIC_BLURB));
 
     g_type_class_add_private(klass, sizeof(TrgCellRendererRatioPrivate));
 }
 
-static void trg_cell_renderer_ratio_init(TrgCellRendererRatio * self)
+static void trg_cell_renderer_ratio_init(TrgCellRendererRatio *self)
 {
     g_object_set(self, "xalign", 1.0f, NULL);
 }
 
 GtkCellRenderer *trg_cell_renderer_ratio_new(void)
 {
-    return
-        GTK_CELL_RENDERER(g_object_new
-                          (TRG_TYPE_CELL_RENDERER_RATIO, NULL));
+    return GTK_CELL_RENDERER(g_object_new(TRG_TYPE_CELL_RENDERER_RATIO, NULL));
 }

--- a/src/trg-cell-renderer-ratio.h
+++ b/src/trg-cell-renderer-ratio.h
@@ -25,17 +25,17 @@
 
 G_BEGIN_DECLS
 #define TRG_TYPE_CELL_RENDERER_RATIO trg_cell_renderer_ratio_get_type()
-#define TRG_CELL_RENDERER_RATIO(obj) \
-  (G_TYPE_CHECK_INSTANCE_CAST ((obj), TRG_TYPE_CELL_RENDERER_RATIO, TrgCellRendererRatio))
-#define TRG_CELL_RENDERER_RATIO_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_CAST ((klass), TRG_TYPE_CELL_RENDERER_RATIO, TrgCellRendererRatioClass))
-#define TRG_IS_CELL_RENDERER_RATIO(obj) \
-  (G_TYPE_CHECK_INSTANCE_TYPE ((obj), TRG_TYPE_CELL_RENDERER_RATIO))
-#define TRG_IS_CELL_RENDERER_RATIO_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_TYPE ((klass), TRG_TYPE_CELL_RENDERER_RATIO))
-#define TRG_CELL_RENDERER_RATIO_GET_CLASS(obj) \
-  (G_TYPE_INSTANCE_GET_CLASS ((obj), TRG_TYPE_CELL_RENDERER_RATIO, TrgCellRendererRatioClass))
-    typedef struct {
+#define TRG_CELL_RENDERER_RATIO(obj)                                                               \
+    (G_TYPE_CHECK_INSTANCE_CAST((obj), TRG_TYPE_CELL_RENDERER_RATIO, TrgCellRendererRatio))
+#define TRG_CELL_RENDERER_RATIO_CLASS(klass)                                                       \
+    (G_TYPE_CHECK_CLASS_CAST((klass), TRG_TYPE_CELL_RENDERER_RATIO, TrgCellRendererRatioClass))
+#define TRG_IS_CELL_RENDERER_RATIO(obj)                                                            \
+    (G_TYPE_CHECK_INSTANCE_TYPE((obj), TRG_TYPE_CELL_RENDERER_RATIO))
+#define TRG_IS_CELL_RENDERER_RATIO_CLASS(klass)                                                    \
+    (G_TYPE_CHECK_CLASS_TYPE((klass), TRG_TYPE_CELL_RENDERER_RATIO))
+#define TRG_CELL_RENDERER_RATIO_GET_CLASS(obj)                                                     \
+    (G_TYPE_INSTANCE_GET_CLASS((obj), TRG_TYPE_CELL_RENDERER_RATIO, TrgCellRendererRatioClass))
+typedef struct {
     GtkCellRendererText parent;
 } TrgCellRendererRatio;
 
@@ -48,4 +48,4 @@ GType trg_cell_renderer_ratio_get_type(void);
 GtkCellRenderer *trg_cell_renderer_ratio_new(void);
 
 G_END_DECLS
-#endif                          /* TRG_CELL_RENDERER_RATIO_H_ */
+#endif /* TRG_CELL_RENDERER_RATIO_H_ */

--- a/src/trg-cell-renderer-size.c
+++ b/src/trg-cell-renderer-size.c
@@ -19,8 +19,8 @@
 
 #include "config.h"
 
-#include <stdint.h>
 #include <gtk/gtk.h>
+#include <stdint.h>
 
 #include "trg-cell-renderer-size.h"
 #include "util.h"
@@ -30,23 +30,19 @@ enum {
     PROP_SIZE_VALUE
 };
 
-G_DEFINE_TYPE(TrgCellRendererSize, trg_cell_renderer_size,
-              GTK_TYPE_CELL_RENDERER_TEXT)
-#define TRG_CELL_RENDERER_SIZE_GET_PRIVATE(o) \
-  (G_TYPE_INSTANCE_GET_PRIVATE ((o), TRG_TYPE_CELL_RENDERER_SIZE, TrgCellRendererSizePrivate))
+G_DEFINE_TYPE(TrgCellRendererSize, trg_cell_renderer_size, GTK_TYPE_CELL_RENDERER_TEXT)
+#define TRG_CELL_RENDERER_SIZE_GET_PRIVATE(o)                                                      \
+    (G_TYPE_INSTANCE_GET_PRIVATE((o), TRG_TYPE_CELL_RENDERER_SIZE, TrgCellRendererSizePrivate))
 typedef struct _TrgCellRendererSizePrivate TrgCellRendererSizePrivate;
 
 struct _TrgCellRendererSizePrivate {
     gint64 size_value;
 };
 
-static void
-trg_cell_renderer_size_get_property(GObject * object,
-                                    guint property_id, GValue * value,
-                                    GParamSpec * pspec)
+static void trg_cell_renderer_size_get_property(GObject *object, guint property_id, GValue *value,
+                                                GParamSpec *pspec)
 {
-    TrgCellRendererSizePrivate *priv =
-        TRG_CELL_RENDERER_SIZE_GET_PRIVATE(object);
+    TrgCellRendererSizePrivate *priv = TRG_CELL_RENDERER_SIZE_GET_PRIVATE(object);
     switch (property_id) {
     case PROP_SIZE_VALUE:
         g_value_set_int64(value, priv->size_value);
@@ -57,13 +53,10 @@ trg_cell_renderer_size_get_property(GObject * object,
     }
 }
 
-static void
-trg_cell_renderer_size_set_property(GObject * object, guint property_id,
-                                    const GValue * value,
-                                    GParamSpec * pspec)
+static void trg_cell_renderer_size_set_property(GObject *object, guint property_id,
+                                                const GValue *value, GParamSpec *pspec)
 {
-    TrgCellRendererSizePrivate *priv =
-        TRG_CELL_RENDERER_SIZE_GET_PRIVATE(object);
+    TrgCellRendererSizePrivate *priv = TRG_CELL_RENDERER_SIZE_GET_PRIVATE(object);
     if (property_id == PROP_SIZE_VALUE) {
         gint64 new_value = g_value_get_int64(value);
         if (priv->size_value != new_value) {
@@ -81,40 +74,28 @@ trg_cell_renderer_size_set_property(GObject * object, guint property_id,
     }
 }
 
-static void
-trg_cell_renderer_size_class_init(TrgCellRendererSizeClass * klass)
+static void trg_cell_renderer_size_class_init(TrgCellRendererSizeClass *klass)
 {
     GObjectClass *object_class = G_OBJECT_CLASS(klass);
 
     object_class->get_property = trg_cell_renderer_size_get_property;
     object_class->set_property = trg_cell_renderer_size_set_property;
 
-    g_object_class_install_property(object_class,
-                                    PROP_SIZE_VALUE,
-                                    g_param_spec_int64("size-value",
-                                                       "Size Value",
-                                                       "Size Value",
-                                                       0,
-                                                       G_MAXINT64,
-                                                       0,
-                                                       G_PARAM_READWRITE
-                                                       |
-                                                       G_PARAM_STATIC_NAME
-                                                       |
-                                                       G_PARAM_STATIC_NICK
-                                                       |
-                                                       G_PARAM_STATIC_BLURB));
+    g_object_class_install_property(
+        object_class, PROP_SIZE_VALUE,
+        g_param_spec_int64("size-value", "Size Value", "Size Value", 0, G_MAXINT64, 0,
+                           G_PARAM_READWRITE | G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK
+                               | G_PARAM_STATIC_BLURB));
 
     g_type_class_add_private(klass, sizeof(TrgCellRendererSizePrivate));
 }
 
-static void trg_cell_renderer_size_init(TrgCellRendererSize * self)
+static void trg_cell_renderer_size_init(TrgCellRendererSize *self)
 {
     g_object_set(self, "xalign", 1.0f, NULL);
 }
 
 GtkCellRenderer *trg_cell_renderer_size_new(void)
 {
-    return
-        GTK_CELL_RENDERER(g_object_new(TRG_TYPE_CELL_RENDERER_SIZE, NULL));
+    return GTK_CELL_RENDERER(g_object_new(TRG_TYPE_CELL_RENDERER_SIZE, NULL));
 }

--- a/src/trg-cell-renderer-size.h
+++ b/src/trg-cell-renderer-size.h
@@ -25,17 +25,17 @@
 
 G_BEGIN_DECLS
 #define TRG_TYPE_CELL_RENDERER_SIZE trg_cell_renderer_size_get_type()
-#define TRG_CELL_RENDERER_SIZE(obj) \
-  (G_TYPE_CHECK_INSTANCE_CAST ((obj), TRG_TYPE_CELL_RENDERER_SIZE, TrgCellRendererSize))
-#define TRG_CELL_RENDERER_SIZE_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_CAST ((klass), TRG_TYPE_CELL_RENDERER_SIZE, TrgCellRendererSizeClass))
-#define TRG_IS_CELL_RENDERER_SIZE(obj) \
-  (G_TYPE_CHECK_INSTANCE_TYPE ((obj), TRG_TYPE_CELL_RENDERER_SIZE))
-#define TRG_IS_CELL_RENDERER_SIZE_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_TYPE ((klass), TRG_TYPE_CELL_RENDERER_SIZE))
-#define TRG_CELL_RENDERER_SIZE_GET_CLASS(obj) \
-  (G_TYPE_INSTANCE_GET_CLASS ((obj), TRG_TYPE_CELL_RENDERER_SIZE, TrgCellRendererSizeClass))
-    typedef struct {
+#define TRG_CELL_RENDERER_SIZE(obj)                                                                \
+    (G_TYPE_CHECK_INSTANCE_CAST((obj), TRG_TYPE_CELL_RENDERER_SIZE, TrgCellRendererSize))
+#define TRG_CELL_RENDERER_SIZE_CLASS(klass)                                                        \
+    (G_TYPE_CHECK_CLASS_CAST((klass), TRG_TYPE_CELL_RENDERER_SIZE, TrgCellRendererSizeClass))
+#define TRG_IS_CELL_RENDERER_SIZE(obj)                                                             \
+    (G_TYPE_CHECK_INSTANCE_TYPE((obj), TRG_TYPE_CELL_RENDERER_SIZE))
+#define TRG_IS_CELL_RENDERER_SIZE_CLASS(klass)                                                     \
+    (G_TYPE_CHECK_CLASS_TYPE((klass), TRG_TYPE_CELL_RENDERER_SIZE))
+#define TRG_CELL_RENDERER_SIZE_GET_CLASS(obj)                                                      \
+    (G_TYPE_INSTANCE_GET_CLASS((obj), TRG_TYPE_CELL_RENDERER_SIZE, TrgCellRendererSizeClass))
+typedef struct {
     GtkCellRendererText parent;
 } TrgCellRendererSize;
 
@@ -48,4 +48,4 @@ GType trg_cell_renderer_size_get_type(void);
 GtkCellRenderer *trg_cell_renderer_size_new(void);
 
 G_END_DECLS
-#endif                          /* TRG_CELL_RENDERER_SIZE_H_ */
+#endif /* TRG_CELL_RENDERER_SIZE_H_ */

--- a/src/trg-cell-renderer-speed.c
+++ b/src/trg-cell-renderer-speed.c
@@ -19,33 +19,30 @@
 
 #include "config.h"
 
-#include <stdint.h>
 #include <gtk/gtk.h>
+#include <stdint.h>
 
 #include "trg-cell-renderer-speed.h"
 #include "util.h"
 
 enum {
-    PROP_0, PROP_SPEED_VALUE
+    PROP_0,
+    PROP_SPEED_VALUE
 };
 
-G_DEFINE_TYPE(TrgCellRendererSpeed, trg_cell_renderer_speed,
-              GTK_TYPE_CELL_RENDERER_TEXT)
-#define TRG_CELL_RENDERER_SPEED_GET_PRIVATE(o) \
-  (G_TYPE_INSTANCE_GET_PRIVATE ((o), TRG_TYPE_CELL_RENDERER_SPEED, TrgCellRendererSpeedPrivate))
+G_DEFINE_TYPE(TrgCellRendererSpeed, trg_cell_renderer_speed, GTK_TYPE_CELL_RENDERER_TEXT)
+#define TRG_CELL_RENDERER_SPEED_GET_PRIVATE(o)                                                     \
+    (G_TYPE_INSTANCE_GET_PRIVATE((o), TRG_TYPE_CELL_RENDERER_SPEED, TrgCellRendererSpeedPrivate))
 typedef struct _TrgCellRendererSpeedPrivate TrgCellRendererSpeedPrivate;
 
 struct _TrgCellRendererSpeedPrivate {
     gint64 speed_value;
 };
 
-static void trg_cell_renderer_speed_get_property(GObject * object,
-                                                 guint property_id,
-                                                 GValue * value,
-                                                 GParamSpec * pspec)
+static void trg_cell_renderer_speed_get_property(GObject *object, guint property_id, GValue *value,
+                                                 GParamSpec *pspec)
 {
-    TrgCellRendererSpeedPrivate *priv =
-        TRG_CELL_RENDERER_SPEED_GET_PRIVATE(object);
+    TrgCellRendererSpeedPrivate *priv = TRG_CELL_RENDERER_SPEED_GET_PRIVATE(object);
     switch (property_id) {
     case PROP_SPEED_VALUE:
         g_value_set_int64(value, priv->speed_value);
@@ -56,13 +53,10 @@ static void trg_cell_renderer_speed_get_property(GObject * object,
     }
 }
 
-static void trg_cell_renderer_speed_set_property(GObject * object,
-                                                 guint property_id,
-                                                 const GValue * value,
-                                                 GParamSpec * pspec)
+static void trg_cell_renderer_speed_set_property(GObject *object, guint property_id,
+                                                 const GValue *value, GParamSpec *pspec)
 {
-    TrgCellRendererSpeedPrivate *priv =
-        TRG_CELL_RENDERER_SPEED_GET_PRIVATE(object);
+    TrgCellRendererSpeedPrivate *priv = TRG_CELL_RENDERER_SPEED_GET_PRIVATE(object);
     if (property_id == PROP_SPEED_VALUE) {
         gint64 new_value = g_value_get_int64(value);
         if (new_value != priv->speed_value) {
@@ -80,39 +74,28 @@ static void trg_cell_renderer_speed_set_property(GObject * object,
     }
 }
 
-static void trg_cell_renderer_speed_class_init(TrgCellRendererSpeedClass *
-                                               klass)
+static void trg_cell_renderer_speed_class_init(TrgCellRendererSpeedClass *klass)
 {
     GObjectClass *object_class = G_OBJECT_CLASS(klass);
 
     object_class->get_property = trg_cell_renderer_speed_get_property;
     object_class->set_property = trg_cell_renderer_speed_set_property;
 
-    g_object_class_install_property(object_class,
-                                    PROP_SPEED_VALUE,
-                                    g_param_spec_int64("speed-value",
-                                                       "Speed Value",
-                                                       "Speed Value",
-                                                       0,
-                                                       G_MAXINT64,
-                                                       0,
-                                                       G_PARAM_READWRITE |
-                                                       G_PARAM_STATIC_NAME
-                                                       |
-                                                       G_PARAM_STATIC_NICK
-                                                       |
-                                                       G_PARAM_STATIC_BLURB));
+    g_object_class_install_property(
+        object_class, PROP_SPEED_VALUE,
+        g_param_spec_int64("speed-value", "Speed Value", "Speed Value", 0, G_MAXINT64, 0,
+                           G_PARAM_READWRITE | G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK
+                               | G_PARAM_STATIC_BLURB));
 
     g_type_class_add_private(klass, sizeof(TrgCellRendererSpeedPrivate));
 }
 
-static void trg_cell_renderer_speed_init(TrgCellRendererSpeed * self)
+static void trg_cell_renderer_speed_init(TrgCellRendererSpeed *self)
 {
     g_object_set(self, "xalign", 1.0f, NULL);
 }
 
 GtkCellRenderer *trg_cell_renderer_speed_new(void)
 {
-    return GTK_CELL_RENDERER(g_object_new
-                             (TRG_TYPE_CELL_RENDERER_SPEED, NULL));
+    return GTK_CELL_RENDERER(g_object_new(TRG_TYPE_CELL_RENDERER_SPEED, NULL));
 }

--- a/src/trg-cell-renderer-speed.h
+++ b/src/trg-cell-renderer-speed.h
@@ -17,7 +17,6 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-
 #ifndef TRG_CELL_RENDERER_SPEED_H_
 #define TRG_CELL_RENDERER_SPEED_H_
 
@@ -26,17 +25,17 @@
 
 G_BEGIN_DECLS
 #define TRG_TYPE_CELL_RENDERER_SPEED trg_cell_renderer_speed_get_type()
-#define TRG_CELL_RENDERER_SPEED(obj) \
-  (G_TYPE_CHECK_INSTANCE_CAST ((obj), TRG_TYPE_CELL_RENDERER_SPEED, TrgCellRendererSpeed))
-#define TRG_CELL_RENDERER_SPEED_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_CAST ((klass), TRG_TYPE_CELL_RENDERER_SPEED, TrgCellRendererSpeedClass))
-#define TRG_IS_CELL_RENDERER_SPEED(obj) \
-  (G_TYPE_CHECK_INSTANCE_TYPE ((obj), TRG_TYPE_CELL_RENDERER_SPEED))
-#define TRG_IS_CELL_RENDERER_SPEED_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_TYPE ((klass), TRG_TYPE_CELL_RENDERER_SPEED))
-#define TRG_CELL_RENDERER_SPEED_GET_CLASS(obj) \
-  (G_TYPE_INSTANCE_GET_CLASS ((obj), TRG_TYPE_CELL_RENDERER_SPEED, TrgCellRendererSpeedClass))
-    typedef struct {
+#define TRG_CELL_RENDERER_SPEED(obj)                                                               \
+    (G_TYPE_CHECK_INSTANCE_CAST((obj), TRG_TYPE_CELL_RENDERER_SPEED, TrgCellRendererSpeed))
+#define TRG_CELL_RENDERER_SPEED_CLASS(klass)                                                       \
+    (G_TYPE_CHECK_CLASS_CAST((klass), TRG_TYPE_CELL_RENDERER_SPEED, TrgCellRendererSpeedClass))
+#define TRG_IS_CELL_RENDERER_SPEED(obj)                                                            \
+    (G_TYPE_CHECK_INSTANCE_TYPE((obj), TRG_TYPE_CELL_RENDERER_SPEED))
+#define TRG_IS_CELL_RENDERER_SPEED_CLASS(klass)                                                    \
+    (G_TYPE_CHECK_CLASS_TYPE((klass), TRG_TYPE_CELL_RENDERER_SPEED))
+#define TRG_CELL_RENDERER_SPEED_GET_CLASS(obj)                                                     \
+    (G_TYPE_INSTANCE_GET_CLASS((obj), TRG_TYPE_CELL_RENDERER_SPEED, TrgCellRendererSpeedClass))
+typedef struct {
     GtkCellRendererText parent;
 } TrgCellRendererSpeed;
 
@@ -49,4 +48,4 @@ GType trg_cell_renderer_speed_get_type(void);
 GtkCellRenderer *trg_cell_renderer_speed_new(void);
 
 G_END_DECLS
-#endif                          /* TRG_CELL_RENDERER_SPEED_H_ */
+#endif /* TRG_CELL_RENDERER_SPEED_H_ */

--- a/src/trg-cell-renderer-wanted.c
+++ b/src/trg-cell-renderer-wanted.c
@@ -19,12 +19,12 @@
 
 #include "config.h"
 
-#include <stdint.h>
 #include <glib/gi18n.h>
 #include <gtk/gtk.h>
+#include <stdint.h>
 
-#include "trg-cell-renderer-wanted.h"
 #include "protocol-constants.h"
+#include "trg-cell-renderer-wanted.h"
 #include "trg-files-model.h"
 #include "util.h"
 
@@ -33,24 +33,19 @@ enum {
     PROP_WANTED_VALUE
 };
 
-G_DEFINE_TYPE(TrgCellRendererWanted, trg_cell_renderer_wanted,
-              GTK_TYPE_CELL_RENDERER_TOGGLE)
-#define TRG_CELL_RENDERER_WANTED_GET_PRIVATE(o) \
-  (G_TYPE_INSTANCE_GET_PRIVATE ((o), TRG_TYPE_CELL_RENDERER_WANTED, TrgCellRendererWantedPrivate))
-typedef struct _TrgCellRendererWantedPrivate
- TrgCellRendererWantedPrivate;
+G_DEFINE_TYPE(TrgCellRendererWanted, trg_cell_renderer_wanted, GTK_TYPE_CELL_RENDERER_TOGGLE)
+#define TRG_CELL_RENDERER_WANTED_GET_PRIVATE(o)                                                    \
+    (G_TYPE_INSTANCE_GET_PRIVATE((o), TRG_TYPE_CELL_RENDERER_WANTED, TrgCellRendererWantedPrivate))
+typedef struct _TrgCellRendererWantedPrivate TrgCellRendererWantedPrivate;
 
 struct _TrgCellRendererWantedPrivate {
     gint wanted_value;
 };
 
-static void
-trg_cell_renderer_wanted_get_property(GObject * object,
-                                      guint property_id,
-                                      GValue * value, GParamSpec * pspec)
+static void trg_cell_renderer_wanted_get_property(GObject *object, guint property_id, GValue *value,
+                                                  GParamSpec *pspec)
 {
-    TrgCellRendererWantedPrivate *priv =
-        TRG_CELL_RENDERER_WANTED_GET_PRIVATE(object);
+    TrgCellRendererWantedPrivate *priv = TRG_CELL_RENDERER_WANTED_GET_PRIVATE(object);
     switch (property_id) {
     case PROP_WANTED_VALUE:
         g_value_set_int(value, priv->wanted_value);
@@ -61,49 +56,37 @@ trg_cell_renderer_wanted_get_property(GObject * object,
     }
 }
 
-static void
-trg_cell_renderer_wanted_set_property(GObject * object,
-                                      guint property_id,
-                                      const GValue * value,
-                                      GParamSpec * pspec)
+static void trg_cell_renderer_wanted_set_property(GObject *object, guint property_id,
+                                                  const GValue *value, GParamSpec *pspec)
 {
-    TrgCellRendererWantedPrivate *priv =
-        TRG_CELL_RENDERER_WANTED_GET_PRIVATE(object);
+    TrgCellRendererWantedPrivate *priv = TRG_CELL_RENDERER_WANTED_GET_PRIVATE(object);
 
     if (property_id == PROP_WANTED_VALUE) {
         priv->wanted_value = g_value_get_int(value);
-        g_object_set(G_OBJECT(object), "inconsistent",
-                     (priv->wanted_value == TR_PRI_MIXED), "active",
-                     (priv->wanted_value == TRUE), NULL);
+        g_object_set(G_OBJECT(object), "inconsistent", (priv->wanted_value == TR_PRI_MIXED),
+                     "active", (priv->wanted_value == TRUE), NULL);
     } else {
         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, property_id, pspec);
     }
 }
 
-static void
-trg_cell_renderer_wanted_class_init(TrgCellRendererWantedClass * klass)
+static void trg_cell_renderer_wanted_class_init(TrgCellRendererWantedClass *klass)
 {
     GObjectClass *object_class = G_OBJECT_CLASS(klass);
 
     object_class->get_property = trg_cell_renderer_wanted_get_property;
     object_class->set_property = trg_cell_renderer_wanted_set_property;
 
-    g_object_class_install_property(object_class,
-                                    PROP_WANTED_VALUE,
-                                    g_param_spec_int
-                                    ("wanted-value",
-                                     "Wanted Value",
-                                     "Wanted Value", TR_PRI_UNSET,
-                                     TRUE, TRUE,
-                                     G_PARAM_READWRITE |
-                                     G_PARAM_STATIC_NAME |
-                                     G_PARAM_STATIC_NICK |
-                                     G_PARAM_STATIC_BLURB));
+    g_object_class_install_property(
+        object_class, PROP_WANTED_VALUE,
+        g_param_spec_int("wanted-value", "Wanted Value", "Wanted Value", TR_PRI_UNSET, TRUE, TRUE,
+                         G_PARAM_READWRITE | G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK
+                             | G_PARAM_STATIC_BLURB));
 
     g_type_class_add_private(klass, sizeof(TrgCellRendererWantedPrivate));
 }
 
-static void trg_cell_renderer_wanted_init(TrgCellRendererWanted * self)
+static void trg_cell_renderer_wanted_init(TrgCellRendererWanted *self)
 {
     /*g_object_set(G_OBJECT(self), "xalign", (gfloat) 0.5, "yalign", (gfloat) 0.5,
        NULL); */
@@ -111,7 +94,5 @@ static void trg_cell_renderer_wanted_init(TrgCellRendererWanted * self)
 
 GtkCellRenderer *trg_cell_renderer_wanted_new(void)
 {
-    return
-        GTK_CELL_RENDERER(g_object_new
-                          (TRG_TYPE_CELL_RENDERER_WANTED, NULL));
+    return GTK_CELL_RENDERER(g_object_new(TRG_TYPE_CELL_RENDERER_WANTED, NULL));
 }

--- a/src/trg-cell-renderer-wanted.h
+++ b/src/trg-cell-renderer-wanted.h
@@ -25,17 +25,17 @@
 
 G_BEGIN_DECLS
 #define TRG_TYPE_CELL_RENDERER_WANTED trg_cell_renderer_wanted_get_type()
-#define TRG_CELL_RENDERER_WANTED(obj) \
-  (G_TYPE_CHECK_INSTANCE_CAST ((obj), TRG_TYPE_CELL_RENDERER_WANTED, TrgCellRendererWanted))
-#define TRG_CELL_RENDERER_WANTED_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_CAST ((klass), TRG_TYPE_CELL_RENDERER_WANTED, TrgCellRendererWantedClass))
-#define TRG_IS_CELL_RENDERER_WANTED(obj) \
-  (G_TYPE_CHECK_INSTANCE_TYPE ((obj), TRG_TYPE_CELL_RENDERER_WANTED))
-#define TRG_IS_CELL_RENDERER_WANTED_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_TYPE ((klass), TRG_TYPE_CELL_RENDERER_WANTED))
-#define TRG_CELL_RENDERER_WANTED_GET_CLASS(obj) \
-  (G_TYPE_INSTANCE_GET_CLASS ((obj), TRG_TYPE_CELL_RENDERER_WANTED, TrgCellRendererWantedClass))
-    typedef struct {
+#define TRG_CELL_RENDERER_WANTED(obj)                                                              \
+    (G_TYPE_CHECK_INSTANCE_CAST((obj), TRG_TYPE_CELL_RENDERER_WANTED, TrgCellRendererWanted))
+#define TRG_CELL_RENDERER_WANTED_CLASS(klass)                                                      \
+    (G_TYPE_CHECK_CLASS_CAST((klass), TRG_TYPE_CELL_RENDERER_WANTED, TrgCellRendererWantedClass))
+#define TRG_IS_CELL_RENDERER_WANTED(obj)                                                           \
+    (G_TYPE_CHECK_INSTANCE_TYPE((obj), TRG_TYPE_CELL_RENDERER_WANTED))
+#define TRG_IS_CELL_RENDERER_WANTED_CLASS(klass)                                                   \
+    (G_TYPE_CHECK_CLASS_TYPE((klass), TRG_TYPE_CELL_RENDERER_WANTED))
+#define TRG_CELL_RENDERER_WANTED_GET_CLASS(obj)                                                    \
+    (G_TYPE_INSTANCE_GET_CLASS((obj), TRG_TYPE_CELL_RENDERER_WANTED, TrgCellRendererWantedClass))
+typedef struct {
     GtkCellRendererToggle parent;
 } TrgCellRendererWanted;
 
@@ -48,4 +48,4 @@ GType trg_cell_renderer_wanted_get_type(void);
 GtkCellRenderer *trg_cell_renderer_wanted_new(void);
 
 G_END_DECLS
-#endif                          /* TRG_CELL_RENDERER_WANTED_H_ */
+#endif /* TRG_CELL_RENDERER_WANTED_H_ */

--- a/src/trg-client.h
+++ b/src/trg-client.h
@@ -25,36 +25,36 @@
 #include <curl/curl.h>
 #include <curl/easy.h>
 
-#include <json-glib/json-glib.h>
 #include <glib-object.h>
+#include <json-glib/json-glib.h>
 
-#include "trg-prefs.h"
 #include "session-get.h"
+#include "trg-prefs.h"
 
-#define TRANSMISSION_MIN_SUPPORTED 2.0
+#define TRANSMISSION_MIN_SUPPORTED              2.0
 #define X_TRANSMISSION_SESSION_ID_HEADER_PREFIX "X-Transmission-Session-Id: "
 
-#define TORRENT_GET_MODE_FIRST 0
-#define TORRENT_GET_MODE_ACTIVE 1
+#define TORRENT_GET_MODE_FIRST       0
+#define TORRENT_GET_MODE_ACTIVE      1
 #define TORRENT_GET_MODE_INTERACTION 2
-#define TORRENT_GET_MODE_UPDATE 3
+#define TORRENT_GET_MODE_UPDATE      3
 
-#define TORRENT_GET_TAG_MODE_FULL -1
+#define TORRENT_GET_TAG_MODE_FULL   -1
 #define TORRENT_GET_TAG_MODE_UPDATE -2
 
 #define TRG_NO_HOSTNAME_SET -2
 
-#define HTTP_URI_PREFIX "http"
+#define HTTP_URI_PREFIX  "http"
 #define HTTPS_URI_PREFIX "https"
-#define HTTP_OK 200
-#define HTTP_CONFLICT 409
+#define HTTP_OK          200
+#define HTTP_CONFLICT    409
 
-#define FAIL_JSON_DECODE -2
+#define FAIL_JSON_DECODE           -2
 #define FAIL_RESPONSE_UNSUCCESSFUL -3
-#define DISPATCH_POOL_SIZE 3
+#define DISPATCH_POOL_SIZE         3
 
 #define HTTP_CLASS_TRANSMISSION 0
-#define HTTP_CLASS_PUBLIC 1
+#define HTTP_CLASS_PUBLIC       1
 
 typedef struct {
     int status;
@@ -77,26 +77,21 @@ typedef struct {
 typedef struct _TrgClientPrivate TrgClientPrivate;
 
 G_BEGIN_DECLS
-#define TRG_TYPE_CLIENT trg_client_get_type()
-#define TRG_CLIENT(obj) \
-  (G_TYPE_CHECK_INSTANCE_CAST ((obj), TRG_TYPE_CLIENT, TrgClient))
-#define TRG_CLIENT_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_CAST ((klass), TRG_TYPE_CLIENT, TrgClientClass))
-#define TRG_IS_CLIENT(obj) \
-  (G_TYPE_CHECK_INSTANCE_TYPE ((obj), TRG_TYPE_CLIENT))
-#define TRG_IS_CLIENT_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_TYPE ((klass), TRG_TYPE_CLIENT))
-#define TRG_CLIENT_GET_CLASS(obj) \
-  (G_TYPE_INSTANCE_GET_CLASS ((obj), TRG_TYPE_CLIENT, TrgClientClass))
-    typedef struct {
+#define TRG_TYPE_CLIENT            trg_client_get_type()
+#define TRG_CLIENT(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), TRG_TYPE_CLIENT, TrgClient))
+#define TRG_CLIENT_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass), TRG_TYPE_CLIENT, TrgClientClass))
+#define TRG_IS_CLIENT(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), TRG_TYPE_CLIENT))
+#define TRG_IS_CLIENT_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass), TRG_TYPE_CLIENT))
+#define TRG_CLIENT_GET_CLASS(obj)                                                                  \
+    (G_TYPE_INSTANCE_GET_CLASS((obj), TRG_TYPE_CLIENT, TrgClientClass))
+typedef struct {
     GObject parent;
     TrgClientPrivate *priv;
 } TrgClient;
 
 typedef struct {
     GObjectClass parent_class;
-    void (*session_updated) (TrgClient * tc, JsonObject * session,
-                             gpointer data);
+    void (*session_updated)(TrgClient *tc, JsonObject *session, gpointer data);
 
 } TrgClientClass;
 
@@ -115,58 +110,56 @@ typedef struct {
 } trg_tls;
 
 /* stuff that used to be in http.h */
-void trg_response_free(trg_response * response);
-int trg_http_perform(TrgClient * tc, trg_request *request, trg_response * rsp);
+void trg_response_free(trg_response *response);
+int trg_http_perform(TrgClient *tc, trg_request *request, trg_response *rsp);
 
 /* end http.h*/
 
 /* stuff that used to be in dispatch.c */
-trg_response *dispatch(TrgClient * tc, trg_request *req);
+trg_response *dispatch(TrgClient *tc, trg_request *req);
 trg_response *dispatch_public_http(TrgClient *tc, trg_request *req);
-gboolean dispatch_async(TrgClient * client, JsonNode * req,
-                        GSourceFunc callback, gpointer data);
-gboolean async_http_request(TrgClient *tc, gchar *url, const gchar *cookie, GSourceFunc callback, gpointer data);
+gboolean dispatch_async(TrgClient *client, JsonNode *req, GSourceFunc callback, gpointer data);
+gboolean async_http_request(TrgClient *tc, gchar *url, const gchar *cookie, GSourceFunc callback,
+                            gpointer data);
 
 /* end dispatch.c*/
 
 GType trg_client_get_type(void);
 
 TrgClient *trg_client_new(void);
-TrgPrefs *trg_client_get_prefs(TrgClient * tc);
-int trg_client_populate_with_settings(TrgClient * tc);
-void trg_client_set_session(TrgClient * tc, JsonObject * session);
-gdouble trg_client_get_version(TrgClient * tc);
-const gchar *trg_client_get_version_string(TrgClient * tc);
-gint64 trg_client_get_rpc_version(TrgClient * tc);
-gchar *trg_client_get_password(TrgClient * tc);
-gchar *trg_client_get_username(TrgClient * tc);
-gchar *trg_client_get_url(TrgClient * tc);
-gchar *trg_client_get_session_id(TrgClient * tc);
-void trg_client_set_session_id(TrgClient * tc, gchar * session_id);
+TrgPrefs *trg_client_get_prefs(TrgClient *tc);
+int trg_client_populate_with_settings(TrgClient *tc);
+void trg_client_set_session(TrgClient *tc, JsonObject *session);
+gdouble trg_client_get_version(TrgClient *tc);
+const gchar *trg_client_get_version_string(TrgClient *tc);
+gint64 trg_client_get_rpc_version(TrgClient *tc);
+gchar *trg_client_get_password(TrgClient *tc);
+gchar *trg_client_get_username(TrgClient *tc);
+gchar *trg_client_get_url(TrgClient *tc);
+gchar *trg_client_get_session_id(TrgClient *tc);
+void trg_client_set_session_id(TrgClient *tc, gchar *session_id);
 #ifndef CURL_NO_SSL
-gboolean trg_client_get_ssl(TrgClient * tc);
-gboolean trg_client_get_ssl_validate(TrgClient * tc);
+gboolean trg_client_get_ssl(TrgClient *tc);
+gboolean trg_client_get_ssl_validate(TrgClient *tc);
 #endif
-gchar *trg_client_get_proxy(TrgClient * tc);
-gint64 trg_client_get_serial(TrgClient * tc);
-void trg_client_thread_pool_push(TrgClient * tc, gpointer data,
-                                 GError ** err);
-void trg_client_set_torrent_table(TrgClient * tc, GHashTable * table);
-GHashTable *trg_client_get_torrent_table(TrgClient * tc);
-JsonObject *trg_client_get_session(TrgClient * tc);
-void trg_client_status_change(TrgClient * tc, gboolean connected);
-gboolean trg_client_is_connected(TrgClient * tc);
-void trg_client_configunlock(TrgClient * tc);
-void trg_client_configlock(TrgClient * tc);
-guint trg_client_inc_failcount(TrgClient * tc);
-guint trg_client_get_failcount(TrgClient * tc);
-void trg_client_reset_failcount(TrgClient * tc);
-void trg_client_inc_serial(TrgClient * tc);
-void trg_client_inc_connid(TrgClient * tc);
-gboolean trg_client_update_session(TrgClient * tc, GSourceFunc callback,
-                                   gpointer data);
-gboolean trg_client_get_seed_ratio_limited(TrgClient * tc);
-gdouble trg_client_get_seed_ratio_limit(TrgClient * tc);
+gchar *trg_client_get_proxy(TrgClient *tc);
+gint64 trg_client_get_serial(TrgClient *tc);
+void trg_client_thread_pool_push(TrgClient *tc, gpointer data, GError **err);
+void trg_client_set_torrent_table(TrgClient *tc, GHashTable *table);
+GHashTable *trg_client_get_torrent_table(TrgClient *tc);
+JsonObject *trg_client_get_session(TrgClient *tc);
+void trg_client_status_change(TrgClient *tc, gboolean connected);
+gboolean trg_client_is_connected(TrgClient *tc);
+void trg_client_configunlock(TrgClient *tc);
+void trg_client_configlock(TrgClient *tc);
+guint trg_client_inc_failcount(TrgClient *tc);
+guint trg_client_get_failcount(TrgClient *tc);
+void trg_client_reset_failcount(TrgClient *tc);
+void trg_client_inc_serial(TrgClient *tc);
+void trg_client_inc_connid(TrgClient *tc);
+gboolean trg_client_update_session(TrgClient *tc, GSourceFunc callback, gpointer data);
+gboolean trg_client_get_seed_ratio_limited(TrgClient *tc);
+gdouble trg_client_get_seed_ratio_limit(TrgClient *tc);
 
 G_END_DECLS
-#endif                          /* _TRG_CLIENT_H_ */
+#endif /* _TRG_CLIENT_H_ */

--- a/src/trg-destination-combo.c
+++ b/src/trg-destination-combo.c
@@ -22,10 +22,10 @@
 #include <glib/gi18n.h>
 #include <gtk/gtk.h>
 
-#include "trg-client.h"
 #include "torrent.h"
-#include "trg-torrent-model.h"
+#include "trg-client.h"
 #include "trg-destination-combo.h"
+#include "trg-torrent-model.h"
 #include "util.h"
 
 struct _TrgDestinationCombo {
@@ -37,35 +37,39 @@ typedef struct {
     gchar *last_selection;
 } TrgDestinationComboPrivate;
 
-G_DEFINE_TYPE_WITH_PRIVATE(TrgDestinationCombo, trg_destination_combo,
-              GTK_TYPE_COMBO_BOX)
+G_DEFINE_TYPE_WITH_PRIVATE(TrgDestinationCombo, trg_destination_combo, GTK_TYPE_COMBO_BOX)
 
 enum {
-    PROP_0, PROP_CLIENT, PROP_LAST_SELECTION
+    PROP_0,
+    PROP_CLIENT,
+    PROP_LAST_SELECTION
 };
 
 enum {
-    DEST_DEFAULT, DEST_LABEL, DEST_EXISTING
+    DEST_DEFAULT,
+    DEST_LABEL,
+    DEST_EXISTING
 };
 
 enum {
-    DEST_COLUMN_LABEL, DEST_COLUMN_DIR, DEST_COLUMN_TYPE, N_DEST_COLUMNS
+    DEST_COLUMN_LABEL,
+    DEST_COLUMN_DIR,
+    DEST_COLUMN_TYPE,
+    N_DEST_COLUMNS
 };
 
-static void trg_destination_combo_finalize(GObject * object)
+static void trg_destination_combo_finalize(GObject *object)
 {
-    TrgDestinationComboPrivate *priv =
-        trg_destination_combo_get_instance_private(TRG_DESTINATION_COMBO(object));
+    TrgDestinationComboPrivate *priv
+        = trg_destination_combo_get_instance_private(TRG_DESTINATION_COMBO(object));
     g_free(priv->last_selection);
 }
 
-static void
-trg_destination_combo_get_property(GObject * object,
-                                   guint property_id,
-                                   GValue * value, GParamSpec * pspec)
+static void trg_destination_combo_get_property(GObject *object, guint property_id, GValue *value,
+                                               GParamSpec *pspec)
 {
-    TrgDestinationComboPrivate *priv =
-        trg_destination_combo_get_instance_private(TRG_DESTINATION_COMBO(object));
+    TrgDestinationComboPrivate *priv
+        = trg_destination_combo_get_instance_private(TRG_DESTINATION_COMBO(object));
     switch (property_id) {
     case PROP_CLIENT:
         g_value_set_pointer(value, priv->client);
@@ -79,14 +83,11 @@ trg_destination_combo_get_property(GObject * object,
     }
 }
 
-static void
-trg_destination_combo_set_property(GObject * object,
-                                   guint property_id,
-                                   const GValue * value,
-                                   GParamSpec * pspec)
+static void trg_destination_combo_set_property(GObject *object, guint property_id,
+                                               const GValue *value, GParamSpec *pspec)
 {
-    TrgDestinationComboPrivate *priv =
-        trg_destination_combo_get_instance_private(TRG_DESTINATION_COMBO(object));
+    TrgDestinationComboPrivate *priv
+        = trg_destination_combo_get_instance_private(TRG_DESTINATION_COMBO(object));
     switch (property_id) {
     case PROP_CLIENT:
         priv->client = g_value_get_pointer(value);
@@ -100,50 +101,43 @@ trg_destination_combo_set_property(GObject * object,
     }
 }
 
-static gboolean g_slist_str_set_add(GSList ** list, const gchar * string)
+static gboolean g_slist_str_set_add(GSList **list, const gchar *string)
 {
     GSList *li;
     for (li = *list; li; li = g_slist_next(li))
-        if (!g_strcmp0((gchar *) li->data, string))
+        if (!g_strcmp0((gchar *)li->data, string))
             return FALSE;
 
-    *list = g_slist_insert_sorted(*list, (gpointer) string,
-                                  (GCompareFunc) g_strcmp0);
+    *list = g_slist_insert_sorted(*list, (gpointer)string, (GCompareFunc)g_strcmp0);
 
     return TRUE;
 }
 
-void trg_destination_combo_save_selection(TrgDestinationCombo * combo_box)
+void trg_destination_combo_save_selection(TrgDestinationCombo *combo_box)
 {
-    TrgDestinationComboPrivate *priv =
-        trg_destination_combo_get_instance_private(combo_box);
+    TrgDestinationComboPrivate *priv = trg_destination_combo_get_instance_private(combo_box);
     GtkTreeIter iter;
 
-    if (priv->last_selection
-        && gtk_combo_box_get_active_iter(GTK_COMBO_BOX(combo_box), &iter))
-    {
-        GtkTreeModel *model =
-            gtk_combo_box_get_model(GTK_COMBO_BOX(combo_box));
+    if (priv->last_selection && gtk_combo_box_get_active_iter(GTK_COMBO_BOX(combo_box), &iter)) {
+        GtkTreeModel *model = gtk_combo_box_get_model(GTK_COMBO_BOX(combo_box));
         TrgPrefs *prefs = trg_client_get_prefs(priv->client);
         gchar *text;
 
         gtk_tree_model_get(model, &iter, DEST_COLUMN_DIR, &text, -1);
-        trg_prefs_set_string(prefs, priv->last_selection, text,
-                             TRG_PREFS_CONNECTION);
+        trg_prefs_set_string(prefs, priv->last_selection, text, TRG_PREFS_CONNECTION);
         g_free(text);
     }
 }
 
-static inline GtkEntry *trg_destination_combo_get_entry(TrgDestinationCombo * combo)
+static inline GtkEntry *trg_destination_combo_get_entry(TrgDestinationCombo *combo)
 {
     return GTK_ENTRY(gtk_bin_get_child(GTK_BIN(combo)));
 }
 
-gboolean trg_destination_combo_has_text(TrgDestinationCombo * combo)
+gboolean trg_destination_combo_has_text(TrgDestinationCombo *combo)
 {
-    const gchar *text =
-        gtk_entry_get_text(trg_destination_combo_get_entry
-                           (TRG_DESTINATION_COMBO(combo)));
+    const gchar *text
+        = gtk_entry_get_text(trg_destination_combo_get_entry(TRG_DESTINATION_COMBO(combo)));
     return strlen(text) > 0;
 }
 
@@ -152,12 +146,10 @@ struct findDupeArg {
     gboolean isDupe;
 };
 
-static gboolean
-trg_destination_combo_insert_check_dupe_foreach(GtkTreeModel * model,
-                                                GtkTreePath *
-                                                path G_GNUC_UNUSED,
-                                                GtkTreeIter * iter,
-                                                struct findDupeArg *args)
+static gboolean trg_destination_combo_insert_check_dupe_foreach(GtkTreeModel *model,
+                                                                GtkTreePath *path G_GNUC_UNUSED,
+                                                                GtkTreeIter *iter,
+                                                                struct findDupeArg *args)
 {
     gchar *existing;
     gtk_tree_model_get(model, iter, DEST_COLUMN_DIR, &existing, -1);
@@ -166,11 +158,8 @@ trg_destination_combo_insert_check_dupe_foreach(GtkTreeModel * model,
     return args->isDupe;
 }
 
-static void
-trg_destination_combo_insert(GtkComboBox * box,
-                             const gchar * label,
-                             const gchar * dir,
-                             guint         type)
+static void trg_destination_combo_insert(GtkComboBox *box, const gchar *label, const gchar *dir,
+                                         guint type)
 {
     GtkTreeModel *model = gtk_combo_box_get_model(box);
     gchar *comboLabel;
@@ -179,25 +168,21 @@ trg_destination_combo_insert(GtkComboBox * box,
         struct findDupeArg args;
         args.isDupe = FALSE;
         args.dir = dir;
-        gtk_tree_model_foreach(GTK_TREE_MODEL(model),
-                               (GtkTreeModelForeachFunc)
-                               trg_destination_combo_insert_check_dupe_foreach,
-                               &args);
+        gtk_tree_model_foreach(
+            GTK_TREE_MODEL(model),
+            (GtkTreeModelForeachFunc)trg_destination_combo_insert_check_dupe_foreach, &args);
         if (args.isDupe)
             return;
     }
 
-    comboLabel =
-        label ? g_strdup_printf("%s (%s)", label, dir) : g_strdup(dir);
+    comboLabel = label ? g_strdup_printf("%s (%s)", label, dir) : g_strdup(dir);
 
-    gtk_list_store_insert_with_values(GTK_LIST_STORE(model), NULL, -1,
-                                      DEST_COLUMN_LABEL, comboLabel,
-                                      DEST_COLUMN_DIR, dir,
-                                      DEST_COLUMN_TYPE, type, -1);
+    gtk_list_store_insert_with_values(GTK_LIST_STORE(model), NULL, -1, DEST_COLUMN_LABEL,
+                                      comboLabel, DEST_COLUMN_DIR, dir, DEST_COLUMN_TYPE, type, -1);
     g_free(comboLabel);
 }
 
-gchar *trg_destination_combo_get_dir(TrgDestinationCombo * combo)
+gchar *trg_destination_combo_get_dir(TrgDestinationCombo *combo)
 {
     GtkTreeModel *model = gtk_combo_box_get_model(GTK_COMBO_BOX(combo));
     GtkTreeIter iter;
@@ -214,13 +199,10 @@ gchar *trg_destination_combo_get_dir(TrgDestinationCombo * combo)
         }
     }
 
-    return
-        g_strdup(gtk_entry_get_text
-                 (trg_destination_combo_get_entry(combo)));
+    return g_strdup(gtk_entry_get_text(trg_destination_combo_get_entry(combo)));
 }
 
-static void
-load_directory_model(TrgDestinationCombo *self)
+static void load_directory_model(TrgDestinationCombo *self)
 {
     TrgDestinationComboPrivate *priv = trg_destination_combo_get_instance_private(self);
     TrgClient *client = priv->client;
@@ -233,37 +215,28 @@ load_directory_model(TrgDestinationCombo *self)
     gchar *defaultDir;
 
     /* Add default dir */
-    defaultDir =
-        g_strdup(session_get_download_dir(trg_client_get_session(client)));
+    defaultDir = g_strdup(session_get_download_dir(trg_client_get_session(client)));
     rm_trailing_slashes(defaultDir);
 
-    trg_destination_combo_insert(GTK_COMBO_BOX(self),
-                                 NULL,
-                                 defaultDir, DEST_DEFAULT);
-    g_free (defaultDir);
-
+    trg_destination_combo_insert(GTK_COMBO_BOX(self), NULL, defaultDir, DEST_DEFAULT);
+    g_free(defaultDir);
 
     /* Add saved dirs */
-    savedDestinations =
-        trg_prefs_get_array(prefs, TRG_PREFS_KEY_DESTINATIONS,
-                            TRG_PREFS_CONNECTION);
+    savedDestinations
+        = trg_prefs_get_array(prefs, TRG_PREFS_KEY_DESTINATIONS, TRG_PREFS_CONNECTION);
     if (savedDestinations) {
         list = json_array_get_elements(savedDestinations);
         if (list) {
             for (li = list; li; li = g_list_next(li)) {
-                JsonObject *obj =
-                    json_node_get_object((JsonNode *) li->data);
-                trg_destination_combo_insert(GTK_COMBO_BOX(self),
-                                             json_object_get_string_member
-                                                 (obj, TRG_PREFS_SUBKEY_LABEL),
-                                            json_object_get_string_member
-                                                 (obj, TRG_PREFS_KEY_DESTINATIONS_SUBKEY_DIR),
-                                             DEST_LABEL);
+                JsonObject *obj = json_node_get_object((JsonNode *)li->data);
+                trg_destination_combo_insert(
+                    GTK_COMBO_BOX(self), json_object_get_string_member(obj, TRG_PREFS_SUBKEY_LABEL),
+                    json_object_get_string_member(obj, TRG_PREFS_KEY_DESTINATIONS_SUBKEY_DIR),
+                    DEST_LABEL);
             }
             g_list_free(list);
         }
     }
-
 
     /* Add all previously used download dirs */
     list = g_hash_table_get_values(trg_client_get_torrent_table(client));
@@ -272,7 +245,7 @@ load_directory_model(TrgDestinationCombo *self)
         GtkTreeModel *model;
         GtkTreePath *path;
 
-        rr = (GtkTreeRowReference *) li->data;
+        rr = (GtkTreeRowReference *)li->data;
         model = gtk_tree_row_reference_get_model(rr);
         path = gtk_tree_row_reference_get_path(rr);
 
@@ -282,8 +255,7 @@ load_directory_model(TrgDestinationCombo *self)
             if (gtk_tree_model_get_iter(model, &iter, path)) {
                 gchar *dd;
 
-                gtk_tree_model_get(model, &iter,
-                                   TORRENT_COLUMN_DOWNLOADDIR, &dd, -1);
+                gtk_tree_model_get(model, &iter, TORRENT_COLUMN_DOWNLOADDIR, &dd, -1);
 
                 if (dd && g_strcmp0(dd, defaultDir))
                     g_slist_str_set_add(&dirs, dd);
@@ -296,52 +268,46 @@ load_directory_model(TrgDestinationCombo *self)
     }
 
     for (sli = dirs; sli; sli = g_slist_next(sli))
-        trg_destination_combo_insert(GTK_COMBO_BOX(self),
-                                     NULL,
-                                     (gchar *) sli->data,
-                                     DEST_EXISTING);
+        trg_destination_combo_insert(GTK_COMBO_BOX(self), NULL, (gchar *)sli->data, DEST_EXISTING);
 
-    g_slist_free_full (dirs, g_free);
+    g_slist_free_full(dirs, g_free);
     g_list_free(list);
 }
 
 static void set_text_column(GtkCellLayout *layout, guint col)
 {
-    GList *cells = gtk_cell_layout_get_cells (layout);
-    g_assert (cells != NULL);
-    gtk_cell_layout_set_attributes (layout, GTK_CELL_RENDERER(cells->data), "text", col, NULL);
-    g_list_free (cells);
+    GList *cells = gtk_cell_layout_get_cells(layout);
+    g_assert(cells != NULL);
+    gtk_cell_layout_set_attributes(layout, GTK_CELL_RENDERER(cells->data), "text", col, NULL);
+    g_list_free(cells);
 }
 
 static void trg_destination_combo_constructed(GObject *object)
 {
-    TrgDestinationCombo *self = TRG_DESTINATION_COMBO (object);
-    TrgDestinationComboPrivate *priv =
-        trg_destination_combo_get_instance_private(self);
+    TrgDestinationCombo *self = TRG_DESTINATION_COMBO(object);
+    TrgDestinationComboPrivate *priv = trg_destination_combo_get_instance_private(self);
     TrgPrefs *prefs = trg_client_get_prefs(priv->client);
 
     G_OBJECT_CLASS(trg_destination_combo_parent_class)->constructed(object);
 
-    load_directory_model (self);
-    set_text_column (GTK_CELL_LAYOUT(self), DEST_COLUMN_LABEL);
+    load_directory_model(self);
+    set_text_column(GTK_CELL_LAYOUT(self), DEST_COLUMN_LABEL);
 
     /* Must be set after constructed */
     if (priv->last_selection) {
         /* Restore any previous selection */
-        char *lastDestination = trg_prefs_get_string(prefs, priv->last_selection,
-                                               TRG_PREFS_CONNECTION);
-        if (!gtk_combo_box_set_active_id (GTK_COMBO_BOX(object), lastDestination))
-            g_warning ("Last selection was not a valid ID");
+        char *lastDestination
+            = trg_prefs_get_string(prefs, priv->last_selection, TRG_PREFS_CONNECTION);
+        if (!gtk_combo_box_set_active_id(GTK_COMBO_BOX(object), lastDestination))
+            g_warning("Last selection was not a valid ID");
         g_free(lastDestination);
-    }
-    else {
+    } else {
         /* DefaultDir is the first item otherwise */
-        gtk_combo_box_set_active (GTK_COMBO_BOX(object), 0);
+        gtk_combo_box_set_active(GTK_COMBO_BOX(object), 0);
     }
 }
 
-static void
-trg_destination_combo_class_init(TrgDestinationComboClass * klass)
+static void trg_destination_combo_class_init(TrgDestinationComboClass *klass)
 {
     GObjectClass *object_class = G_OBJECT_CLASS(klass);
 
@@ -350,43 +316,30 @@ trg_destination_combo_class_init(TrgDestinationComboClass * klass)
     object_class->finalize = trg_destination_combo_finalize;
     object_class->constructed = trg_destination_combo_constructed;
 
-    g_object_class_install_property(object_class,
-                                    PROP_CLIENT,
-                                    g_param_spec_pointer("trg-client",
-                                                         "TClient",
-                                                         "Client",
-                                                         G_PARAM_READWRITE |
-                                                         G_PARAM_CONSTRUCT_ONLY |
-                                                         G_PARAM_STATIC_STRINGS));
+    g_object_class_install_property(
+        object_class, PROP_CLIENT,
+        g_param_spec_pointer("trg-client", "TClient", "Client",
+                             G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS));
 
-    g_object_class_install_property(object_class,
-                                    PROP_LAST_SELECTION,
-                                    g_param_spec_string
-                                    ("last-selection-key",
-                                     "LastSelectionKey",
-                                     "LastSelectionKey", NULL,
-                                     G_PARAM_READWRITE |
-                                     G_PARAM_CONSTRUCT_ONLY |
-                                     G_PARAM_STATIC_STRINGS));
+    g_object_class_install_property(
+        object_class, PROP_LAST_SELECTION,
+        g_param_spec_string("last-selection-key", "LastSelectionKey", "LastSelectionKey", NULL,
+                            G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS));
 }
 
-static void trg_destination_combo_init(TrgDestinationCombo * self)
+static void trg_destination_combo_init(TrgDestinationCombo *self)
 {
     GtkListStore *store;
 
     store = gtk_list_store_new(N_DEST_COLUMNS, G_TYPE_STRING, G_TYPE_STRING, G_TYPE_UINT);
     gtk_combo_box_set_model(GTK_COMBO_BOX(self), GTK_TREE_MODEL(store));
-    gtk_combo_box_set_id_column (GTK_COMBO_BOX(self), DEST_COLUMN_DIR);
-    gtk_combo_box_set_entry_text_column (GTK_COMBO_BOX(self), DEST_COLUMN_LABEL);
+    gtk_combo_box_set_id_column(GTK_COMBO_BOX(self), DEST_COLUMN_DIR);
+    gtk_combo_box_set_entry_text_column(GTK_COMBO_BOX(self), DEST_COLUMN_LABEL);
     g_object_unref(store);
 }
 
-GtkWidget *trg_destination_combo_new(TrgClient * client,
-                                     const gchar * lastSelectionKey)
+GtkWidget *trg_destination_combo_new(TrgClient *client, const gchar *lastSelectionKey)
 {
-    return GTK_WIDGET(g_object_new(TRG_TYPE_DESTINATION_COMBO,
-                                   "has-entry", TRUE,
-                                   "trg-client", client,
-                                   "last-selection-key", lastSelectionKey,
-                                   NULL));
+    return GTK_WIDGET(g_object_new(TRG_TYPE_DESTINATION_COMBO, "has-entry", TRUE, "trg-client",
+                                   client, "last-selection-key", lastSelectionKey, NULL));
 }

--- a/src/trg-destination-combo.h
+++ b/src/trg-destination-combo.h
@@ -28,13 +28,13 @@
 G_BEGIN_DECLS
 
 #define TRG_TYPE_DESTINATION_COMBO (trg_destination_combo_get_type())
-G_DECLARE_FINAL_TYPE(TrgDestinationCombo, trg_destination_combo, TRG, DESTINATION_COMBO, GtkComboBox)
+G_DECLARE_FINAL_TYPE(TrgDestinationCombo, trg_destination_combo, TRG, DESTINATION_COMBO,
+                     GtkComboBox)
 
-GtkWidget *trg_destination_combo_new(TrgClient * client,
-                                     const gchar * lastSelectionKey);
-gchar *trg_destination_combo_get_dir(TrgDestinationCombo * combo);
-gboolean trg_destination_combo_has_text(TrgDestinationCombo * combo);
-void trg_destination_combo_save_selection(TrgDestinationCombo * combo_box);
+GtkWidget *trg_destination_combo_new(TrgClient *client, const gchar *lastSelectionKey);
+gchar *trg_destination_combo_get_dir(TrgDestinationCombo *combo);
+gboolean trg_destination_combo_has_text(TrgDestinationCombo *combo);
+void trg_destination_combo_save_selection(TrgDestinationCombo *combo_box);
 
 G_END_DECLS
-#endif                          /* TRG_DESTINATION_COMBO_H_ */
+#endif /* TRG_DESTINATION_COMBO_H_ */

--- a/src/trg-file-parser.c
+++ b/src/trg-file-parser.c
@@ -28,13 +28,9 @@
 #include "bencode.h"
 #include "trg-file-parser.h"
 
-static trg_files_tree_node *trg_file_parser_node_insert(trg_files_tree_node
-                                                        * top,
-                                                        trg_files_tree_node
-                                                        * last,
-                                                        be_node *
-                                                        file_node,
-                                                        gint index)
+static trg_files_tree_node *trg_file_parser_node_insert(trg_files_tree_node *top,
+                                                        trg_files_tree_node *last,
+                                                        be_node *file_node, gint index)
 {
     be_node *file_length_node = be_dict_find(file_node, "length", BE_INT);
     be_node *file_path_list = be_dict_find(file_node, "path", BE_LIST);
@@ -62,7 +58,7 @@ static trg_files_tree_node *trg_file_parser_node_insert(trg_files_tree_node
         trg_files_tree_node *target_node = NULL;
 
         if (li && !isFile) {
-            trg_files_tree_node *lastPathNode = (trg_files_tree_node *) li->data;
+            trg_files_tree_node *lastPathNode = (trg_files_tree_node *)li->data;
 
             if (!g_strcmp0(lastPathNode->name, path_el_node->val.s)) {
                 target_node = lastPathNode;
@@ -73,7 +69,7 @@ static trg_files_tree_node *trg_file_parser_node_insert(trg_files_tree_node
         }
 
         if (!target_node && lastIter && lastIter->childrenHash && !isFile)
-          target_node = g_hash_table_lookup(lastIter->childrenHash, path_el_node->val.s);
+            target_node = g_hash_table_lookup(lastIter->childrenHash, path_el_node->val.s);
 
         if (!target_node) {
             target_node = g_new0(trg_files_tree_node, 1);
@@ -83,7 +79,7 @@ static trg_files_tree_node *trg_file_parser_node_insert(trg_files_tree_node
         }
 
         if (isFile) {
-            target_node->length = (gint64) file_length_node->val.i;
+            target_node->length = (gint64)file_length_node->val.i;
 
             while (lastIter) {
                 lastIter->length += target_node->length;
@@ -100,15 +96,14 @@ static trg_files_tree_node *trg_file_parser_node_insert(trg_files_tree_node
     return lastIter;
 }
 
-void trg_torrent_file_free(trg_torrent_file * t)
+void trg_torrent_file_free(trg_torrent_file *t)
 {
     trg_files_tree_node_free(t->top_node);
     g_free(t->name);
     g_free(t);
 }
 
-static trg_files_tree_node *trg_parse_torrent_file_nodes(be_node *
-                                                         info_node)
+static trg_files_tree_node *trg_parse_torrent_file_nodes(be_node *info_node)
 {
     be_node *files_node = be_dict_find(info_node, "files", BE_LIST);
     trg_files_tree_node *top_node = g_new0(trg_files_tree_node, 1);
@@ -123,9 +118,7 @@ static trg_files_tree_node *trg_parse_torrent_file_nodes(be_node *
         be_node *file_node = files_node->val.l[i];
 
         if (!be_validate_node(file_node, BE_DICT)
-            || !(lastNode =
-                 trg_file_parser_node_insert(top_node, lastNode,
-                                             file_node, i))) {
+            || !(lastNode = trg_file_parser_node_insert(top_node, lastNode, file_node, i))) {
             /* Unexpected format. Throw away everything, file indexes need to
              * be correct. */
             trg_files_tree_node_free(top_node);
@@ -136,9 +129,10 @@ static trg_files_tree_node *trg_parse_torrent_file_nodes(be_node *
     return top_node;
 }
 
-trg_torrent_file *trg_parse_torrent_data(const gchar *data, gsize length) {
-	trg_torrent_file *ret = NULL;
-	be_node *top_node, *info_node, *name_node;
+trg_torrent_file *trg_parse_torrent_data(const gchar *data, gsize length)
+{
+    trg_torrent_file *ret = NULL;
+    be_node *top_node, *info_node, *name_node;
 
     top_node = be_decoden(data, length);
 
@@ -171,17 +165,17 @@ trg_torrent_file *trg_parse_torrent_data(const gchar *data, gsize length) {
         }
 
         file_node = g_new0(trg_files_tree_node, 1);
-        file_node->length = (gint64) (length_node->val.i);
+        file_node->length = (gint64)(length_node->val.i);
         file_node->name = g_strdup(ret->name);
         ret->top_node = file_node;
     }
 
-  out:
+out:
     be_free(top_node);
     return ret;
 }
 
-trg_torrent_file *trg_parse_torrent_file(const gchar * filename)
+trg_torrent_file *trg_parse_torrent_file(const gchar *filename)
 {
     GError *error = NULL;
     trg_torrent_file *ret = NULL;

--- a/src/trg-file-parser.h
+++ b/src/trg-file-parser.h
@@ -24,6 +24,6 @@ typedef struct {
     trg_files_tree_node *top_node;
 } trg_torrent_file;
 
-void trg_torrent_file_free(trg_torrent_file * t);
-trg_torrent_file *trg_parse_torrent_file(const gchar * filename);
+void trg_torrent_file_free(trg_torrent_file *t);
+trg_torrent_file *trg_parse_torrent_file(const gchar *filename);
 trg_torrent_file *trg_parse_torrent_data(const gchar *data, gsize length);

--- a/src/trg-file-rename-dialog.c
+++ b/src/trg-file-rename-dialog.c
@@ -19,22 +19,21 @@
 
 #include "config.h"
 
-#include <string.h>
 #include <glib/gi18n.h>
 #include <gtk/gtk.h>
 #include <json-glib/json-glib.h>
+#include <string.h>
 
-#include "trg-client.h"
-#include "trg-main-window.h"
-#include "trg-file-rename-dialog.h"
-#include "trg-destination-combo.h"
 #include "hig.h"
 #include "requests.h"
+#include "trg-client.h"
+#include "trg-destination-combo.h"
+#include "trg-file-rename-dialog.h"
+#include "trg-main-window.h"
 
-G_DEFINE_TYPE(TrgFileRenameDialog, trg_file_rename_dialog,
-              GTK_TYPE_DIALOG)
-#define TRG_FILE_RENAME_DIALOG_GET_PRIVATE(o) \
-  (G_TYPE_INSTANCE_GET_PRIVATE ((o), TRG_TYPE_FILE_RENAME_DIALOG, TrgFileRenameDialogPrivate))
+G_DEFINE_TYPE(TrgFileRenameDialog, trg_file_rename_dialog, GTK_TYPE_DIALOG)
+#define TRG_FILE_RENAME_DIALOG_GET_PRIVATE(o)                                                      \
+    (G_TYPE_INSTANCE_GET_PRIVATE((o), TRG_TYPE_FILE_RENAME_DIALOG, TrgFileRenameDialogPrivate))
 typedef struct _TrgFileRenameDialogPrivate TrgFileRenameDialogPrivate;
 
 struct _TrgFileRenameDialogPrivate {
@@ -54,8 +53,7 @@ enum {
     PROP_TREEVIEW
 };
 
-static gchar *
-trg_file_rename_dialog_get_file_path(GtkTreeModel* model, const GtkTreeIter *iter)
+static gchar *trg_file_rename_dialog_get_file_path(GtkTreeModel *model, const GtkTreeIter *iter)
 {
     GtkTreeIter current = *iter;
     GtkTreeIter parent;
@@ -78,22 +76,18 @@ trg_file_rename_dialog_get_file_path(GtkTreeModel* model, const GtkTreeIter *ite
     return filepath;
 }
 
-static void
-trg_file_rename_response_cb(GtkDialog * dlg, gint res_id, gpointer data)
+static void trg_file_rename_response_cb(GtkDialog *dlg, gint res_id, gpointer data)
 {
-    TrgFileRenameDialogPrivate *priv =
-        TRG_FILE_RENAME_DIALOG_GET_PRIVATE(dlg);
+    TrgFileRenameDialogPrivate *priv = TRG_FILE_RENAME_DIALOG_GET_PRIVATE(dlg);
 
     if (res_id == GTK_RESPONSE_ACCEPT) {
         const gchar *name = gtk_entry_buffer_get_text(priv->name_entry_buf);
-        JsonNode *request = torrent_rename_path(priv->ids, priv->orig_path,
-                                                name);
+        JsonNode *request = torrent_rename_path(priv->ids, priv->orig_path, name);
 
         GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(priv->treeview));
         trg_files_model_set_accept(TRG_FILES_MODEL(model), FALSE);
 
-        dispatch_async(priv->client, request,
-                       on_files_update, priv->treeview);
+        dispatch_async(priv->client, request, on_files_update, priv->treeview);
     } else {
         g_free(priv->orig_path);
         json_array_unref(priv->ids);
@@ -101,27 +95,19 @@ trg_file_rename_response_cb(GtkDialog * dlg, gint res_id, gpointer data)
     gtk_widget_destroy(GTK_WIDGET(dlg));
 }
 
-static void location_changed(GtkComboBox * w, gpointer data)
+static void location_changed(GtkComboBox *w, gpointer data)
 {
-    TrgFileRenameDialogPrivate *priv =
-        TRG_FILE_RENAME_DIALOG_GET_PRIVATE(data);
+    TrgFileRenameDialogPrivate *priv = TRG_FILE_RENAME_DIALOG_GET_PRIVATE(data);
     gtk_widget_set_sensitive(priv->rename_button,
-                             gtk_entry_buffer_get_length
-                              (priv->name_entry_buf));
+                             gtk_entry_buffer_get_length(priv->name_entry_buf));
 }
 
-static GObject *trg_file_rename_dialog_constructor(GType type,
-                                                   guint
-                                                   n_construct_properties,
-                                                   GObjectConstructParam *
-                                                   construct_params)
+static GObject *trg_file_rename_dialog_constructor(GType type, guint n_construct_properties,
+                                                   GObjectConstructParam *construct_params)
 {
-    GObject *object = G_OBJECT_CLASS
-        (trg_file_rename_dialog_parent_class)->constructor(type,
-                                                            n_construct_properties,
-                                                            construct_params);
-    TrgFileRenameDialogPrivate *priv =
-        TRG_FILE_RENAME_DIALOG_GET_PRIVATE(object);
+    GObject *object = G_OBJECT_CLASS(trg_file_rename_dialog_parent_class)
+                          ->constructor(type, n_construct_properties, construct_params);
+    TrgFileRenameDialogPrivate *priv = TRG_FILE_RENAME_DIALOG_GET_PRIVATE(object);
 
     gint64 target_id;
     guint count;
@@ -143,7 +129,7 @@ static GObject *trg_file_rename_dialog_constructor(GType type,
     if (list) {
         GtkTreeIter iter;
 
-        gtk_tree_model_get_iter(model, &iter, (GtkTreePath *) list->data);
+        gtk_tree_model_get_iter(model, &iter, (GtkTreePath *)list->data);
         gtk_tree_model_get(model, &iter, FILESCOL_NAME, &orig_filename, -1);
 
         priv->orig_path = trg_file_rename_dialog_get_file_path(model, &iter);
@@ -156,37 +142,29 @@ static GObject *trg_file_rename_dialog_constructor(GType type,
 
     t = hig_workarea_create();
 
-    priv->name_entry_buf = gtk_entry_buffer_new(orig_filename,
-                                                strlen(orig_filename));
-    GtkWidget* name_entry = gtk_entry_new_with_buffer(priv->name_entry_buf);
+    priv->name_entry_buf = gtk_entry_buffer_new(orig_filename, strlen(orig_filename));
+    GtkWidget *name_entry = gtk_entry_new_with_buffer(priv->name_entry_buf);
     gtk_entry_set_activates_default(GTK_ENTRY(name_entry), TRUE);
 
-    g_signal_connect(name_entry, "changed",
-                     G_CALLBACK(location_changed), object);
+    g_signal_connect(name_entry, "changed", G_CALLBACK(location_changed), object);
     hig_workarea_add_row(t, &row, _("Name:"), name_entry, NULL);
 
     gtk_window_set_destroy_with_parent(GTK_WINDOW(object), TRUE);
 
-    gtk_dialog_add_button(GTK_DIALOG(object), _("_Close"),
-                          GTK_RESPONSE_CANCEL);
-    priv->rename_button =
-        gtk_dialog_add_button(GTK_DIALOG(object), _("Rename"),
-                              GTK_RESPONSE_ACCEPT);
+    gtk_dialog_add_button(GTK_DIALOG(object), _("_Close"), GTK_RESPONSE_CANCEL);
+    priv->rename_button
+        = gtk_dialog_add_button(GTK_DIALOG(object), _("Rename"), GTK_RESPONSE_ACCEPT);
 
     gtk_widget_set_sensitive(priv->rename_button,
-                             gtk_entry_buffer_get_length
-                              (priv->name_entry_buf));
+                             gtk_entry_buffer_get_length(priv->name_entry_buf));
 
     gtk_container_set_border_width(GTK_CONTAINER(object), GUI_PAD);
 
-    gtk_dialog_set_default_response(GTK_DIALOG(object),
-                                    GTK_RESPONSE_ACCEPT);
- 
+    gtk_dialog_set_default_response(GTK_DIALOG(object), GTK_RESPONSE_ACCEPT);
+
     gtk_container_set_border_width(GTK_CONTAINER(t), GUI_PAD);
 
-    gtk_box_pack_start(GTK_BOX
-                       (gtk_dialog_get_content_area(GTK_DIALOG(object))),
-                       t, TRUE, TRUE, 0);
+    gtk_box_pack_start(GTK_BOX(gtk_dialog_get_content_area(GTK_DIALOG(object))), t, TRUE, TRUE, 0);
 
     target_id = trg_files_model_get_torrent_id(TRG_FILES_MODEL(model));
     priv->ids = json_array_new();
@@ -197,33 +175,28 @@ static GObject *trg_file_rename_dialog_constructor(GType type,
     } else {
         /* this really shouldn't happen since TrgFilesTreeView checks number of
          * selected files before allowing rename */
-        msg = g_strdup_printf(_("INTERNAL ERROR: Rename %d files not supported"),
-                              count);
+        msg = g_strdup_printf(_("INTERNAL ERROR: Rename %d files not supported"), count);
         gtk_widget_set_sensitive(priv->rename_button, FALSE);
         gtk_widget_set_sensitive(name_entry, FALSE);
     }
 
-    gtk_window_set_transient_for(GTK_WINDOW(object),
-                                 GTK_WINDOW(priv->win));
+    gtk_window_set_transient_for(GTK_WINDOW(object), GTK_WINDOW(priv->win));
     gtk_window_set_title(GTK_WINDOW(object), msg);
 
-    g_signal_connect(G_OBJECT(object),
-                     "response",
-                     G_CALLBACK(trg_file_rename_response_cb), priv->win);
+    g_signal_connect(G_OBJECT(object), "response", G_CALLBACK(trg_file_rename_response_cb),
+                     priv->win);
 
     g_free(msg);
     g_free(orig_filename);
-    g_list_free_full(list, (GDestroyNotify) gtk_tree_path_free);
+    g_list_free_full(list, (GDestroyNotify)gtk_tree_path_free);
 
     return object;
 }
 
-static void
-trg_file_rename_dialog_get_property(GObject * object, guint property_id,
-                                     GValue * value, GParamSpec * pspec)
+static void trg_file_rename_dialog_get_property(GObject *object, guint property_id, GValue *value,
+                                                GParamSpec *pspec)
 {
-    TrgFileRenameDialogPrivate *priv =
-        TRG_FILE_RENAME_DIALOG_GET_PRIVATE(object);
+    TrgFileRenameDialogPrivate *priv = TRG_FILE_RENAME_DIALOG_GET_PRIVATE(object);
     switch (property_id) {
     case PROP_CLIENT:
         g_value_set_pointer(value, priv->client);
@@ -240,13 +213,10 @@ trg_file_rename_dialog_get_property(GObject * object, guint property_id,
     }
 }
 
-static void
-trg_file_rename_dialog_set_property(GObject * object, guint property_id,
-                                     const GValue * value,
-                                     GParamSpec * pspec)
+static void trg_file_rename_dialog_set_property(GObject *object, guint property_id,
+                                                const GValue *value, GParamSpec *pspec)
 {
-    TrgFileRenameDialogPrivate *priv =
-        TRG_FILE_RENAME_DIALOG_GET_PRIVATE(object);
+    TrgFileRenameDialogPrivate *priv = TRG_FILE_RENAME_DIALOG_GET_PRIVATE(object);
     switch (property_id) {
     case PROP_CLIENT:
         priv->client = g_value_get_pointer(value);
@@ -263,8 +233,7 @@ trg_file_rename_dialog_set_property(GObject * object, guint property_id,
     }
 }
 
-static void
-trg_file_rename_dialog_class_init(TrgFileRenameDialogClass * klass)
+static void trg_file_rename_dialog_class_init(TrgFileRenameDialogClass *klass)
 {
     GObjectClass *object_class = G_OBJECT_CLASS(klass);
 
@@ -274,52 +243,33 @@ trg_file_rename_dialog_class_init(TrgFileRenameDialogClass * klass)
     object_class->set_property = trg_file_rename_dialog_set_property;
     object_class->constructor = trg_file_rename_dialog_constructor;
 
-    g_object_class_install_property(object_class,
-                                    PROP_TREEVIEW,
-                                    g_param_spec_object
-                                    ("files-tree-view",
-                                     "TrgFilesTreeView",
-                                     "TrgFilesTreeView",
-                                     TRG_TYPE_FILES_TREE_VIEW,
-                                     G_PARAM_READWRITE |
-                                     G_PARAM_CONSTRUCT_ONLY |
-                                     G_PARAM_STATIC_NAME |
-                                     G_PARAM_STATIC_NICK |
-                                     G_PARAM_STATIC_BLURB));
+    g_object_class_install_property(
+        object_class, PROP_TREEVIEW,
+        g_param_spec_object("files-tree-view", "TrgFilesTreeView", "TrgFilesTreeView",
+                            TRG_TYPE_FILES_TREE_VIEW,
+                            G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME
+                                | G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
 
-    g_object_class_install_property(object_class,
-                                    PROP_PARENT_WINDOW,
-                                    g_param_spec_object
-                                    ("parent-window", "Parent window",
-                                     "Parent window", TRG_TYPE_MAIN_WINDOW,
-                                     G_PARAM_READWRITE |
-                                     G_PARAM_CONSTRUCT_ONLY |
-                                     G_PARAM_STATIC_NAME |
-                                     G_PARAM_STATIC_NICK |
-                                     G_PARAM_STATIC_BLURB));
+    g_object_class_install_property(
+        object_class, PROP_PARENT_WINDOW,
+        g_param_spec_object("parent-window", "Parent window", "Parent window", TRG_TYPE_MAIN_WINDOW,
+                            G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME
+                                | G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
 
-    g_object_class_install_property(object_class,
-                                    PROP_CLIENT,
-                                    g_param_spec_pointer
-                                    ("trg-client", "TClient",
-                                     "Client",
-                                     G_PARAM_READWRITE |
-                                     G_PARAM_CONSTRUCT_ONLY |
-                                     G_PARAM_STATIC_NAME |
-                                     G_PARAM_STATIC_NICK |
-                                     G_PARAM_STATIC_BLURB));
+    g_object_class_install_property(
+        object_class, PROP_CLIENT,
+        g_param_spec_pointer("trg-client", "TClient", "Client",
+                             G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME
+                                 | G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
 }
 
-static void trg_file_rename_dialog_init(TrgFileRenameDialog * self)
+static void trg_file_rename_dialog_init(TrgFileRenameDialog *self)
 {
 }
 
-TrgFileRenameDialog *trg_file_rename_dialog_new(TrgMainWindow * win,
-                                                  TrgClient * client,
-                                                  TrgFilesTreeView * ttv)
+TrgFileRenameDialog *trg_file_rename_dialog_new(TrgMainWindow *win, TrgClient *client,
+                                                TrgFilesTreeView *ttv)
 {
-    return g_object_new(TRG_TYPE_FILE_RENAME_DIALOG,
-                        "trg-client", client,
-                        "files-tree-view", ttv, "parent-window", win,
-                        NULL);
+    return g_object_new(TRG_TYPE_FILE_RENAME_DIALOG, "trg-client", client, "files-tree-view", ttv,
+                        "parent-window", win, NULL);
 }

--- a/src/trg-file-rename-dialog.h
+++ b/src/trg-file-rename-dialog.h
@@ -24,21 +24,21 @@
 #include <gtk/gtk.h>
 
 #include "trg-client.h"
-#include "trg-main-window.h"
 #include "trg-files-tree-view.h"
+#include "trg-main-window.h"
 
 G_BEGIN_DECLS
 #define TRG_TYPE_FILE_RENAME_DIALOG trg_file_rename_dialog_get_type()
-#define TRG_FILE_RENAME_DIALOG(obj) \
-  (G_TYPE_CHECK_INSTANCE_CAST ((obj), TRG_TYPE_FILE_RENAME_DIALOG, TrgFileRenameDialog))
-#define TRG_FILE_RENAME_DIALOG_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_CAST ((klass), TRG_TYPE_FILE_RENAME_DIALOG, TrgFileRenameDialogClass))
-#define TRG_IS_FILE_RENAME_DIALOG(obj) \
-  (G_TYPE_CHECK_INSTANCE_TYPE ((obj), TRG_TYPE_FILE_RENAME_DIALOG))
-#define TRG_IS_FILE_RENAME_DIALOG_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_TYPE ((klass), TRG_TYPE_FILE_RENAME_DIALOG))
-#define TRG_FILE_RENAME_DIALOG_GET_CLASS(obj) \
-  (G_TYPE_INSTANCE_GET_CLASS ((obj), TRG_TYPE_FILE_RENAME_DIALOG, TrgFileRenameDialogClass))
+#define TRG_FILE_RENAME_DIALOG(obj)                                                                \
+    (G_TYPE_CHECK_INSTANCE_CAST((obj), TRG_TYPE_FILE_RENAME_DIALOG, TrgFileRenameDialog))
+#define TRG_FILE_RENAME_DIALOG_CLASS(klass)                                                        \
+    (G_TYPE_CHECK_CLASS_CAST((klass), TRG_TYPE_FILE_RENAME_DIALOG, TrgFileRenameDialogClass))
+#define TRG_IS_FILE_RENAME_DIALOG(obj)                                                             \
+    (G_TYPE_CHECK_INSTANCE_TYPE((obj), TRG_TYPE_FILE_RENAME_DIALOG))
+#define TRG_IS_FILE_RENAME_DIALOG_CLASS(klass)                                                     \
+    (G_TYPE_CHECK_CLASS_TYPE((klass), TRG_TYPE_FILE_RENAME_DIALOG))
+#define TRG_FILE_RENAME_DIALOG_GET_CLASS(obj)                                                      \
+    (G_TYPE_INSTANCE_GET_CLASS((obj), TRG_TYPE_FILE_RENAME_DIALOG, TrgFileRenameDialogClass))
 
 typedef struct {
     GtkDialog parent;
@@ -50,10 +50,8 @@ typedef struct {
 
 GType trg_file_rename_dialog_get_type(void);
 
-TrgFileRenameDialog *trg_file_rename_dialog_new(TrgMainWindow * win,
-                                                TrgClient * client,
-                                                TrgFilesTreeView *
-                                                ttv);
+TrgFileRenameDialog *trg_file_rename_dialog_new(TrgMainWindow *win, TrgClient *client,
+                                                TrgFilesTreeView *ttv);
 
 G_END_DECLS
-#endif                          /* TRG_FILE_RENAME_DIALOG_H_ */
+#endif /* TRG_FILE_RENAME_DIALOG_H_ */

--- a/src/trg-files-model-common.c
+++ b/src/trg-files-model-common.c
@@ -34,40 +34,31 @@ struct SubtreeForeachData {
     GtkTreePath *path;
 };
 
-static void
-set_wanted_foreachfunc(GtkTreeModel * model,
-                       GtkTreePath * path G_GNUC_UNUSED,
-                       GtkTreeIter * iter, gpointer data)
+static void set_wanted_foreachfunc(GtkTreeModel *model, GtkTreePath *path G_GNUC_UNUSED,
+                                   GtkTreeIter *iter, gpointer data)
 {
-    struct SubtreeForeachData *args = (struct SubtreeForeachData *) data;
+    struct SubtreeForeachData *args = (struct SubtreeForeachData *)data;
 
-    gtk_tree_store_set(GTK_TREE_STORE(model), iter, args->column,
-                       args->new_value, -1);
+    gtk_tree_store_set(GTK_TREE_STORE(model), iter, args->column, args->new_value, -1);
 
-    trg_files_tree_model_set_subtree(model, path, iter, args->column,
-                                     args->new_value);
+    trg_files_tree_model_set_subtree(model, path, iter, args->column, args->new_value);
 }
 
-static void
-set_priority_foreachfunc(GtkTreeModel * model,
-                         GtkTreePath * path,
-                         GtkTreeIter * iter, gpointer data)
+static void set_priority_foreachfunc(GtkTreeModel *model, GtkTreePath *path, GtkTreeIter *iter,
+                                     gpointer data)
 {
-    struct SubtreeForeachData *args = (struct SubtreeForeachData *) data;
+    struct SubtreeForeachData *args = (struct SubtreeForeachData *)data;
     GValue value = { 0 };
 
     g_value_init(&value, G_TYPE_INT);
     g_value_set_int(&value, args->new_value);
 
-    gtk_tree_store_set_value(GTK_TREE_STORE(model), iter, args->column,
-                             &value);
+    gtk_tree_store_set_value(GTK_TREE_STORE(model), iter, args->column, &value);
 
-    trg_files_tree_model_set_subtree(model, path, iter, args->column,
-                                     args->new_value);
+    trg_files_tree_model_set_subtree(model, path, iter, args->column, args->new_value);
 }
 
-void
-trg_files_model_set_wanted(GtkTreeView * tv, gint column, gint new_value)
+void trg_files_model_set_wanted(GtkTreeView *tv, gint column, gint new_value)
 {
     struct SubtreeForeachData args;
     GtkTreeSelection *selection = gtk_tree_view_get_selection(tv);
@@ -75,13 +66,10 @@ trg_files_model_set_wanted(GtkTreeView * tv, gint column, gint new_value)
     args.column = column;
     args.new_value = new_value;
 
-    gtk_tree_selection_selected_foreach(selection, set_wanted_foreachfunc,
-                                        &args);
+    gtk_tree_selection_selected_foreach(selection, set_wanted_foreachfunc, &args);
 }
 
-void
-trg_files_tree_model_set_priority(GtkTreeView * tv, gint column,
-                                  gint new_value)
+void trg_files_tree_model_set_priority(GtkTreeView *tv, gint column, gint new_value)
 {
     struct SubtreeForeachData args;
     GtkTreeSelection *selection = gtk_tree_view_get_selection(tv);
@@ -89,35 +77,28 @@ trg_files_tree_model_set_priority(GtkTreeView * tv, gint column,
     args.column = column;
     args.new_value = new_value;
 
-    gtk_tree_selection_selected_foreach(selection,
-                                        set_priority_foreachfunc, &args);
-
+    gtk_tree_selection_selected_foreach(selection, set_priority_foreachfunc, &args);
 }
 
-static gboolean
-setSubtreeForeach(GtkTreeModel * model, GtkTreePath * path,
-                  GtkTreeIter * iter, gpointer gdata)
+static gboolean setSubtreeForeach(GtkTreeModel *model, GtkTreePath *path, GtkTreeIter *iter,
+                                  gpointer gdata)
 {
     struct SubtreeForeachData *data = gdata;
 
-    if (!gtk_tree_path_compare(path, data->path)
-        || gtk_tree_path_is_descendant(path, data->path)) {
+    if (!gtk_tree_path_compare(path, data->path) || gtk_tree_path_is_descendant(path, data->path)) {
         GValue value = { 0 };
 
         g_value_init(&value, G_TYPE_INT);
         g_value_set_int(&value, data->new_value);
 
-        gtk_tree_store_set_value(GTK_TREE_STORE(model), iter, data->column,
-                                 &value);
+        gtk_tree_store_set_value(GTK_TREE_STORE(model), iter, data->column, &value);
     }
 
-    return FALSE;               /* keep walking */
+    return FALSE; /* keep walking */
 }
 
-void
-trg_files_tree_model_propogate_change_up(GtkTreeModel * model,
-                                         GtkTreeIter * iter,
-                                         gint column, gint new_value)
+void trg_files_tree_model_propogate_change_up(GtkTreeModel *model, GtkTreeIter *iter, gint column,
+                                              gint new_value)
 {
     GtkTreeIter back_iter = *iter;
     gint result = new_value;
@@ -135,8 +116,7 @@ trg_files_tree_model_propogate_change_up(GtkTreeModel * model,
             GtkTreeIter child;
             gint current_value;
 
-            if (!gtk_tree_model_iter_nth_child
-                (model, &child, &tmp_iter, i))
+            if (!gtk_tree_model_iter_nth_child(model, &child, &tmp_iter, i))
                 continue;
 
             gtk_tree_model_get(model, &child, column, &current_value, -1);
@@ -146,18 +126,14 @@ trg_files_tree_model_propogate_change_up(GtkTreeModel * model,
             }
         }
 
-        gtk_tree_store_set(GTK_TREE_STORE(model), &tmp_iter, column,
-                           result, -1);
+        gtk_tree_store_set(GTK_TREE_STORE(model), &tmp_iter, column, result, -1);
 
         back_iter = tmp_iter;
     }
 }
 
-void
-trg_files_tree_model_set_subtree(GtkTreeModel * model,
-                                 GtkTreePath * path,
-                                 GtkTreeIter * iter, gint column,
-                                 gint new_value)
+void trg_files_tree_model_set_subtree(GtkTreeModel *model, GtkTreePath *path, GtkTreeIter *iter,
+                                      gint column, gint new_value)
 {
     GtkTreeIter back_iter = *iter;
 
@@ -170,17 +146,13 @@ trg_files_tree_model_set_subtree(GtkTreeModel * model,
 
         gtk_tree_model_foreach(model, setSubtreeForeach, &tmp);
     } else {
-        gtk_tree_store_set(GTK_TREE_STORE(model), &back_iter, column,
-                           new_value, -1);
+        gtk_tree_store_set(GTK_TREE_STORE(model), &back_iter, column, new_value, -1);
     }
 
-    trg_files_tree_model_propogate_change_up(model, iter, column,
-                                             new_value);
+    trg_files_tree_model_propogate_change_up(model, iter, column, new_value);
 }
 
-void
-trg_files_model_update_parents(GtkTreeModel * model,
-                               GtkTreeIter * iter, gint size_column)
+void trg_files_model_update_parents(GtkTreeModel *model, GtkTreeIter *iter, gint size_column)
 {
     GtkTreeIter back_iter = *iter;
     GtkTreeIter tmp_iter;
@@ -193,9 +165,7 @@ trg_files_model_update_parents(GtkTreeModel * model,
 
     do {
         gtk_tree_model_get(model, &tmp_iter, size_column, &oldSize, -1);
-        gtk_tree_store_set(GTK_TREE_STORE(model), &tmp_iter, size_column,
-                           size + oldSize, -1);
+        gtk_tree_store_set(GTK_TREE_STORE(model), &tmp_iter, size_column, size + oldSize, -1);
         back_iter = tmp_iter;
-    }
-    while (gtk_tree_model_iter_parent(model, &tmp_iter, &back_iter));
+    } while (gtk_tree_model_iter_parent(model, &tmp_iter, &back_iter));
 }

--- a/src/trg-files-model-common.h
+++ b/src/trg-files-model-common.h
@@ -20,22 +20,14 @@
 #ifndef TRG_FILES_TREE_MODEL_COMMON_H_
 #define TRG_FILES_TREE_MODEL_COMMON_H_
 
-void trg_files_tree_model_propogate_change_up(GtkTreeModel * model,
-                                              GtkTreeIter * iter,
-                                              gint column, gint new_value);
-void trg_files_tree_model_set_subtree(GtkTreeModel * model,
-                                      GtkTreePath * path,
-                                      GtkTreeIter * iter, gint column,
-                                      gint new_value);
-void trg_files_tree_model_set_priority(GtkTreeView * tv, gint column,
-                                       gint new_value);
-void trg_files_model_set_wanted(GtkTreeView * tv, gint column,
-                                gint new_value);
-gboolean trg_files_model_update_parent_size(GtkTreeModel * model,
-                                            GtkTreePath * path,
-                                            GtkTreeIter * iter,
-                                            gpointer data);
-void trg_files_model_update_parents(GtkTreeModel * model,
-                                    GtkTreeIter * iter, gint size_column);
+void trg_files_tree_model_propogate_change_up(GtkTreeModel *model, GtkTreeIter *iter, gint column,
+                                              gint new_value);
+void trg_files_tree_model_set_subtree(GtkTreeModel *model, GtkTreePath *path, GtkTreeIter *iter,
+                                      gint column, gint new_value);
+void trg_files_tree_model_set_priority(GtkTreeView *tv, gint column, gint new_value);
+void trg_files_model_set_wanted(GtkTreeView *tv, gint column, gint new_value);
+gboolean trg_files_model_update_parent_size(GtkTreeModel *model, GtkTreePath *path,
+                                            GtkTreeIter *iter, gpointer data);
+void trg_files_model_update_parents(GtkTreeModel *model, GtkTreeIter *iter, gint size_column);
 
-#endif                          /* TRG_FILES_TREE_MODEL_COMMON_H_ */
+#endif /* TRG_FILES_TREE_MODEL_COMMON_H_ */

--- a/src/trg-files-model.h
+++ b/src/trg-files-model.h
@@ -27,17 +27,15 @@
 
 G_BEGIN_DECLS
 #define TRG_TYPE_FILES_MODEL trg_files_model_get_type()
-#define TRG_FILES_MODEL(obj) \
-  (G_TYPE_CHECK_INSTANCE_CAST ((obj), TRG_TYPE_FILES_MODEL, TrgFilesModel))
-#define TRG_FILES_MODEL_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_CAST ((klass), TRG_TYPE_FILES_MODEL, TrgFilesModelClass))
-#define TRG_IS_FILES_MODEL(obj) \
-  (G_TYPE_CHECK_INSTANCE_TYPE ((obj), TRG_TYPE_FILES_MODEL))
-#define TRG_IS_FILES_MODEL_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_TYPE ((klass), TRG_TYPE_FILES_MODEL))
-#define TRG_FILES_MODEL_GET_CLASS(obj) \
-  (G_TYPE_INSTANCE_GET_CLASS ((obj), TRG_TYPE_FILES_MODEL, TrgFilesModelClass))
-    typedef struct {
+#define TRG_FILES_MODEL(obj)                                                                       \
+    (G_TYPE_CHECK_INSTANCE_CAST((obj), TRG_TYPE_FILES_MODEL, TrgFilesModel))
+#define TRG_FILES_MODEL_CLASS(klass)                                                               \
+    (G_TYPE_CHECK_CLASS_CAST((klass), TRG_TYPE_FILES_MODEL, TrgFilesModelClass))
+#define TRG_IS_FILES_MODEL(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), TRG_TYPE_FILES_MODEL))
+#define TRG_IS_FILES_MODEL_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass), TRG_TYPE_FILES_MODEL))
+#define TRG_FILES_MODEL_GET_CLASS(obj)                                                             \
+    (G_TYPE_INSTANCE_GET_CLASS((obj), TRG_TYPE_FILES_MODEL, TrgFilesModelClass))
+typedef struct {
     GtkTreeStore parent;
 } TrgFilesModel;
 
@@ -62,10 +60,9 @@ G_END_DECLS enum {
 
 #define TRG_FILES_MODEL_CREATE_THREAD_IF_GT 600
 
-void trg_files_model_update(TrgFilesModel * model, GtkTreeView * tv,
-                            gint64 updateSerial, JsonObject * t,
-                            gint mode);
-gint64 trg_files_model_get_torrent_id(TrgFilesModel * model);
-void trg_files_model_set_accept(TrgFilesModel * model, gboolean accept);
+void trg_files_model_update(TrgFilesModel *model, GtkTreeView *tv, gint64 updateSerial,
+                            JsonObject *t, gint mode);
+gint64 trg_files_model_get_torrent_id(TrgFilesModel *model);
+void trg_files_model_set_accept(TrgFilesModel *model, gboolean accept);
 
-#endif                          /* TRG_FILES_MODEL_H_ */
+#endif /* TRG_FILES_MODEL_H_ */

--- a/src/trg-files-tree-view-common.c
+++ b/src/trg-files-tree-view-common.c
@@ -29,28 +29,25 @@
 #include "trg-files-model-common.h"
 #include "trg-files-tree-view-common.h"
 
-static void expand_all_cb(GtkWidget * w, gpointer data)
+static void expand_all_cb(GtkWidget *w, gpointer data)
 {
     gtk_tree_view_expand_all(GTK_TREE_VIEW(data));
 }
 
-static void collapse_all_cb(GtkWidget * w, gpointer data)
+static void collapse_all_cb(GtkWidget *w, gpointer data)
 {
     gtk_tree_view_collapse_all(GTK_TREE_VIEW(data));
 }
 
-static unsigned get_selected_rows_count(GtkTreeView * tv)
+static unsigned get_selected_rows_count(GtkTreeView *tv)
 {
     GtkTreeSelection *selection = gtk_tree_view_get_selection(tv);
     return gtk_tree_selection_count_selected_rows(selection);
 }
 
-static void
-view_popup_menu(GtkWidget * treeview, GdkEventButton * event,
-                GCallback rename_cb, GCallback low_cb,
-                GCallback normal_cb, GCallback high_cb,
-                GCallback wanted_cb, GCallback unwanted_cb,
-                gpointer data G_GNUC_UNUSED)
+static void view_popup_menu(GtkWidget *treeview, GdkEventButton *event, GCallback rename_cb,
+                            GCallback low_cb, GCallback normal_cb, GCallback high_cb,
+                            GCallback wanted_cb, GCallback unwanted_cb, gpointer data G_GNUC_UNUSED)
 {
     GtkWidget *menu, *menuitem;
 
@@ -66,8 +63,7 @@ view_popup_menu(GtkWidget * treeview, GdkEventButton * event,
         }
         gtk_menu_shell_append(GTK_MENU_SHELL(menu), menuitem);
 
-        gtk_menu_shell_append(GTK_MENU_SHELL(menu),
-                              gtk_separator_menu_item_new());
+        gtk_menu_shell_append(GTK_MENU_SHELL(menu), gtk_separator_menu_item_new());
     }
 
     menuitem = gtk_menu_item_new_with_label(_("High Priority"));
@@ -82,8 +78,7 @@ view_popup_menu(GtkWidget * treeview, GdkEventButton * event,
     g_signal_connect(menuitem, "activate", low_cb, treeview);
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), menuitem);
 
-    gtk_menu_shell_append(GTK_MENU_SHELL(menu),
-                          gtk_separator_menu_item_new());
+    gtk_menu_shell_append(GTK_MENU_SHELL(menu), gtk_separator_menu_item_new());
 
     menuitem = gtk_menu_item_new_with_label(_("Download"));
     g_signal_connect(menuitem, "activate", wanted_cb, treeview);
@@ -93,17 +88,14 @@ view_popup_menu(GtkWidget * treeview, GdkEventButton * event,
     g_signal_connect(menuitem, "activate", unwanted_cb, treeview);
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), menuitem);
 
-    gtk_menu_shell_append(GTK_MENU_SHELL(menu),
-                          gtk_separator_menu_item_new());
+    gtk_menu_shell_append(GTK_MENU_SHELL(menu), gtk_separator_menu_item_new());
 
     menuitem = gtk_menu_item_new_with_label(_("Expand All"));
-    g_signal_connect(menuitem, "activate", G_CALLBACK(expand_all_cb),
-                     treeview);
+    g_signal_connect(menuitem, "activate", G_CALLBACK(expand_all_cb), treeview);
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), menuitem);
 
     menuitem = gtk_menu_item_new_with_label(_("Collapse All"));
-    g_signal_connect(menuitem, "activate", G_CALLBACK(collapse_all_cb),
-                     treeview);
+    g_signal_connect(menuitem, "activate", G_CALLBACK(collapse_all_cb), treeview);
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), menuitem);
 
     gtk_widget_show_all(menu);
@@ -111,26 +103,18 @@ view_popup_menu(GtkWidget * treeview, GdkEventButton * event,
     gtk_menu_popup_at_pointer(GTK_MENU(menu), (GdkEvent *)event);
 }
 
-gboolean
-trg_files_tree_view_viewOnPopupMenu(GtkWidget * treeview,
-                                    GCallback rename_cb,
-                                    GCallback low_cb,
-                                    GCallback normal_cb,
-                                    GCallback high_cb,
-                                    GCallback wanted_cb,
-                                    GCallback unwanted_cb,
-                                    gpointer userdata)
+gboolean trg_files_tree_view_viewOnPopupMenu(GtkWidget *treeview, GCallback rename_cb,
+                                             GCallback low_cb, GCallback normal_cb,
+                                             GCallback high_cb, GCallback wanted_cb,
+                                             GCallback unwanted_cb, gpointer userdata)
 {
-    view_popup_menu(treeview, NULL, rename_cb, low_cb, normal_cb, high_cb, wanted_cb,
-                    unwanted_cb, userdata);
+    view_popup_menu(treeview, NULL, rename_cb, low_cb, normal_cb, high_cb, wanted_cb, unwanted_cb,
+                    userdata);
     return TRUE;
 }
 
-static gboolean
-onViewPathToggled(GtkTreeView * view,
-                  GtkTreeViewColumn * col,
-                  GtkTreePath * path,
-                  gint pri_id, gint enabled_id, gpointer data)
+static gboolean onViewPathToggled(GtkTreeView *view, GtkTreeViewColumn *col, GtkTreePath *path,
+                                  gint pri_id, gint enabled_id, gpointer data)
 {
     int cid;
     gboolean handled = FALSE;
@@ -159,15 +143,13 @@ onViewPathToggled(GtkTreeView * view,
                 priority = TR_PRI_NORMAL;
                 break;
             }
-            trg_files_tree_model_set_subtree(model, path, &iter, pri_id,
-                                             priority);
+            trg_files_tree_model_set_subtree(model, path, &iter, pri_id, priority);
         } else if (cid == enabled_id) {
             int enabled;
             gtk_tree_model_get(model, &iter, enabled_id, &enabled, -1);
             enabled = !enabled;
 
-            trg_files_tree_model_set_subtree(model, path, &iter,
-                                             enabled_id, enabled);
+            trg_files_tree_model_set_subtree(model, path, &iter, enabled_id, enabled);
         }
 
         handled = TRUE;
@@ -176,15 +158,12 @@ onViewPathToggled(GtkTreeView * view,
     return handled;
 }
 
-static gboolean
-getAndSelectEventPath(GtkTreeView * treeview,
-                      GdkEventButton * event,
-                      GtkTreeViewColumn ** col, GtkTreePath ** path)
+static gboolean getAndSelectEventPath(GtkTreeView *treeview, GdkEventButton *event,
+                                      GtkTreeViewColumn **col, GtkTreePath **path)
 {
     GtkTreeSelection *sel;
 
-    if (gtk_tree_view_get_path_at_pos
-        (treeview, event->x, event->y, path, col, NULL, NULL)) {
+    if (gtk_tree_view_get_path_at_pos(treeview, event->x, event->y, path, col, NULL, NULL)) {
         sel = gtk_tree_view_get_selection(treeview);
         if (!gtk_tree_selection_path_is_selected(sel, *path)) {
             gtk_tree_selection_unselect_all(sel);
@@ -196,18 +175,11 @@ getAndSelectEventPath(GtkTreeView * treeview,
     return FALSE;
 }
 
-gboolean
-trg_files_tree_view_onViewButtonPressed(GtkWidget * w,
-                                        GdkEventButton * event,
-                                        gint pri_id,
-                                        gint enabled_id,
-                                        GCallback rename_cb,
-                                        GCallback low_cb,
-                                        GCallback normal_cb,
-                                        GCallback high_cb,
-                                        GCallback wanted_cb,
-                                        GCallback unwanted_cb,
-                                        gpointer gdata)
+gboolean trg_files_tree_view_onViewButtonPressed(GtkWidget *w, GdkEventButton *event, gint pri_id,
+                                                 gint enabled_id, GCallback rename_cb,
+                                                 GCallback low_cb, GCallback normal_cb,
+                                                 GCallback high_cb, GCallback wanted_cb,
+                                                 GCallback unwanted_cb, gpointer gdata)
 {
     GtkTreeViewColumn *col = NULL;
     GtkTreePath *path = NULL;
@@ -218,22 +190,19 @@ trg_files_tree_view_onViewButtonPressed(GtkWidget * w,
     if (event->type == GDK_BUTTON_PRESS && event->button == 1
         && !(event->state & (GDK_SHIFT_MASK | GDK_CONTROL_MASK))
         && getAndSelectEventPath(treeview, event, &col, &path)) {
-        handled =
-            onViewPathToggled(treeview, col, path, pri_id, enabled_id,
-                              NULL);
+        handled = onViewPathToggled(treeview, col, path, pri_id, enabled_id, NULL);
     } else if (event->type == GDK_BUTTON_PRESS && event->button == 3) {
         selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(treeview));
 
-        if (gtk_tree_view_get_path_at_pos(GTK_TREE_VIEW(treeview),
-                                          (gint) event->x, (gint) event->y,
+        if (gtk_tree_view_get_path_at_pos(GTK_TREE_VIEW(treeview), (gint)event->x, (gint)event->y,
                                           &path, NULL, NULL, NULL)) {
             if (!gtk_tree_selection_path_is_selected(selection, path)) {
                 gtk_tree_selection_unselect_all(selection);
                 gtk_tree_selection_select_path(selection, path);
             }
 
-            view_popup_menu(w, event, rename_cb, low_cb, normal_cb, high_cb,
-                            wanted_cb, unwanted_cb, gdata);
+            view_popup_menu(w, event, rename_cb, low_cb, normal_cb, high_cb, wanted_cb, unwanted_cb,
+                            gdata);
             handled = TRUE;
         }
     }

--- a/src/trg-files-tree-view-common.h
+++ b/src/trg-files-tree-view-common.h
@@ -20,25 +20,15 @@
 #ifndef TRG_FILES_TREE_VIEW_COMMON_H_
 #define TRG_FILES_TREE_VIEW_COMMON_H_
 
-gboolean trg_files_tree_view_onViewButtonPressed(GtkWidget * w,
-                                                 GdkEventButton * event,
-                                                 gint pri_id,
-                                                 gint enabled_id,
-                                                 GCallback rename_cb,
-                                                 GCallback low_cb,
-                                                 GCallback normal_cb,
-                                                 GCallback high_cb,
-                                                 GCallback wanted_cb,
-                                                 GCallback unwanted_cb,
-                                                 gpointer gdata);
+gboolean trg_files_tree_view_onViewButtonPressed(GtkWidget *w, GdkEventButton *event, gint pri_id,
+                                                 gint enabled_id, GCallback rename_cb,
+                                                 GCallback low_cb, GCallback normal_cb,
+                                                 GCallback high_cb, GCallback wanted_cb,
+                                                 GCallback unwanted_cb, gpointer gdata);
 
-gboolean trg_files_tree_view_viewOnPopupMenu(GtkWidget * treeview,
-                                             GCallback rename_cb,
-                                             GCallback low_cb,
-                                             GCallback normal_cb,
-                                             GCallback high_cb,
-                                             GCallback wanted_cb,
-                                             GCallback unwanted_cb,
-                                             gpointer userdata);
+gboolean trg_files_tree_view_viewOnPopupMenu(GtkWidget *treeview, GCallback rename_cb,
+                                             GCallback low_cb, GCallback normal_cb,
+                                             GCallback high_cb, GCallback wanted_cb,
+                                             GCallback unwanted_cb, gpointer userdata);
 
-#endif                          /* TRG_FILES_TREE_VIEW_COMMON_H_ */
+#endif /* TRG_FILES_TREE_VIEW_COMMON_H_ */

--- a/src/trg-files-tree-view.c
+++ b/src/trg-files-tree-view.c
@@ -22,22 +22,22 @@
 #include <glib/gi18n.h>
 #include <gtk/gtk.h>
 
-#include "trg-client.h"
-#include "trg-tree-view.h"
-#include "trg-file-rename-dialog.h"
-#include "trg-files-model-common.h"
-#include "trg-files-tree-view-common.h"
-#include "trg-files-tree-view.h"
-#include "trg-files-model.h"
-#include "trg-main-window.h"
-#include "requests.h"
-#include "util.h"
 #include "json.h"
 #include "protocol-constants.h"
+#include "requests.h"
+#include "trg-client.h"
+#include "trg-file-rename-dialog.h"
+#include "trg-files-model-common.h"
+#include "trg-files-model.h"
+#include "trg-files-tree-view-common.h"
+#include "trg-files-tree-view.h"
+#include "trg-main-window.h"
+#include "trg-tree-view.h"
+#include "util.h"
 
 G_DEFINE_TYPE(TrgFilesTreeView, trg_files_tree_view, TRG_TYPE_TREE_VIEW)
-#define TRG_FILES_TREE_VIEW_GET_PRIVATE(o) \
-  (G_TYPE_INSTANCE_GET_PRIVATE ((o), TRG_TYPE_FILES_TREE_VIEW, TrgFilesTreeViewPrivate))
+#define TRG_FILES_TREE_VIEW_GET_PRIVATE(o)                                                         \
+    (G_TYPE_INSTANCE_GET_PRIVATE((o), TRG_TYPE_FILES_TREE_VIEW, TrgFilesTreeViewPrivate))
 typedef struct _TrgFilesTreeViewPrivate TrgFilesTreeViewPrivate;
 
 struct _TrgFilesTreeViewPrivate {
@@ -45,18 +45,16 @@ struct _TrgFilesTreeViewPrivate {
     TrgMainWindow *win;
 };
 
-static void trg_files_tree_view_class_init(TrgFilesTreeViewClass * klass)
+static void trg_files_tree_view_class_init(TrgFilesTreeViewClass *klass)
 {
     g_type_class_add_private(klass, sizeof(TrgFilesTreeViewPrivate));
 }
 
-static gboolean
-send_updated_file_prefs_foreachfunc(GtkTreeModel * model,
-                                    GtkTreePath *
-                                    path G_GNUC_UNUSED,
-                                    GtkTreeIter * iter, gpointer data)
+static gboolean send_updated_file_prefs_foreachfunc(GtkTreeModel *model,
+                                                    GtkTreePath *path G_GNUC_UNUSED,
+                                                    GtkTreeIter *iter, gpointer data)
 {
-    JsonObject *args = (JsonObject *) data;
+    JsonObject *args = (JsonObject *)data;
     gint priority;
     gint id;
     gint wanted;
@@ -66,8 +64,7 @@ send_updated_file_prefs_foreachfunc(GtkTreeModel * model,
     if (id < 0)
         return FALSE;
 
-    gtk_tree_model_get(model, iter, FILESCOL_WANTED, &wanted,
-                       FILESCOL_PRIORITY, &priority, -1);
+    gtk_tree_model_get(model, iter, FILESCOL_WANTED, &wanted, FILESCOL_PRIORITY, &priority, -1);
 
     if (wanted)
         add_file_id_to_array(args, FIELD_FILES_WANTED, id);
@@ -86,11 +83,9 @@ send_updated_file_prefs_foreachfunc(GtkTreeModel * model,
 
 gboolean on_files_update(gpointer data)
 {
-    trg_response *response = (trg_response *) data;
-    TrgFilesTreeViewPrivate *priv =
-        TRG_FILES_TREE_VIEW_GET_PRIVATE(response->cb_data);
-    GtkTreeModel *model =
-        gtk_tree_view_get_model(GTK_TREE_VIEW(response->cb_data));
+    trg_response *response = (trg_response *)data;
+    TrgFilesTreeViewPrivate *priv = TRG_FILES_TREE_VIEW_GET_PRIVATE(response->cb_data);
+    GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(response->cb_data));
 
     trg_files_model_set_accept(TRG_FILES_MODEL(model), TRUE);
 
@@ -99,7 +94,7 @@ gboolean on_files_update(gpointer data)
     return on_generic_interactive_action_response(data);
 }
 
-static void send_updated_file_prefs(TrgFilesTreeView * tv)
+static void send_updated_file_prefs(TrgFilesTreeView *tv)
 {
     TrgFilesTreeViewPrivate *priv = TRG_FILES_TREE_VIEW_GET_PRIVATE(tv);
     JsonNode *req;
@@ -116,72 +111,56 @@ static void send_updated_file_prefs(TrgFilesTreeView * tv)
     req = torrent_set(targetIdArray);
     args = node_get_arguments(req);
 
-    gtk_tree_model_foreach(model, send_updated_file_prefs_foreachfunc,
-                           args);
+    gtk_tree_model_foreach(model, send_updated_file_prefs_foreachfunc, args);
 
     trg_files_model_set_accept(TRG_FILES_MODEL(model), FALSE);
 
     dispatch_async(priv->client, req, on_files_update, tv);
 }
 
-static void rename_file(GtkWidget * w G_GNUC_UNUSED, gpointer data)
+static void rename_file(GtkWidget *w G_GNUC_UNUSED, gpointer data)
 {
     TrgFilesTreeView *tv = TRG_FILES_TREE_VIEW(data);
     TrgFilesTreeViewPrivate *priv = TRG_FILES_TREE_VIEW_GET_PRIVATE(tv);
-    gtk_widget_show_all(GTK_WIDGET
-                        (trg_file_rename_dialog_new
-                         (priv->win, priv->client, tv)));
+    gtk_widget_show_all(GTK_WIDGET(trg_file_rename_dialog_new(priv->win, priv->client, tv)));
 }
 
-static void set_low(GtkWidget * w G_GNUC_UNUSED, gpointer data)
+static void set_low(GtkWidget *w G_GNUC_UNUSED, gpointer data)
 {
-    trg_files_tree_model_set_priority(GTK_TREE_VIEW(data),
-                                      FILESCOL_PRIORITY, TR_PRI_LOW);
+    trg_files_tree_model_set_priority(GTK_TREE_VIEW(data), FILESCOL_PRIORITY, TR_PRI_LOW);
     send_updated_file_prefs(TRG_FILES_TREE_VIEW(data));
 }
 
-static void set_normal(GtkWidget * w G_GNUC_UNUSED, gpointer data)
+static void set_normal(GtkWidget *w G_GNUC_UNUSED, gpointer data)
 {
-    trg_files_tree_model_set_priority(GTK_TREE_VIEW(data),
-                                      FILESCOL_PRIORITY, TR_PRI_NORMAL);
+    trg_files_tree_model_set_priority(GTK_TREE_VIEW(data), FILESCOL_PRIORITY, TR_PRI_NORMAL);
     send_updated_file_prefs(TRG_FILES_TREE_VIEW(data));
 }
 
-static void set_high(GtkWidget * w G_GNUC_UNUSED, gpointer data)
+static void set_high(GtkWidget *w G_GNUC_UNUSED, gpointer data)
 {
-    trg_files_tree_model_set_priority(GTK_TREE_VIEW(data),
-                                      FILESCOL_PRIORITY, TR_PRI_HIGH);
+    trg_files_tree_model_set_priority(GTK_TREE_VIEW(data), FILESCOL_PRIORITY, TR_PRI_HIGH);
     send_updated_file_prefs(TRG_FILES_TREE_VIEW(data));
 }
 
-static void set_unwanted(GtkWidget * w G_GNUC_UNUSED, gpointer data)
+static void set_unwanted(GtkWidget *w G_GNUC_UNUSED, gpointer data)
 {
-    trg_files_model_set_wanted(GTK_TREE_VIEW(data), FILESCOL_WANTED,
-                               FALSE);
+    trg_files_model_set_wanted(GTK_TREE_VIEW(data), FILESCOL_WANTED, FALSE);
     send_updated_file_prefs(TRG_FILES_TREE_VIEW(data));
 }
 
-static void set_wanted(GtkWidget * w G_GNUC_UNUSED, gpointer data)
+static void set_wanted(GtkWidget *w G_GNUC_UNUSED, gpointer data)
 {
     trg_files_model_set_wanted(GTK_TREE_VIEW(data), FILESCOL_WANTED, TRUE);
     send_updated_file_prefs(TRG_FILES_TREE_VIEW(data));
 }
 
-static gboolean
-view_onButtonPressed(GtkWidget * treeview,
-                     GdkEventButton * event, gpointer userdata)
+static gboolean view_onButtonPressed(GtkWidget *treeview, GdkEventButton *event, gpointer userdata)
 {
-    gboolean handled =
-        trg_files_tree_view_onViewButtonPressed(treeview, event,
-                                                -1,
-                                                FILESCOL_WANTED,
-                                                G_CALLBACK(rename_file),
-                                                G_CALLBACK(set_low),
-                                                G_CALLBACK(set_normal),
-                                                G_CALLBACK(set_high),
-                                                G_CALLBACK(set_wanted),
-                                                G_CALLBACK(set_unwanted),
-                                                userdata);
+    gboolean handled = trg_files_tree_view_onViewButtonPressed(
+        treeview, event, -1, FILESCOL_WANTED, G_CALLBACK(rename_file), G_CALLBACK(set_low),
+        G_CALLBACK(set_normal), G_CALLBACK(set_high), G_CALLBACK(set_wanted),
+        G_CALLBACK(set_unwanted), userdata);
 
     if (handled)
         send_updated_file_prefs(TRG_FILES_TREE_VIEW(treeview));
@@ -189,10 +168,8 @@ view_onButtonPressed(GtkWidget * treeview,
     return handled;
 }
 
-static gboolean
-search_func (GtkTreeModel *model, gint column,
-                 const gchar *key, GtkTreeIter *iter,
-                 gpointer search_data)
+static gboolean search_func(GtkTreeModel *model, gint column, const gchar *key, GtkTreeIter *iter,
+                            gpointer search_data)
 {
     gchar *iter_string = NULL;
     gchar *lowercase = NULL;
@@ -207,47 +184,37 @@ search_func (GtkTreeModel *model, gint column,
     return result;
 }
 
-static void trg_files_tree_view_init(TrgFilesTreeView * self)
+static void trg_files_tree_view_init(TrgFilesTreeView *self)
 {
     TrgTreeView *ttv = TRG_TREE_VIEW(self);
     trg_column_description *desc;
 
-    desc = trg_tree_view_reg_column(ttv, TRG_COLTYPE_FILEICONTEXT,
-                                    FILESCOL_NAME, _("Name"), "name", 0);
+    desc = trg_tree_view_reg_column(ttv, TRG_COLTYPE_FILEICONTEXT, FILESCOL_NAME, _("Name"), "name",
+                                    0);
     desc->model_column_extra = FILESCOL_ID;
 
-    trg_tree_view_reg_column(ttv, TRG_COLTYPE_SIZE, FILESCOL_SIZE,
-                             _("Size"), "size", 0);
-    trg_tree_view_reg_column(ttv, TRG_COLTYPE_PROG, FILESCOL_PROGRESS,
-                             _("Progress"), "progress", 0);
-    trg_tree_view_reg_column(ttv, TRG_COLTYPE_WANTED, FILESCOL_WANTED,
-                             _("Download"), "wanted", 0);
-    trg_tree_view_reg_column(ttv, TRG_COLTYPE_PRIO, FILESCOL_PRIORITY,
-                             _("Priority"), "priority", 0);
+    trg_tree_view_reg_column(ttv, TRG_COLTYPE_SIZE, FILESCOL_SIZE, _("Size"), "size", 0);
+    trg_tree_view_reg_column(ttv, TRG_COLTYPE_PROG, FILESCOL_PROGRESS, _("Progress"), "progress",
+                             0);
+    trg_tree_view_reg_column(ttv, TRG_COLTYPE_WANTED, FILESCOL_WANTED, _("Download"), "wanted", 0);
+    trg_tree_view_reg_column(ttv, TRG_COLTYPE_PRIO, FILESCOL_PRIORITY, _("Priority"), "priority",
+                             0);
 
     gtk_tree_view_set_search_column(GTK_TREE_VIEW(self), FILESCOL_NAME);
 
     gtk_tree_view_set_search_equal_func(GTK_TREE_VIEW(self),
-                                        (GtkTreeViewSearchEqualFunc) search_func,
-                                        gtk_tree_view_get_model(GTK_TREE_VIEW(self)),
-                                        NULL);
+                                        (GtkTreeViewSearchEqualFunc)search_func,
+                                        gtk_tree_view_get_model(GTK_TREE_VIEW(self)), NULL);
 
-    g_signal_connect(self, "button-press-event",
-                     G_CALLBACK(view_onButtonPressed), NULL);
-    g_signal_connect(self, "popup-menu",
-                     G_CALLBACK(trg_files_tree_view_viewOnPopupMenu),
-                     NULL);
+    g_signal_connect(self, "button-press-event", G_CALLBACK(view_onButtonPressed), NULL);
+    g_signal_connect(self, "popup-menu", G_CALLBACK(trg_files_tree_view_viewOnPopupMenu), NULL);
 }
 
-TrgFilesTreeView *trg_files_tree_view_new(TrgFilesModel * model,
-                                          TrgMainWindow * win,
-                                          TrgClient * client,
-                                          const gchar * configId)
+TrgFilesTreeView *trg_files_tree_view_new(TrgFilesModel *model, TrgMainWindow *win,
+                                          TrgClient *client, const gchar *configId)
 {
-    GObject *obj = g_object_new(TRG_TYPE_FILES_TREE_VIEW,
-                                "config-id", configId,
-                                "prefs", trg_client_get_prefs(client),
-                                NULL);
+    GObject *obj = g_object_new(TRG_TYPE_FILES_TREE_VIEW, "config-id", configId, "prefs",
+                                trg_client_get_prefs(client), NULL);
 
     TrgFilesTreeViewPrivate *priv = TRG_FILES_TREE_VIEW_GET_PRIVATE(obj);
 

--- a/src/trg-files-tree-view.h
+++ b/src/trg-files-tree-view.h
@@ -22,22 +22,21 @@
 
 #include <glib-object.h>
 
-#include "trg-main-window.h"
 #include "trg-client.h"
 #include "trg-files-model.h"
+#include "trg-main-window.h"
 
 G_BEGIN_DECLS
 #define TRG_TYPE_FILES_TREE_VIEW trg_files_tree_view_get_type()
-#define TRG_FILES_TREE_VIEW(obj) \
-  (G_TYPE_CHECK_INSTANCE_CAST ((obj), TRG_TYPE_FILES_TREE_VIEW, TrgFilesTreeView))
-#define TRG_FILES_TREE_VIEW_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_CAST ((klass), TRG_TYPE_FILES_TREE_VIEW, TrgFilesTreeViewClass))
-#define TRG_IS_FILES_TREE_VIEW(obj) \
-  (G_TYPE_CHECK_INSTANCE_TYPE ((obj), TRG_TYPE_FILES_TREE_VIEW))
-#define TRG_IS_FILES_TREE_VIEW_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_TYPE ((klass), TRG_TYPE_FILES_TREE_VIEW))
-#define TRG_FILES_TREE_VIEW_GET_CLASS(obj) \
-  (G_TYPE_INSTANCE_GET_CLASS ((obj), TRG_TYPE_FILES_TREE_VIEW, TrgFilesTreeViewClass))
+#define TRG_FILES_TREE_VIEW(obj)                                                                   \
+    (G_TYPE_CHECK_INSTANCE_CAST((obj), TRG_TYPE_FILES_TREE_VIEW, TrgFilesTreeView))
+#define TRG_FILES_TREE_VIEW_CLASS(klass)                                                           \
+    (G_TYPE_CHECK_CLASS_CAST((klass), TRG_TYPE_FILES_TREE_VIEW, TrgFilesTreeViewClass))
+#define TRG_IS_FILES_TREE_VIEW(obj) (G_TYPE_CHECK_INSTANCE_TYPE((obj), TRG_TYPE_FILES_TREE_VIEW))
+#define TRG_IS_FILES_TREE_VIEW_CLASS(klass)                                                        \
+    (G_TYPE_CHECK_CLASS_TYPE((klass), TRG_TYPE_FILES_TREE_VIEW))
+#define TRG_FILES_TREE_VIEW_GET_CLASS(obj)                                                         \
+    (G_TYPE_INSTANCE_GET_CLASS((obj), TRG_TYPE_FILES_TREE_VIEW, TrgFilesTreeViewClass))
 typedef struct {
     TrgTreeView parent;
 } TrgFilesTreeView;
@@ -55,24 +54,15 @@ GType trg_files_tree_view_get_type(void);
 
 gboolean on_files_update(gpointer data);
 
-TrgFilesTreeView *trg_files_tree_view_new(TrgFilesModel * model,
-                                          TrgMainWindow * win,
-                                          TrgClient * client,
-                                          const gchar * configId);
+TrgFilesTreeView *trg_files_tree_view_new(TrgFilesModel *model, TrgMainWindow *win,
+                                          TrgClient *client, const gchar *configId);
 
-void
-trg_files_tree_view_renderPriority(GtkTreeViewColumn *
-                                   column G_GNUC_UNUSED,
-                                   GtkCellRenderer * renderer,
-                                   GtkTreeModel * model,
-                                   GtkTreeIter * iter,
-                                   gpointer data G_GNUC_UNUSED);
-void trg_files_tree_view_renderDownload(GtkTreeViewColumn *
-                                        column G_GNUC_UNUSED,
-                                        GtkCellRenderer * renderer,
-                                        GtkTreeModel * model,
-                                        GtkTreeIter * iter,
-                                        gpointer data G_GNUC_UNUSED);
+void trg_files_tree_view_renderPriority(GtkTreeViewColumn *column G_GNUC_UNUSED,
+                                        GtkCellRenderer *renderer, GtkTreeModel *model,
+                                        GtkTreeIter *iter, gpointer data G_GNUC_UNUSED);
+void trg_files_tree_view_renderDownload(GtkTreeViewColumn *column G_GNUC_UNUSED,
+                                        GtkCellRenderer *renderer, GtkTreeModel *model,
+                                        GtkTreeIter *iter, gpointer data G_GNUC_UNUSED);
 
 G_END_DECLS
-#endif                          /* TRG_FILES_TREE_VIEW_H_ */
+#endif /* TRG_FILES_TREE_VIEW_H_ */

--- a/src/trg-files-tree.c
+++ b/src/trg-files-tree.c
@@ -30,25 +30,25 @@
 
 #include "trg-files-tree.h"
 
-void trg_files_tree_node_add_child(trg_files_tree_node* node, trg_files_tree_node* child)
+void trg_files_tree_node_add_child(trg_files_tree_node *node, trg_files_tree_node *child)
 {
-  if (!node->childrenHash) {
-    node->childrenHash = g_hash_table_new(g_str_hash, g_str_equal);
-  }
-  g_hash_table_insert(node->childrenHash, child->name, child);
-  node->children = g_list_append(node->children, child);
+    if (!node->childrenHash) {
+        node->childrenHash = g_hash_table_new(g_str_hash, g_str_equal);
+    }
+    g_hash_table_insert(node->childrenHash, child->name, child);
+    node->children = g_list_append(node->children, child);
 }
 
-void trg_files_tree_node_free(trg_files_tree_node * node)
+void trg_files_tree_node_free(trg_files_tree_node *node)
 {
     GList *li;
 
     for (li = node->children; li; li = g_list_next(li))
-        trg_files_tree_node_free((trg_files_tree_node *) li->data);
+        trg_files_tree_node_free((trg_files_tree_node *)li->data);
 
     if (node->childrenHash)
-      g_hash_table_destroy(node->childrenHash);
-    
+        g_hash_table_destroy(node->childrenHash);
+
     g_list_free(node->children);
     g_free(node->name);
     g_free(node);

--- a/src/trg-files-tree.h
+++ b/src/trg-files-tree.h
@@ -37,7 +37,7 @@ typedef struct {
     gint enabled;
 } trg_files_tree_node;
 
-void trg_files_tree_node_add_child(trg_files_tree_node* node, trg_files_tree_node* child);
-void trg_files_tree_node_free(trg_files_tree_node * node);
+void trg_files_tree_node_add_child(trg_files_tree_node *node, trg_files_tree_node *child);
+void trg_files_tree_node_free(trg_files_tree_node *node);
 
-#endif                          /* TRG_FILES_MODEL_H_ */
+#endif /* TRG_FILES_MODEL_H_ */

--- a/src/trg-general-panel.c
+++ b/src/trg-general-panel.c
@@ -19,31 +19,29 @@
 
 #include "config.h"
 
-#include <string.h>
 #include <glib-object.h>
 #include <glib/gi18n.h>
 #include <gtk/gtk.h>
+#include <string.h>
 
-#include "trg-client.h"
+#include "protocol-constants.h"
 #include "torrent.h"
-#include "util.h"
+#include "trg-client.h"
 #include "trg-general-panel.h"
 #include "trg-torrent-model.h"
-#include "protocol-constants.h"
+#include "util.h"
 
-#define TRG_GENERAL_PANEL_SPACING_X         4
-#define TRG_GENERAL_PANEL_SPACING_Y         2
-#define TRG_GENERAL_PANEL_COLUMNS           6
+#define TRG_GENERAL_PANEL_SPACING_X 4
+#define TRG_GENERAL_PANEL_SPACING_Y 2
+#define TRG_GENERAL_PANEL_COLUMNS   6
 
-static void gtk_label_clear(GtkLabel * l);
-static GtkLabel *gen_panel_label_get_key_label(GtkLabel * l);
-static GtkLabel *trg_general_panel_add_label(TrgGeneralPanel * gp,
-                                             char *key, guint col,
-                                             guint row);
+static void gtk_label_clear(GtkLabel *l);
+static GtkLabel *gen_panel_label_get_key_label(GtkLabel *l);
+static GtkLabel *trg_general_panel_add_label(TrgGeneralPanel *gp, char *key, guint col, guint row);
 
 G_DEFINE_TYPE(TrgGeneralPanel, trg_general_panel, GTK_TYPE_GRID)
-#define TRG_GENERAL_PANEL_GET_PRIVATE(o) \
-  (G_TYPE_INSTANCE_GET_PRIVATE ((o), TRG_TYPE_GENERAL_PANEL, TrgGeneralPanelPrivate))
+#define TRG_GENERAL_PANEL_GET_PRIVATE(o)                                                           \
+    (G_TYPE_INSTANCE_GET_PRIVATE((o), TRG_TYPE_GENERAL_PANEL, TrgGeneralPanelPrivate))
 typedef struct _TrgGeneralPanelPrivate TrgGeneralPanelPrivate;
 
 struct _TrgGeneralPanelPrivate {
@@ -71,7 +69,7 @@ struct _TrgGeneralPanelPrivate {
     TrgClient *tc;
 };
 
-void trg_general_panel_clear(TrgGeneralPanel * panel)
+void trg_general_panel_clear(TrgGeneralPanel *panel)
 {
     TrgGeneralPanelPrivate *priv = TRG_GENERAL_PANEL_GET_PRIVATE(panel);
 
@@ -95,31 +93,28 @@ void trg_general_panel_clear(TrgGeneralPanel * panel)
     gtk_label_clear(priv->gen_comment_label);
     gtk_label_clear(priv->gen_hash_label);
     gtk_label_clear(priv->gen_error_label);
-    gtk_label_clear(gen_panel_label_get_key_label
-                    (GTK_LABEL(priv->gen_error_label)));
+    gtk_label_clear(gen_panel_label_get_key_label(GTK_LABEL(priv->gen_error_label)));
 }
 
-static void gtk_label_clear(GtkLabel * l)
+static void gtk_label_clear(GtkLabel *l)
 {
     gtk_label_set_text(l, "");
 }
 
-static GtkLabel *gen_panel_label_get_key_label(GtkLabel * l)
+static GtkLabel *gen_panel_label_get_key_label(GtkLabel *l)
 {
     return GTK_LABEL(g_object_get_data(G_OBJECT(l), "key-label"));
 }
 
-static void trg_general_panel_class_init(TrgGeneralPanelClass * klass)
+static void trg_general_panel_class_init(TrgGeneralPanelClass *klass)
 {
     g_type_class_add_private(klass, sizeof(TrgGeneralPanelPrivate));
 }
 
-void
-trg_general_panel_update(TrgGeneralPanel * panel, JsonObject * t,
-                         GtkTreeIter * iter)
+void trg_general_panel_update(TrgGeneralPanel *panel, JsonObject *t, GtkTreeIter *iter)
 {
     TrgGeneralPanelPrivate *priv;
-    gchar buf[32], buf1[32]; //TODO: do it better
+    gchar buf[32], buf1[32]; // TODO: do it better
     gchar *statusString, *fullStatusString, *completedAtString, *speed, *comment, *markup;
     const gchar *errorStr;
     gint64 eta, uploaded, corrupted, haveValid, completedAt;
@@ -128,35 +123,34 @@ trg_general_panel_update(TrgGeneralPanel * panel, JsonObject * t,
 
     priv = TRG_GENERAL_PANEL_GET_PRIVATE(panel);
 
-    gtk_tree_model_get(GTK_TREE_MODEL(priv->model), iter,
-                       TORRENT_COLUMN_SEEDS, &seeders,
-                       TORRENT_COLUMN_LEECHERS, &leechers,
-                       TORRENT_COLUMN_STATUS, &statusString, -1);
+    gtk_tree_model_get(GTK_TREE_MODEL(priv->model), iter, TORRENT_COLUMN_SEEDS, &seeders,
+                       TORRENT_COLUMN_LEECHERS, &leechers, TORRENT_COLUMN_STATUS, &statusString,
+                       -1);
 
     trg_strlsize(buf, torrent_get_size_when_done(t));
     gtk_label_set_text(GTK_LABEL(priv->gen_size_label), buf);
 
-	trg_strlspeed(buf, torrent_get_rate_down(t) / disk_K);
-	if (torrent_get_download_limited(t)){
-		trg_strlspeed(buf1, torrent_get_download_limit(t));
-		speed = g_strdup_printf("%s [%s]", buf, buf1);
-	} else
-		speed = g_strdup_printf("%s", buf);
+    trg_strlspeed(buf, torrent_get_rate_down(t) / disk_K);
+    if (torrent_get_download_limited(t)) {
+        trg_strlspeed(buf1, torrent_get_download_limit(t));
+        speed = g_strdup_printf("%s [%s]", buf, buf1);
+    } else
+        speed = g_strdup_printf("%s", buf);
     gtk_label_set_text(GTK_LABEL(priv->gen_down_rate_label), speed);
     g_free(speed);
 
-	trg_strlspeed(buf, torrent_get_rate_up(t) / disk_K);
-    if (torrent_get_upload_limited(t)){
-		trg_strlspeed(buf1, torrent_get_upload_limit(t));
-		speed = g_strdup_printf("%s [%s]", buf, buf1);	
-	} else
-		speed = g_strdup_printf("%s", buf);
+    trg_strlspeed(buf, torrent_get_rate_up(t) / disk_K);
+    if (torrent_get_upload_limited(t)) {
+        trg_strlspeed(buf1, torrent_get_upload_limit(t));
+        speed = g_strdup_printf("%s [%s]", buf, buf1);
+    } else
+        speed = g_strdup_printf("%s", buf);
     gtk_label_set_text(GTK_LABEL(priv->gen_up_rate_label), speed);
-	g_free(speed);
+    g_free(speed);
 
-	corrupted = torrent_get_corrupted(t);
-	trg_strlsize(buf, corrupted);
-	gtk_label_set_text(GTK_LABEL(priv->gen_corrupted_label), buf);
+    corrupted = torrent_get_corrupted(t);
+    trg_strlsize(buf, corrupted);
+    gtk_label_set_text(GTK_LABEL(priv->gen_corrupted_label), buf);
 
     uploaded = torrent_get_uploaded(t);
     trg_strlsize(buf, uploaded);
@@ -169,72 +163,62 @@ trg_general_panel_update(TrgGeneralPanel * panel, JsonObject * t,
     gtk_label_set_text(GTK_LABEL(priv->gen_downloaded_label), buf);
 
     if (uploaded > 0 && haveValid > 0) {
-        trg_strlratio(buf, (double) uploaded / (double) haveValid);
+        trg_strlratio(buf, (double)uploaded / (double)haveValid);
         gtk_label_set_text(GTK_LABEL(priv->gen_ratio_label), buf);
     } else {
         gtk_label_set_text(GTK_LABEL(priv->gen_ratio_label), _("N/A"));
     }
 
-	trg_strlratio(buf, torrent_get_seed_ratio_limit(t));
-	gtk_label_set_text(GTK_LABEL(priv->gen_limit_label), buf);
+    trg_strlratio(buf, torrent_get_seed_ratio_limit(t));
+    gtk_label_set_text(GTK_LABEL(priv->gen_limit_label), buf);
 
     completedAt = torrent_get_done_date(t);
     if (completedAt > 0) {
         completedAtString = epoch_to_string(completedAt);
-        gtk_label_set_text(GTK_LABEL(priv->gen_completedat_label),
-                           completedAtString);
+        gtk_label_set_text(GTK_LABEL(priv->gen_completedat_label), completedAtString);
         g_free(completedAtString);
     } else {
         gtk_label_set_text(GTK_LABEL(priv->gen_completedat_label), "");
     }
 
     fullStatusString = g_strdup_printf("%s %s", statusString,
-                                       torrent_get_is_private(t) ?
-                                       _("(Private)") : _("(Public)"));
-    gtk_label_set_text(GTK_LABEL(priv->gen_status_label),
-                       fullStatusString);
+                                       torrent_get_is_private(t) ? _("(Private)") : _("(Public)"));
+    gtk_label_set_text(GTK_LABEL(priv->gen_status_label), fullStatusString);
     g_free(fullStatusString);
     g_free(statusString);
 
-	switch(torrent_get_bandwidth_priority(t)){
-		case TR_PRI_LOW:
-			gtk_label_set_text(GTK_LABEL(priv->gen_priority_label), _("Low"));
-			break;
-		case TR_PRI_NORMAL:
-			gtk_label_set_text(GTK_LABEL(priv->gen_priority_label), _("Normal"));
-			break;
-		case TR_PRI_HIGH:
-			gtk_label_set_text(GTK_LABEL(priv->gen_priority_label), _("High"));
-			break;
-	}
+    switch (torrent_get_bandwidth_priority(t)) {
+    case TR_PRI_LOW:
+        gtk_label_set_text(GTK_LABEL(priv->gen_priority_label), _("Low"));
+        break;
+    case TR_PRI_NORMAL:
+        gtk_label_set_text(GTK_LABEL(priv->gen_priority_label), _("Normal"));
+        break;
+    case TR_PRI_HIGH:
+        gtk_label_set_text(GTK_LABEL(priv->gen_priority_label), _("High"));
+        break;
+    }
 
     trg_strlpercent(buf, torrent_get_percent_done(t));
     gtk_label_set_text(GTK_LABEL(priv->gen_completed_label), buf);
 
-    gtk_label_set_text(GTK_LABEL(priv->gen_name_label),
-                       torrent_get_name(t));
+    gtk_label_set_text(GTK_LABEL(priv->gen_name_label), torrent_get_name(t));
 
-    gtk_label_set_text(GTK_LABEL(priv->gen_downloaddir_label),
-                       torrent_get_download_dir(t));
+    gtk_label_set_text(GTK_LABEL(priv->gen_downloaddir_label), torrent_get_download_dir(t));
 
     comment = add_links_to_text(torrent_get_comment(t));
     gtk_label_set_markup(GTK_LABEL(priv->gen_comment_label), comment);
     g_free(comment);
 
     errorStr = torrent_get_errorstr(t);
-    keyLabel =
-        gen_panel_label_get_key_label(GTK_LABEL(priv->gen_error_label));
+    keyLabel = gen_panel_label_get_key_label(GTK_LABEL(priv->gen_error_label));
     if (strlen(errorStr) > 0) {
-        markup =
-            g_markup_printf_escaped("<span fgcolor=\"red\">%s</span>",
-                                    errorStr);
+        markup = g_markup_printf_escaped("<span fgcolor=\"red\">%s</span>", errorStr);
         gtk_label_set_markup(GTK_LABEL(priv->gen_error_label), markup);
         g_free(markup);
 
-        markup =
-            g_markup_printf_escaped
-            ("<span font_weight=\"bold\" fgcolor=\"red\">%s</span>",
-             _("Error"));
+        markup = g_markup_printf_escaped("<span font_weight=\"bold\" fgcolor=\"red\">%s</span>",
+                                         _("Error"));
         gtk_label_set_markup(keyLabel, markup);
         g_free(markup);
     } else {
@@ -249,26 +233,19 @@ trg_general_panel_update(TrgGeneralPanel * panel, JsonObject * t,
         gtk_label_set_text(GTK_LABEL(priv->gen_eta_label), _("N/A"));
     }
 
-    g_snprintf(buf, sizeof(buf), "%" G_GINT64_FORMAT,
-             seeders >= 0 ? seeders : 0);
+    g_snprintf(buf, sizeof(buf), "%" G_GINT64_FORMAT, seeders >= 0 ? seeders : 0);
     gtk_label_set_text(GTK_LABEL(priv->gen_seeders_label), buf);
-    g_snprintf(buf, sizeof(buf), "%" G_GINT64_FORMAT,
-             leechers >= 0 ? leechers : 0);
+    g_snprintf(buf, sizeof(buf), "%" G_GINT64_FORMAT, leechers >= 0 ? leechers : 0);
     gtk_label_set_text(GTK_LABEL(priv->gen_leechers_label), buf);
 }
 
-static GtkLabel *trg_general_panel_add_label_with_width(TrgGeneralPanel *
-                                                        gp, char *key,
-                                                        guint col,
-                                                        guint row,
-                                                        gint width)
+static GtkLabel *trg_general_panel_add_label_with_width(TrgGeneralPanel *gp, char *key, guint col,
+                                                        guint row, gint width)
 {
     GtkWidget *value, *keyLabel;
 
     guint startCol = col * 2;
-    guint endCol = (guint)(width < 0
-                           ? (TRG_GENERAL_PANEL_COLUMNS)
-                           : width);
+    guint endCol = (guint)(width < 0 ? (TRG_GENERAL_PANEL_COLUMNS) : width);
 
     keyLabel = gtk_label_new(NULL);
     gtk_label_set_xalign(GTK_LABEL(keyLabel), 0.0f);
@@ -276,15 +253,11 @@ static GtkLabel *trg_general_panel_add_label_with_width(TrgGeneralPanel *
     gtk_label_set_width_chars(GTK_LABEL(keyLabel), 10);
 
     if (strlen(key) > 0) {
-        gchar *keyMarkup =
-            g_markup_printf_escaped(strlen(key) > 0 ? "<b>%s:</b>" : "",
-                                    key);
+        gchar *keyMarkup = g_markup_printf_escaped(strlen(key) > 0 ? "<b>%s:</b>" : "", key);
         gtk_label_set_markup(GTK_LABEL(keyLabel), keyMarkup);
         g_free(keyMarkup);
     }
-    gtk_grid_attach(GTK_GRID(gp), keyLabel,
-                    startCol, row,
-                    1, 1);
+    gtk_grid_attach(GTK_GRID(gp), keyLabel, startCol, row, 1, 1);
 
     value = gtk_label_new(NULL);
     gtk_label_set_xalign(GTK_LABEL(value), 0.0f);
@@ -293,72 +266,49 @@ static GtkLabel *trg_general_panel_add_label_with_width(TrgGeneralPanel *
 
     g_object_set_data(G_OBJECT(value), "key-label", keyLabel);
     gtk_label_set_selectable(GTK_LABEL(value), TRUE);
-    gtk_grid_attach(GTK_GRID(gp), value,
-                    startCol + 1, row,
-                    endCol, 1);
+    gtk_grid_attach(GTK_GRID(gp), value, startCol + 1, row, endCol, 1);
 
     return GTK_LABEL(value);
 }
 
-static GtkLabel *trg_general_panel_add_label(TrgGeneralPanel * gp,
-                                             char *key, guint col,
-                                             guint row)
+static GtkLabel *trg_general_panel_add_label(TrgGeneralPanel *gp, char *key, guint col, guint row)
 {
     return trg_general_panel_add_label_with_width(gp, key, col, row, 1);
 }
 
-static void trg_general_panel_init(TrgGeneralPanel * self)
+static void trg_general_panel_init(TrgGeneralPanel *self)
 {
     TrgGeneralPanelPrivate *priv = TRG_GENERAL_PANEL_GET_PRIVATE(self);
-	priv->gen_name_label =
-		trg_general_panel_add_label_with_width(self, _("Name"), 0, 0, -1);
+    priv->gen_name_label = trg_general_panel_add_label_with_width(self, _("Name"), 0, 0, -1);
 
-	priv->gen_size_label =
-		trg_general_panel_add_label(self, _("Size"), 0, 1);
-	priv->gen_down_rate_label =
-		trg_general_panel_add_label(self, _("Rate Down"), 1, 1);
-	priv->gen_completed_label =
-		trg_general_panel_add_label(self, _("Completed"), 2, 1);
+    priv->gen_size_label = trg_general_panel_add_label(self, _("Size"), 0, 1);
+    priv->gen_down_rate_label = trg_general_panel_add_label(self, _("Rate Down"), 1, 1);
+    priv->gen_completed_label = trg_general_panel_add_label(self, _("Completed"), 2, 1);
 
-	priv->gen_eta_label =
-		trg_general_panel_add_label(self, _("ETA"), 0, 2);
-	priv->gen_up_rate_label =
-		trg_general_panel_add_label(self, _("Rate Up"), 1, 2);
-	priv->gen_downloaded_label =
-		trg_general_panel_add_label(self, _("Downloaded"), 2, 2);
+    priv->gen_eta_label = trg_general_panel_add_label(self, _("ETA"), 0, 2);
+    priv->gen_up_rate_label = trg_general_panel_add_label(self, _("Rate Up"), 1, 2);
+    priv->gen_downloaded_label = trg_general_panel_add_label(self, _("Downloaded"), 2, 2);
 
-	priv->gen_seeders_label =
-		trg_general_panel_add_label(self, _("Seeders"), 0, 3);
-	priv->gen_ratio_label =
-		trg_general_panel_add_label(self, _("Ratio"), 1, 3);
-	priv->gen_uploaded_label =
-		trg_general_panel_add_label(self, _("Uploaded"), 2, 3);
+    priv->gen_seeders_label = trg_general_panel_add_label(self, _("Seeders"), 0, 3);
+    priv->gen_ratio_label = trg_general_panel_add_label(self, _("Ratio"), 1, 3);
+    priv->gen_uploaded_label = trg_general_panel_add_label(self, _("Uploaded"), 2, 3);
 
-	priv->gen_leechers_label =
-		trg_general_panel_add_label(self, _("Leechers"), 0, 4);
-	priv->gen_limit_label =
-		trg_general_panel_add_label(self, _("Ratio limit"), 1, 4);
-	priv->gen_corrupted_label =
-		trg_general_panel_add_label(self, _("Corrupted"), 2, 4);
+    priv->gen_leechers_label = trg_general_panel_add_label(self, _("Leechers"), 0, 4);
+    priv->gen_limit_label = trg_general_panel_add_label(self, _("Ratio limit"), 1, 4);
+    priv->gen_corrupted_label = trg_general_panel_add_label(self, _("Corrupted"), 2, 4);
 
-	priv->gen_status_label =
-		trg_general_panel_add_label(self, _("Status"), 0, 5);
-	priv->gen_priority_label =
-		trg_general_panel_add_label(self, _("Priority"), 1, 5);
-	priv->gen_completedat_label =
-		trg_general_panel_add_label(self, _("Completed At"), 2, 5);
+    priv->gen_status_label = trg_general_panel_add_label(self, _("Status"), 0, 5);
+    priv->gen_priority_label = trg_general_panel_add_label(self, _("Priority"), 1, 5);
+    priv->gen_completedat_label = trg_general_panel_add_label(self, _("Completed At"), 2, 5);
 
-	priv->gen_downloaddir_label =
-		trg_general_panel_add_label_with_width(self, _("Location"), 0, 6, -1);
+    priv->gen_downloaddir_label
+        = trg_general_panel_add_label_with_width(self, _("Location"), 0, 6, -1);
 
-	priv->gen_comment_label =
-		trg_general_panel_add_label(self, _("Comment"), 0, 7);
+    priv->gen_comment_label = trg_general_panel_add_label(self, _("Comment"), 0, 7);
 
-	priv->gen_hash_label =
-		trg_general_panel_add_label(self, _("Hash"), 0, 8);
+    priv->gen_hash_label = trg_general_panel_add_label(self, _("Hash"), 0, 8);
 
-	priv->gen_error_label =
-		trg_general_panel_add_label_with_width(self, "", 0, 9, -1);
+    priv->gen_error_label = trg_general_panel_add_label_with_width(self, "", 0, 9, -1);
 
     gtk_grid_set_row_homogeneous(GTK_GRID(self), TRUE);
     gtk_grid_set_column_spacing(GTK_GRID(self), TRG_GENERAL_PANEL_SPACING_X);
@@ -366,8 +316,7 @@ static void trg_general_panel_init(TrgGeneralPanel * self)
     gtk_widget_set_sensitive(GTK_WIDGET(self), FALSE);
 }
 
-TrgGeneralPanel *trg_general_panel_new(GtkTreeModel * model,
-                                       TrgClient * tc)
+TrgGeneralPanel *trg_general_panel_new(GtkTreeModel *model, TrgClient *tc)
 {
     GObject *obj;
     TrgGeneralPanelPrivate *priv;

--- a/src/trg-general-panel.h
+++ b/src/trg-general-panel.h
@@ -30,17 +30,15 @@
 
 G_BEGIN_DECLS
 #define TRG_TYPE_GENERAL_PANEL trg_general_panel_get_type()
-#define TRG_GENERAL_PANEL(obj) \
-  (G_TYPE_CHECK_INSTANCE_CAST ((obj), TRG_TYPE_GENERAL_PANEL, TrgGeneralPanel))
-#define TRG_GENERAL_PANEL_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_CAST ((klass), TRG_TYPE_GENERAL_PANEL, TrgGeneralPanelClass))
-#define TRG_IS_GENERAL_PANEL(obj) \
-  (G_TYPE_CHECK_INSTANCE_TYPE ((obj), TRG_TYPE_GENERAL_PANEL))
-#define TRG_IS_GENERAL_PANEL_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_TYPE ((klass), TRG_TYPE_GENERAL_PANEL))
-#define TRG_GENERAL_PANEL_GET_CLASS(obj) \
-  (G_TYPE_INSTANCE_GET_CLASS ((obj), TRG_TYPE_GENERAL_PANEL, TrgGeneralPanelClass))
-    typedef struct {
+#define TRG_GENERAL_PANEL(obj)                                                                     \
+    (G_TYPE_CHECK_INSTANCE_CAST((obj), TRG_TYPE_GENERAL_PANEL, TrgGeneralPanel))
+#define TRG_GENERAL_PANEL_CLASS(klass)                                                             \
+    (G_TYPE_CHECK_CLASS_CAST((klass), TRG_TYPE_GENERAL_PANEL, TrgGeneralPanelClass))
+#define TRG_IS_GENERAL_PANEL(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), TRG_TYPE_GENERAL_PANEL))
+#define TRG_IS_GENERAL_PANEL_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass), TRG_TYPE_GENERAL_PANEL))
+#define TRG_GENERAL_PANEL_GET_CLASS(obj)                                                           \
+    (G_TYPE_INSTANCE_GET_CLASS((obj), TRG_TYPE_GENERAL_PANEL, TrgGeneralPanelClass))
+typedef struct {
     GtkGrid parent;
 } TrgGeneralPanel;
 
@@ -50,12 +48,10 @@ typedef struct {
 
 GType trg_general_panel_get_type(void);
 
-TrgGeneralPanel *trg_general_panel_new(GtkTreeModel * model,
-                                       TrgClient * tc);
+TrgGeneralPanel *trg_general_panel_new(GtkTreeModel *model, TrgClient *tc);
 
 G_END_DECLS
-    void trg_general_panel_update(TrgGeneralPanel * panel, JsonObject * t,
-                                  GtkTreeIter * iter);
-void trg_general_panel_clear(TrgGeneralPanel * panel);
+void trg_general_panel_update(TrgGeneralPanel *panel, JsonObject *t, GtkTreeIter *iter);
+void trg_general_panel_clear(TrgGeneralPanel *panel);
 
-#endif                          /* TRG_GENERAL_PANEL_H_ */
+#endif /* TRG_GENERAL_PANEL_H_ */

--- a/src/trg-gtk-app.c
+++ b/src/trg-gtk-app.c
@@ -22,35 +22,32 @@
 #include <glib/gi18n.h>
 #include <gtk/gtk.h>
 
-#include "trg-main-window.h"
 #include "trg-gtk-app.h"
+#include "trg-main-window.h"
 #include "util.h"
 
 enum {
-	PROP_0,
-	PROP_CLIENT,
-	PROP_MINIMISE_ON_START,
-	N_PROPS,
+    PROP_0,
+    PROP_CLIENT,
+    PROP_MINIMISE_ON_START,
+    N_PROPS,
 };
 
-struct _TrgGtkApp
-{
-	GtkApplication parent;
+struct _TrgGtkApp {
+    GtkApplication parent;
 };
 
-typedef struct
-{
+typedef struct {
     TrgClient *client;
     gboolean min_start;
 } TrgGtkAppPrivate;
 
 G_DEFINE_TYPE_WITH_PRIVATE(TrgGtkApp, trg_gtk_app, GTK_TYPE_APPLICATION)
 
-static void
-trg_gtk_app_get_property(GObject * object, guint property_id,
-                         GValue * value, GParamSpec * pspec)
+static void trg_gtk_app_get_property(GObject *object, guint property_id, GValue *value,
+                                     GParamSpec *pspec)
 {
-    TrgGtkAppPrivate *priv = trg_gtk_app_get_instance_private (TRG_GTK_APP(object));
+    TrgGtkAppPrivate *priv = trg_gtk_app_get_instance_private(TRG_GTK_APP(object));
     switch (property_id) {
     case PROP_CLIENT:
         g_value_set_pointer(value, priv->client);
@@ -64,11 +61,10 @@ trg_gtk_app_get_property(GObject * object, guint property_id,
     }
 }
 
-static void
-trg_gtk_app_set_property(GObject * object, guint property_id,
-                         const GValue * value, GParamSpec * pspec)
+static void trg_gtk_app_set_property(GObject *object, guint property_id, const GValue *value,
+                                     GParamSpec *pspec)
 {
-    TrgGtkAppPrivate *priv = trg_gtk_app_get_instance_private (TRG_GTK_APP(object));
+    TrgGtkAppPrivate *priv = trg_gtk_app_get_instance_private(TRG_GTK_APP(object));
     switch (property_id) {
     case PROP_CLIENT:
         priv->client = g_value_get_pointer(value);
@@ -82,20 +78,16 @@ trg_gtk_app_set_property(GObject * object, guint property_id,
     }
 }
 
-static void trg_gtk_app_startup(GApplication * app, gpointer userdata)
+static void trg_gtk_app_startup(GApplication *app, gpointer userdata)
 {
-    TrgGtkAppPrivate *priv = trg_gtk_app_get_instance_private (TRG_GTK_APP(app));
-    TrgMainWindow *window =
-        trg_main_window_new(priv->client, priv->min_start);
+    TrgGtkAppPrivate *priv = trg_gtk_app_get_instance_private(TRG_GTK_APP(app));
+    TrgMainWindow *window = trg_main_window_new(priv->client, priv->min_start);
     gtk_window_set_application(GTK_WINDOW(window), GTK_APPLICATION(app));
 }
 
-static int
-trg_gtk_app_command_line(GApplication * application,
-                         GApplicationCommandLine * cmdline)
+static int trg_gtk_app_command_line(GApplication *application, GApplicationCommandLine *cmdline)
 {
-    GList *windows =
-        gtk_application_get_windows(GTK_APPLICATION(application));
+    GList *windows = gtk_application_get_windows(GTK_APPLICATION(application));
     TrgMainWindow *window;
     gchar **argv;
 
@@ -120,7 +112,7 @@ trg_gtk_app_command_line(GApplication * application,
     return 0;
 }
 
-static void shift_args(gchar ** argv, int i)
+static void shift_args(gchar **argv, int i)
 {
     gint j;
     g_free(argv[i]);
@@ -128,11 +120,9 @@ static void shift_args(gchar ** argv, int i)
         argv[j] = argv[j + 1];
 }
 
-static gboolean
-test_local_cmdline(GApplication * application,
-                   gchar *** arguments, gint * exit_status)
+static gboolean test_local_cmdline(GApplication *application, gchar ***arguments, gint *exit_status)
 {
-    TrgGtkAppPrivate *priv = trg_gtk_app_get_instance_private (TRG_GTK_APP(application));
+    TrgGtkAppPrivate *priv = trg_gtk_app_get_instance_private(TRG_GTK_APP(application));
     gchar **argv;
     gchar *cwd = g_get_current_dir();
     gchar *tmp;
@@ -163,7 +153,7 @@ test_local_cmdline(GApplication * application,
     return FALSE;
 }
 
-static void trg_gtk_app_class_init(TrgGtkAppClass * klass)
+static void trg_gtk_app_class_init(TrgGtkAppClass *klass)
 {
     GObjectClass *object_class = G_OBJECT_CLASS(klass);
     GApplicationClass *app_class = G_APPLICATION_CLASS(klass);
@@ -171,42 +161,29 @@ static void trg_gtk_app_class_init(TrgGtkAppClass * klass)
     object_class->get_property = trg_gtk_app_get_property;
     object_class->set_property = trg_gtk_app_set_property;
     app_class->local_command_line = test_local_cmdline;
-	//app_class->startup = trg_gtk_app_startup;
+    // app_class->startup = trg_gtk_app_startup;
     app_class->command_line = trg_gtk_app_command_line;
 
-    g_object_class_install_property(object_class,
-                                    PROP_CLIENT,
-                                    g_param_spec_pointer("trg-client",
-                                                         "TClient",
-                                                         _("Client"),
-                                                         G_PARAM_READWRITE|
-                                                         G_PARAM_CONSTRUCT_ONLY|
-                                                         G_PARAM_STATIC_STRINGS));
+    g_object_class_install_property(
+        object_class, PROP_CLIENT,
+        g_param_spec_pointer("trg-client", "TClient", _("Client"),
+                             G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS));
 
-    g_object_class_install_property(object_class,
-                                    PROP_MINIMISE_ON_START,
-                                    g_param_spec_boolean("min-on-start",
-                                                         "Min On Start",
-                                                         _("Min On Start"),
-                                                         FALSE,
-                                                         G_PARAM_READWRITE|
-                                                         G_PARAM_CONSTRUCT_ONLY|
-                                                         G_PARAM_STATIC_STRINGS));
+    g_object_class_install_property(
+        object_class, PROP_MINIMISE_ON_START,
+        g_param_spec_boolean("min-on-start", "Min On Start", _("Min On Start"), FALSE,
+                             G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS));
 }
 
-static void trg_gtk_app_init(TrgGtkApp * self)
+static void trg_gtk_app_init(TrgGtkApp *self)
 {
     g_application_set_inactivity_timeout(G_APPLICATION(self), 10000);
-    g_signal_connect(self, "command-line",
-                     G_CALLBACK(trg_gtk_app_command_line), NULL);
-    g_signal_connect(self, "startup",
-                     G_CALLBACK(trg_gtk_app_startup), NULL);
+    g_signal_connect(self, "command-line", G_CALLBACK(trg_gtk_app_command_line), NULL);
+    g_signal_connect(self, "startup", G_CALLBACK(trg_gtk_app_startup), NULL);
 }
 
-TrgGtkApp *trg_gtk_app_new(TrgClient * client)
+TrgGtkApp *trg_gtk_app_new(TrgClient *client)
 {
-    return g_object_new(TRG_TYPE_GTK_APP,
-                        "application-id", APPLICATION_ID,
-                        "flags", G_APPLICATION_HANDLES_COMMAND_LINE,
-                        "trg-client", client, NULL);
+    return g_object_new(TRG_TYPE_GTK_APP, "application-id", APPLICATION_ID, "flags",
+                        G_APPLICATION_HANDLES_COMMAND_LINE, "trg-client", client, NULL);
 }

--- a/src/trg-gtk-app.h
+++ b/src/trg-gtk-app.h
@@ -17,17 +17,16 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-
 #pragma once
 
-#include <gtk/gtk.h>
 #include "trg-client.h"
+#include <gtk/gtk.h>
 
 G_BEGIN_DECLS
 
 #define TRG_TYPE_GTK_APP (trg_gtk_app_get_type())
-G_DECLARE_FINAL_TYPE (TrgGtkApp, trg_gtk_app, TRG, GTK_APP, GtkApplication)
+G_DECLARE_FINAL_TYPE(TrgGtkApp, trg_gtk_app, TRG, GTK_APP, GtkApplication)
 
-TrgGtkApp *trg_gtk_app_new (TrgClient *client);
+TrgGtkApp *trg_gtk_app_new(TrgClient *client);
 
 G_END_DECLS

--- a/src/trg-json-widgets.c
+++ b/src/trg-json-widgets.c
@@ -22,8 +22,8 @@
 #include <gtk/gtk.h>
 #include <json-glib/json-glib.h>
 
-#include "trg-json-widgets.h"
 #include "json.h"
+#include "trg-json-widgets.h"
 #include "util.h"
 
 /* Functions for creating widgets that load/save their state from/to a JSON
@@ -34,36 +34,33 @@
  * pointers for load/save.
  */
 
-void trg_json_widgets_save(GList * list, JsonObject * out)
+void trg_json_widgets_save(GList *list, JsonObject *out)
 {
     GList *li;
     for (li = list; li; li = g_list_next(li)) {
-        trg_json_widget_desc *wd = (trg_json_widget_desc *) li->data;
+        trg_json_widget_desc *wd = (trg_json_widget_desc *)li->data;
         wd->saveFunc(wd->widget, out, wd->key);
     }
 }
 
-void trg_json_widget_desc_free(trg_json_widget_desc * wd)
+void trg_json_widget_desc_free(trg_json_widget_desc *wd)
 {
     g_free(wd->key);
     g_free(wd);
 }
 
-void trg_json_widget_desc_list_free(GList * list)
+void trg_json_widget_desc_list_free(GList *list)
 {
     g_list_free_full(list, (GDestroyNotify)trg_json_widget_desc_free);
 }
 
-void toggle_active_arg_is_sensitive(GtkToggleButton * b, gpointer data)
+void toggle_active_arg_is_sensitive(GtkToggleButton *b, gpointer data)
 {
-    gtk_widget_set_sensitive(GTK_WIDGET(data),
-                             gtk_toggle_button_get_active(b));
+    gtk_widget_set_sensitive(GTK_WIDGET(data), gtk_toggle_button_get_active(b));
 }
 
-GtkWidget *trg_json_widget_check_new(GList ** wl, JsonObject * obj,
-                                     const gchar * key,
-                                     const gchar * label,
-                                     GtkWidget * toggleDep)
+GtkWidget *trg_json_widget_check_new(GList **wl, JsonObject *obj, const gchar *key,
+                                     const gchar *label, GtkWidget *toggleDep)
 {
     GtkWidget *w = gtk_check_button_new_with_mnemonic(label);
     trg_json_widget_desc *wd = g_new0(trg_json_widget_desc, 1);
@@ -73,24 +70,20 @@ GtkWidget *trg_json_widget_check_new(GList ** wl, JsonObject * obj,
     wd->widget = w;
 
     if (toggleDep) {
-        gtk_widget_set_sensitive(w,
-                                 gtk_toggle_button_get_active
-                                 (GTK_TOGGLE_BUTTON(toggleDep)));
-        g_signal_connect(G_OBJECT(toggleDep), "toggled",
-                         G_CALLBACK(toggle_active_arg_is_sensitive), w);
+        gtk_widget_set_sensitive(w, gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(toggleDep)));
+        g_signal_connect(G_OBJECT(toggleDep), "toggled", G_CALLBACK(toggle_active_arg_is_sensitive),
+                         w);
     }
 
-    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(w),
-                                 json_object_get_boolean_member(obj, key));
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(w), json_object_get_boolean_member(obj, key));
 
     *wl = g_list_append(*wl, wd);
 
     return w;
 }
 
-GtkWidget *trg_json_widget_entry_new(GList ** wl, JsonObject * obj,
-                                     const gchar * key,
-                                     GtkWidget * toggleDep)
+GtkWidget *trg_json_widget_entry_new(GList **wl, JsonObject *obj, const gchar *key,
+                                     GtkWidget *toggleDep)
 {
     GtkWidget *w = gtk_entry_new();
     trg_json_widget_desc *wd = g_new0(trg_json_widget_desc, 1);
@@ -100,29 +93,22 @@ GtkWidget *trg_json_widget_entry_new(GList ** wl, JsonObject * obj,
     wd->widget = w;
 
     if (toggleDep) {
-        gtk_widget_set_sensitive(w,
-                                 gtk_toggle_button_get_active
-                                 (GTK_TOGGLE_BUTTON(toggleDep)));
-        g_signal_connect(G_OBJECT(toggleDep), "toggled",
-                         G_CALLBACK(toggle_active_arg_is_sensitive), w);
+        gtk_widget_set_sensitive(w, gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(toggleDep)));
+        g_signal_connect(G_OBJECT(toggleDep), "toggled", G_CALLBACK(toggle_active_arg_is_sensitive),
+                         w);
     }
 
-    gtk_entry_set_text(GTK_ENTRY(w),
-                       json_object_get_string_member(obj, key));
+    gtk_entry_set_text(GTK_ENTRY(w), json_object_get_string_member(obj, key));
 
     *wl = g_list_append(*wl, wd);
 
     return w;
 }
 
-GtkWidget *trg_json_widget_spin_int_new(GList ** wl, JsonObject * obj,
-                                    const gchar * key,
-                                    GtkWidget * toggleDep, gint min,
-                                    gint max, gint step)
+GtkWidget *trg_json_widget_spin_int_new(GList **wl, JsonObject *obj, const gchar *key,
+                                        GtkWidget *toggleDep, gint min, gint max, gint step)
 {
-    GtkWidget *w = gtk_spin_button_new_with_range((gdouble)min,
-                                                  (gdouble)max,
-                                                  (gdouble)step);
+    GtkWidget *w = gtk_spin_button_new_with_range((gdouble)min, (gdouble)max, (gdouble)step);
 
     gtk_spin_button_set_digits(GTK_SPIN_BUTTON(w), 0);
 
@@ -133,25 +119,21 @@ GtkWidget *trg_json_widget_spin_int_new(GList ** wl, JsonObject * obj,
     wd->widget = w;
 
     if (toggleDep) {
-        gtk_widget_set_sensitive(w,
-                                 gtk_toggle_button_get_active
-                                 (GTK_TOGGLE_BUTTON(toggleDep)));
-        g_signal_connect(G_OBJECT(toggleDep), "toggled",
-                         G_CALLBACK(toggle_active_arg_is_sensitive), w);
+        gtk_widget_set_sensitive(w, gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(toggleDep)));
+        g_signal_connect(G_OBJECT(toggleDep), "toggled", G_CALLBACK(toggle_active_arg_is_sensitive),
+                         w);
     }
 
-    gtk_spin_button_set_value(GTK_SPIN_BUTTON(w),
-                              (double)json_object_get_int_member(obj, key));
+    gtk_spin_button_set_value(GTK_SPIN_BUTTON(w), (double)json_object_get_int_member(obj, key));
 
     *wl = g_list_append(*wl, wd);
 
     return w;
 }
 
-GtkWidget *trg_json_widget_spin_double_new(GList ** wl, JsonObject * obj,
-                                    const gchar * key,
-                                    GtkWidget * toggleDep, gdouble min,
-                                    gdouble max, gdouble step)
+GtkWidget *trg_json_widget_spin_double_new(GList **wl, JsonObject *obj, const gchar *key,
+                                           GtkWidget *toggleDep, gdouble min, gdouble max,
+                                           gdouble step)
 {
     GtkWidget *w = gtk_spin_button_new_with_range(min, max, step);
 
@@ -162,52 +144,35 @@ GtkWidget *trg_json_widget_spin_double_new(GList ** wl, JsonObject * obj,
     wd->widget = w;
 
     if (toggleDep) {
-        gtk_widget_set_sensitive(w,
-                                 gtk_toggle_button_get_active
-                                 (GTK_TOGGLE_BUTTON(toggleDep)));
-        g_signal_connect(G_OBJECT(toggleDep), "toggled",
-                         G_CALLBACK(toggle_active_arg_is_sensitive), w);
+        gtk_widget_set_sensitive(w, gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(toggleDep)));
+        g_signal_connect(G_OBJECT(toggleDep), "toggled", G_CALLBACK(toggle_active_arg_is_sensitive),
+                         w);
     }
 
-    gtk_spin_button_set_value(GTK_SPIN_BUTTON(w),
-                              json_object_get_double_member(obj, key));
+    gtk_spin_button_set_value(GTK_SPIN_BUTTON(w), json_object_get_double_member(obj, key));
 
     *wl = g_list_append(*wl, wd);
 
     return w;
 }
 
-void
-trg_json_widget_check_save(GtkWidget * widget, JsonObject * obj,
-                           gchar * key)
+void trg_json_widget_check_save(GtkWidget *widget, JsonObject *obj, gchar *key)
 {
-    gboolean active =
-        gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
+    gboolean active = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
     json_object_set_boolean_member(obj, key, active);
 }
 
-void
-trg_json_widget_entry_save(GtkWidget * widget, JsonObject * obj,
-                           gchar * key)
+void trg_json_widget_entry_save(GtkWidget *widget, JsonObject *obj, gchar *key)
 {
-    json_object_set_string_member(obj, key,
-                                  gtk_entry_get_text(GTK_ENTRY(widget)));
+    json_object_set_string_member(obj, key, gtk_entry_get_text(GTK_ENTRY(widget)));
 }
 
-void
-trg_json_widget_spin_int_save(GtkWidget * widget, JsonObject * obj,
-                                 gchar * key)
+void trg_json_widget_spin_int_save(GtkWidget *widget, JsonObject *obj, gchar *key)
 {
-    json_object_set_int_member(obj, key,
-                               gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON
-                                                                (widget)));
+    json_object_set_int_member(obj, key, gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON(widget)));
 }
 
-void
-trg_json_widget_spin_double_save(GtkWidget * widget, JsonObject * obj,
-                                 gchar * key)
+void trg_json_widget_spin_double_save(GtkWidget *widget, JsonObject *obj, gchar *key)
 {
-    json_object_set_double_member(obj, key,
-                                  gtk_spin_button_get_value(GTK_SPIN_BUTTON
-                                                            (widget)));
+    json_object_set_double_member(obj, key, gtk_spin_button_get_value(GTK_SPIN_BUTTON(widget)));
 }

--- a/src/trg-json-widgets.h
+++ b/src/trg-json-widgets.h
@@ -26,37 +26,27 @@
 typedef struct {
     GtkWidget *widget;
     gchar *key;
-    void (*saveFunc) (GtkWidget * widget, JsonObject * obj, gchar * key);
+    void (*saveFunc)(GtkWidget *widget, JsonObject *obj, gchar *key);
 } trg_json_widget_desc;
 
-void toggle_active_arg_is_sensitive(GtkToggleButton * b, gpointer data);
+void toggle_active_arg_is_sensitive(GtkToggleButton *b, gpointer data);
 
-GtkWidget *trg_json_widget_check_new(GList ** wl, JsonObject * obj,
-                                     const gchar * key,
-                                     const gchar * label,
-                                     GtkWidget * toggleDep);
-GtkWidget *trg_json_widget_entry_new(GList ** wl, JsonObject * obj,
-                                     const gchar * key,
-                                     GtkWidget * toggleDep);
-GtkWidget *trg_json_widget_spin_int_new(GList ** wl, JsonObject * obj,
-                                        const gchar * key,
-                                        GtkWidget * toggleDep, gint min,
-                                        gint max, gint step);
-GtkWidget *trg_json_widget_spin_double_new(GList ** wl, JsonObject * obj,
-                                           const gchar * key,
-                                           GtkWidget * toggleDep, gdouble min,
-                                           gdouble max, gdouble step);
-void trg_json_widget_check_save(GtkWidget * widget, JsonObject * obj,
-                                gchar * key);
-void trg_json_widget_entry_save(GtkWidget * widget, JsonObject * obj,
-                                gchar * key);
-void trg_json_widget_spin_int_save(GtkWidget * widget, JsonObject * obj,
-                                   gchar * key);
-void trg_json_widget_spin_double_save(GtkWidget * widget, JsonObject * obj,
-                                      gchar * key);
+GtkWidget *trg_json_widget_check_new(GList **wl, JsonObject *obj, const gchar *key,
+                                     const gchar *label, GtkWidget *toggleDep);
+GtkWidget *trg_json_widget_entry_new(GList **wl, JsonObject *obj, const gchar *key,
+                                     GtkWidget *toggleDep);
+GtkWidget *trg_json_widget_spin_int_new(GList **wl, JsonObject *obj, const gchar *key,
+                                        GtkWidget *toggleDep, gint min, gint max, gint step);
+GtkWidget *trg_json_widget_spin_double_new(GList **wl, JsonObject *obj, const gchar *key,
+                                           GtkWidget *toggleDep, gdouble min, gdouble max,
+                                           gdouble step);
+void trg_json_widget_check_save(GtkWidget *widget, JsonObject *obj, gchar *key);
+void trg_json_widget_entry_save(GtkWidget *widget, JsonObject *obj, gchar *key);
+void trg_json_widget_spin_int_save(GtkWidget *widget, JsonObject *obj, gchar *key);
+void trg_json_widget_spin_double_save(GtkWidget *widget, JsonObject *obj, gchar *key);
 
-void trg_json_widget_desc_free(trg_json_widget_desc * wd);
-void trg_json_widget_desc_list_free(GList * list);
-void trg_json_widgets_save(GList * list, JsonObject * out);
+void trg_json_widget_desc_free(trg_json_widget_desc *wd);
+void trg_json_widget_desc_list_free(GList *list);
+void trg_json_widgets_save(GList *list, JsonObject *out);
 
-#endif                          /* TRG_JSON_WIDGETS_H_ */
+#endif /* TRG_JSON_WIDGETS_H_ */

--- a/src/trg-main-window.c
+++ b/src/trg-main-window.c
@@ -19,117 +19,99 @@
 
 #include "config.h"
 
+#include <curl/curl.h>
+#include <gdk/gdkkeysyms-compat.h>
+#include <gdk/gdkkeysyms.h>
+#include <gio/gio.h>
+#include <glib.h>
+#include <glib/gi18n.h>
+#include <glib/gprintf.h>
+#include <glib/gstdio.h>
+#include <gtk/gtk.h>
+#include <json-glib/json-glib.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
-#include <gio/gio.h>
-#include <glib.h>
-#include <glib/gprintf.h>
-#include <glib/gstdio.h>
-#include <glib/gi18n.h>
-#include <gtk/gtk.h>
-#include <json-glib/json-glib.h>
-#include <gdk/gdkkeysyms.h>
-#include <gdk/gdkkeysyms-compat.h>
-#include <curl/curl.h>
 #if HAVE_LIBAYATANA_APPINDICATOR
 #include <libayatana-appindicator/app-indicator.h>
 #elif HAVE_LIBAPPINDICATOR
 #include <libappindicator/app-indicator.h>
 #endif
 
-#include "trg-client.h"
 #include "json.h"
-#include "util.h"
+#include "protocol-constants.h"
+#include "remote-exec.h"
 #include "requests.h"
 #include "session-get.h"
 #include "torrent.h"
-#include "protocol-constants.h"
-#include "remote-exec.h"
+#include "trg-client.h"
+#include "util.h"
 
-#include "trg-main-window.h"
 #include "trg-about-window.h"
-#include "trg-tree-view.h"
-#include "trg-prefs.h"
-#include "trg-sortable-filtered-model.h"
-#include "trg-torrent-model.h"
-#include "trg-torrent-tree-view.h"
+#include "trg-files-model.h"
+#include "trg-files-tree-view.h"
+#include "trg-main-window.h"
+#include "trg-menu-bar.h"
 #include "trg-peers-model.h"
 #include "trg-peers-tree-view.h"
-#include "trg-files-tree-view.h"
-#include "trg-files-model.h"
-#include "trg-trackers-tree-view.h"
-#include "trg-trackers-model.h"
+#include "trg-prefs.h"
+#include "trg-sortable-filtered-model.h"
 #include "trg-state-selector.h"
+#include "trg-stats-dialog.h"
+#include "trg-status-bar.h"
+#include "trg-toolbar.h"
+#include "trg-torrent-add-dialog.h"
+#include "trg-torrent-add-url-dialog.h"
 #include "trg-torrent-graph.h"
+#include "trg-torrent-model.h"
 #include "trg-torrent-move-dialog.h"
 #include "trg-torrent-props-dialog.h"
-#include "trg-torrent-add-url-dialog.h"
-#include "trg-torrent-add-dialog.h"
-#include "trg-toolbar.h"
-#include "trg-menu-bar.h"
-#include "trg-status-bar.h"
-#include "trg-stats-dialog.h"
+#include "trg-torrent-tree-view.h"
+#include "trg-trackers-model.h"
+#include "trg-trackers-tree-view.h"
+#include "trg-tree-view.h"
 #if HAVE_RSS
 #include "trg-rss-window.h"
 #endif
-#include "trg-remote-prefs-dialog.h"
 #include "trg-preferences-dialog.h"
+#include "trg-remote-prefs-dialog.h"
 #include "upload.h"
 
 /* The rather large main window class, which glues everything together. */
 
-static void update_selected_torrent_notebook(TrgMainWindow * win,
-                                             gint mode, gint64 id);
-static void torrent_event_notification(TrgTorrentModel * model,
-                                       gchar * icon_name, gchar * desc,
-                                       gchar * prefKey,
-                                       GtkTreeIter * iter, gpointer data);
-static void connchange_whatever_tray(TrgMainWindow * win,
-                                     gboolean connected);
-static void update_whatever_tray(TrgMainWindow * win,
-                                 trg_torrent_model_update_stats *
-                                 stats);
-static void on_torrent_completed(TrgTorrentModel * model,
-                                 GtkTreeIter * iter, gpointer data);
-static void on_torrent_added(TrgTorrentModel * model, GtkTreeIter * iter,
-                             gpointer data);
-static gboolean delete_event(GtkWidget * w, GdkEvent * event,
-                             gpointer data);
-static void destroy_window(TrgMainWindow * win,
-                           gpointer data G_GNUC_UNUSED);
-static void torrent_tv_onRowActivated(GtkTreeView * treeview,
-                                      GtkTreePath * path,
-                                      GtkTreeViewColumn * col,
-                                      gpointer userdata);
-static void add_url_cb(GtkWidget * w, gpointer data);
-static void add_cb(GtkWidget * w, gpointer data);
-static void disconnect_cb(GtkWidget * w, gpointer data);
-static void open_local_prefs_cb(GtkWidget * w G_GNUC_UNUSED,
-                                TrgMainWindow * win);
-static void open_remote_prefs_cb(GtkWidget * w G_GNUC_UNUSED,
-                                 TrgMainWindow * win);
-static TrgToolbar *trg_main_window_toolbar_new(TrgMainWindow * win);
-static void verify_cb(GtkWidget * w, TrgMainWindow * win);
-static void reannounce_cb(GtkWidget * w, TrgMainWindow * win);
-static void pause_cb(GtkWidget * w, TrgMainWindow * win);
-static void resume_cb(GtkWidget * w, TrgMainWindow * win);
-static void remove_cb(GtkWidget * w, TrgMainWindow * win);
-static void resume_all_cb(GtkWidget * w, TrgMainWindow * win);
-static void pause_all_cb(GtkWidget * w, TrgMainWindow * win);
-static void move_cb(GtkWidget * w, TrgMainWindow * win);
-static void delete_cb(GtkWidget * w, TrgMainWindow * win);
-static void open_props_cb(GtkWidget * w, TrgMainWindow * win);
-static gint confirm_action_dialog(GtkWindow * gtk_win,
-                                  GtkTreeSelection * selection,
-                                  const gchar * action_name,
-                                  const gchar * action_label);
-static void view_stats_toggled_cb(GtkWidget * w, gpointer data);
-static void view_states_toggled_cb(GtkCheckMenuItem * w,
-                                   TrgMainWindow * win);
-static void view_notebook_toggled_cb(GtkCheckMenuItem * w,
-                                     TrgMainWindow * win);
-static GtkWidget *trg_main_window_notebook_new(TrgMainWindow * win);
+static void update_selected_torrent_notebook(TrgMainWindow *win, gint mode, gint64 id);
+static void torrent_event_notification(TrgTorrentModel *model, gchar *icon_name, gchar *desc,
+                                       gchar *prefKey, GtkTreeIter *iter, gpointer data);
+static void connchange_whatever_tray(TrgMainWindow *win, gboolean connected);
+static void update_whatever_tray(TrgMainWindow *win, trg_torrent_model_update_stats *stats);
+static void on_torrent_completed(TrgTorrentModel *model, GtkTreeIter *iter, gpointer data);
+static void on_torrent_added(TrgTorrentModel *model, GtkTreeIter *iter, gpointer data);
+static gboolean delete_event(GtkWidget *w, GdkEvent *event, gpointer data);
+static void destroy_window(TrgMainWindow *win, gpointer data G_GNUC_UNUSED);
+static void torrent_tv_onRowActivated(GtkTreeView *treeview, GtkTreePath *path,
+                                      GtkTreeViewColumn *col, gpointer userdata);
+static void add_url_cb(GtkWidget *w, gpointer data);
+static void add_cb(GtkWidget *w, gpointer data);
+static void disconnect_cb(GtkWidget *w, gpointer data);
+static void open_local_prefs_cb(GtkWidget *w G_GNUC_UNUSED, TrgMainWindow *win);
+static void open_remote_prefs_cb(GtkWidget *w G_GNUC_UNUSED, TrgMainWindow *win);
+static TrgToolbar *trg_main_window_toolbar_new(TrgMainWindow *win);
+static void verify_cb(GtkWidget *w, TrgMainWindow *win);
+static void reannounce_cb(GtkWidget *w, TrgMainWindow *win);
+static void pause_cb(GtkWidget *w, TrgMainWindow *win);
+static void resume_cb(GtkWidget *w, TrgMainWindow *win);
+static void remove_cb(GtkWidget *w, TrgMainWindow *win);
+static void resume_all_cb(GtkWidget *w, TrgMainWindow *win);
+static void pause_all_cb(GtkWidget *w, TrgMainWindow *win);
+static void move_cb(GtkWidget *w, TrgMainWindow *win);
+static void delete_cb(GtkWidget *w, TrgMainWindow *win);
+static void open_props_cb(GtkWidget *w, TrgMainWindow *win);
+static gint confirm_action_dialog(GtkWindow *gtk_win, GtkTreeSelection *selection,
+                                  const gchar *action_name, const gchar *action_label);
+static void view_stats_toggled_cb(GtkWidget *w, gpointer data);
+static void view_states_toggled_cb(GtkCheckMenuItem *w, TrgMainWindow *win);
+static void view_notebook_toggled_cb(GtkCheckMenuItem *w, TrgMainWindow *win);
+static GtkWidget *trg_main_window_notebook_new(TrgMainWindow *win);
 static gboolean on_session_get_timer(gpointer data);
 static gboolean on_session_get(gpointer data);
 static gboolean on_torrent_get(gpointer data, int mode);
@@ -139,76 +121,55 @@ static gboolean on_torrent_get_update(gpointer data);
 static gboolean on_torrent_get_interactive(gpointer data);
 static gboolean trg_session_update_timerfunc(gpointer data);
 static gboolean trg_update_torrents_timerfunc(gpointer data);
-static void open_about_cb(GtkWidget * w, GtkWindow * parent);
-static gboolean trg_torrent_tree_view_visible_func(GtkTreeModel * model,
-                                                   GtkTreeIter * iter,
+static void open_about_cb(GtkWidget *w, GtkWindow *parent);
+static gboolean trg_torrent_tree_view_visible_func(GtkTreeModel *model, GtkTreeIter *iter,
                                                    gpointer data);
-static TrgTorrentTreeView
-    * trg_main_window_torrent_tree_view_new(TrgMainWindow * win,
-                                            GtkTreeModel * model);
-static gboolean trg_dialog_error_handler(TrgMainWindow * win,
-                                         trg_response * response);
-static gboolean torrent_selection_changed(GtkTreeSelection * selection,
-                                          TrgMainWindow * win);
-static void trg_main_window_torrent_scrub(TrgMainWindow * win);
-static void entry_filter_changed_cb(GtkWidget * w, TrgMainWindow * win);
-static void torrent_state_selection_changed(TrgStateSelector * selector,
-                                            guint flag, gpointer data);
-static void trg_main_window_conn_changed(TrgMainWindow * win,
-                                         gboolean connected);
-static void trg_main_window_get_property(GObject * object,
-                                         guint property_id, GValue * value,
-                                         GParamSpec * pspec);
-static void trg_main_window_set_property(GObject * object,
-                                         guint property_id,
-                                         const GValue * value,
-                                         GParamSpec * pspec);
-static void quit_cb(GtkWidget * w, gpointer data);
-static TrgMenuBar *trg_main_window_menu_bar_new(TrgMainWindow * win);
-static void clear_filter_entry_cb(GtkEntry * entry,
-                                  GtkEntryIconPosition icon_pos,
-                                  GdkEvent * event, gpointer user_data);
-static GtkWidget *trg_imagemenuitem_box(const gchar * text,
-                                        char * icon_name);
-static GtkWidget *trg_imagemenuitem_new(GtkMenuShell * shell,
-                                        const gchar * text, char * icon_name,
-                                        gboolean sensitive, GCallback cb,
-                                        gpointer cbdata);
-static void set_limit_cb(GtkWidget * w, TrgMainWindow * win);
-static GtkWidget *limit_item_new(TrgMainWindow * win, GtkWidget * menu,
-                                 gint64 currentLimit, gfloat limit);
-static GtkWidget *limit_menu_new(TrgMainWindow * win, gchar * title,
-                                 gchar * enabledKey, gchar * speedKey,
-                                 JsonArray * ids);
-static void trg_torrent_tv_view_menu(GtkWidget * treeview,
-                                     GdkEventButton * event,
-                                     TrgMainWindow * win);
+static TrgTorrentTreeView *trg_main_window_torrent_tree_view_new(TrgMainWindow *win,
+                                                                 GtkTreeModel *model);
+static gboolean trg_dialog_error_handler(TrgMainWindow *win, trg_response *response);
+static gboolean torrent_selection_changed(GtkTreeSelection *selection, TrgMainWindow *win);
+static void trg_main_window_torrent_scrub(TrgMainWindow *win);
+static void entry_filter_changed_cb(GtkWidget *w, TrgMainWindow *win);
+static void torrent_state_selection_changed(TrgStateSelector *selector, guint flag, gpointer data);
+static void trg_main_window_conn_changed(TrgMainWindow *win, gboolean connected);
+static void trg_main_window_get_property(GObject *object, guint property_id, GValue *value,
+                                         GParamSpec *pspec);
+static void trg_main_window_set_property(GObject *object, guint property_id, const GValue *value,
+                                         GParamSpec *pspec);
+static void quit_cb(GtkWidget *w, gpointer data);
+static TrgMenuBar *trg_main_window_menu_bar_new(TrgMainWindow *win);
+static void clear_filter_entry_cb(GtkEntry *entry, GtkEntryIconPosition icon_pos, GdkEvent *event,
+                                  gpointer user_data);
+static GtkWidget *trg_imagemenuitem_box(const gchar *text, char *icon_name);
+static GtkWidget *trg_imagemenuitem_new(GtkMenuShell *shell, const gchar *text, char *icon_name,
+                                        gboolean sensitive, GCallback cb, gpointer cbdata);
+static void set_limit_cb(GtkWidget *w, TrgMainWindow *win);
+static GtkWidget *limit_item_new(TrgMainWindow *win, GtkWidget *menu, gint64 currentLimit,
+                                 gfloat limit);
+static GtkWidget *limit_menu_new(TrgMainWindow *win, gchar *title, gchar *enabledKey,
+                                 gchar *speedKey, JsonArray *ids);
+static void trg_torrent_tv_view_menu(GtkWidget *treeview, GdkEventButton *event,
+                                     TrgMainWindow *win);
 #if HAVE_LIBAPPINDICATOR
-static GtkMenu *trg_tray_view_menu(TrgMainWindow * win, const gchar * msg);
+static GtkMenu *trg_tray_view_menu(TrgMainWindow *win, const gchar *msg);
 #endif
-static gboolean torrent_tv_button_pressed_cb(GtkWidget * treeview,
-                                             GdkEventButton * event,
+static gboolean torrent_tv_button_pressed_cb(GtkWidget *treeview, GdkEventButton *event,
                                              gpointer userdata);
-static gboolean torrent_tv_popup_menu_cb(GtkWidget * treeview,
-                                         gpointer userdata);
-static void trg_main_window_set_hidden_to_tray(TrgMainWindow * win,
-                                               gboolean hidden);
-static gboolean is_ready_for_torrent_action(TrgMainWindow * win);
+static gboolean torrent_tv_popup_menu_cb(GtkWidget *treeview, gpointer userdata);
+static void trg_main_window_set_hidden_to_tray(TrgMainWindow *win, gboolean hidden);
+static gboolean is_ready_for_torrent_action(TrgMainWindow *win);
 
-struct _TrgMainWindow
-{
-	GtkApplicationWindow parent;
+struct _TrgMainWindow {
+    GtkApplicationWindow parent;
 };
 
-typedef struct
-{
+typedef struct {
     TrgClient *client;
     TrgToolbar *toolBar;
     TrgMenuBar *menuBar;
 
     TrgStatusBar *statusBar;
-    GtkWidget *iconStatusItem, *iconDownloadingItem, *iconSeedingItem,
-        *iconSepItem;
+    GtkWidget *iconStatusItem, *iconDownloadingItem, *iconSeedingItem, *iconSepItem;
 #if HAVE_LIBAPPINDICATOR
     AppIndicator *appIndicator;
 #endif
@@ -253,10 +214,12 @@ typedef struct
 G_DEFINE_TYPE_WITH_PRIVATE(TrgMainWindow, trg_main_window, GTK_TYPE_WINDOW)
 
 enum {
-    PROP_0, PROP_CLIENT, PROP_MINIMISE_ON_START
+    PROP_0,
+    PROP_CLIENT,
+    PROP_MINIMISE_ON_START
 };
 
-static void reset_connect_args(TrgMainWindow * win)
+static void reset_connect_args(TrgMainWindow *win)
 {
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
     if (priv->args) {
@@ -265,18 +228,17 @@ static void reset_connect_args(TrgMainWindow * win)
     }
 }
 
-static void trg_main_window_init(TrgMainWindow * self)
+static void trg_main_window_init(TrgMainWindow *self)
 {
 }
 
-gint trg_mw_get_selected_torrent_id(TrgMainWindow * win)
+gint trg_mw_get_selected_torrent_id(TrgMainWindow *win)
 {
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
     return priv->selectedTorrentId;
 }
 
-static void
-update_selected_torrent_notebook(TrgMainWindow * win, gint mode, gint64 id)
+static void update_selected_torrent_notebook(TrgMainWindow *win, gint mode, gint64 id)
 {
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
     TrgClient *client = priv->client;
@@ -284,19 +246,15 @@ update_selected_torrent_notebook(TrgMainWindow * win, gint mode, gint64 id)
     JsonObject *t;
     GtkTreeIter iter;
 
-    if (id >= 0
-        && get_torrent_data(trg_client_get_torrent_table(client), id, &t,
-                            &iter)) {
+    if (id >= 0 && get_torrent_data(trg_client_get_torrent_table(client), id, &t, &iter)) {
         trg_toolbar_torrent_actions_sensitive(priv->toolBar, TRUE);
         trg_menu_bar_torrent_actions_sensitive(priv->menuBar, TRUE);
         trg_general_panel_update(priv->genDetails, t, &iter);
         trg_trackers_model_update(priv->trackersModel, serial, t, mode);
-        trg_files_model_update(priv->filesModel,
-                               GTK_TREE_VIEW(priv->filesTreeView),
-                               serial, t, mode);
-        trg_peers_model_update(priv->peersModel,
-                               TRG_TREE_VIEW(priv->peersTreeView),
-                               serial, t, mode);
+        trg_files_model_update(priv->filesModel, GTK_TREE_VIEW(priv->filesTreeView), serial, t,
+                               mode);
+        trg_peers_model_update(priv->peersModel, TRG_TREE_VIEW(priv->peersTreeView), serial, t,
+                               mode);
     } else {
         trg_main_window_torrent_scrub(win);
     }
@@ -304,11 +262,8 @@ update_selected_torrent_notebook(TrgMainWindow * win, gint mode, gint64 id)
     priv->selectedTorrentId = id;
 }
 
-static void
-torrent_event_notification(TrgTorrentModel * model,
-                           gchar * icon_name, gchar * desc,
-                           gchar * prefKey,
-                           GtkTreeIter * iter, gpointer data)
+static void torrent_event_notification(TrgTorrentModel *model, gchar *icon_name, gchar *desc,
+                                       gchar *prefKey, GtkTreeIter *iter, gpointer data)
 {
     TrgMainWindow *win = TRG_MAIN_WINDOW(data);
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
@@ -320,8 +275,7 @@ torrent_event_notification(TrgTorrentModel * model,
     if (!trg_prefs_get_bool(prefs, prefKey, TRG_PREFS_NOFLAGS))
         return;
 
-    gtk_tree_model_get(GTK_TREE_MODEL(model), iter, TORRENT_COLUMN_NAME,
-                       &name, -1);
+    gtk_tree_model_get(GTK_TREE_MODEL(model), iter, TORRENT_COLUMN_NAME, &name, -1);
 
     icon = g_themed_icon_new(icon_name);
     notify = g_notification_new(name);
@@ -335,73 +289,54 @@ torrent_event_notification(TrgTorrentModel * model,
     g_free(name);
 }
 
-static void
-on_torrent_completed(TrgTorrentModel * model,
-                     GtkTreeIter * iter, gpointer data)
+static void on_torrent_completed(TrgTorrentModel *model, GtkTreeIter *iter, gpointer data)
 {
-    torrent_event_notification(model, "trg-gtk-apply",
-                               _("This torrent has completed."),
-                               TRG_PREFS_KEY_COMPLETE_NOTIFY,
-                               iter, data);
+    torrent_event_notification(model, "trg-gtk-apply", _("This torrent has completed."),
+                               TRG_PREFS_KEY_COMPLETE_NOTIFY, iter, data);
 }
 
-static void
-on_torrent_added(TrgTorrentModel * model, GtkTreeIter * iter,
-                 gpointer data)
+static void on_torrent_added(TrgTorrentModel *model, GtkTreeIter *iter, gpointer data)
 {
-    torrent_event_notification(model, "list-add",
-                               _("This torrent has been added."),
-                               TRG_PREFS_KEY_ADD_NOTIFY,
-                               iter, data);
+    torrent_event_notification(model, "list-add", _("This torrent has been added."),
+                               TRG_PREFS_KEY_ADD_NOTIFY, iter, data);
 }
 
-static gboolean
-delete_event(GtkWidget * w, GdkEvent * event G_GNUC_UNUSED,
-             gpointer data G_GNUC_UNUSED)
+static gboolean delete_event(GtkWidget *w, GdkEvent *event G_GNUC_UNUSED,
+                             gpointer data G_GNUC_UNUSED)
 {
     return FALSE;
 }
 
-static void
-destroy_window(TrgMainWindow * win, gpointer data G_GNUC_UNUSED)
+static void destroy_window(TrgMainWindow *win, gpointer data G_GNUC_UNUSED)
 {
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
     TrgPrefs *prefs = trg_client_get_prefs(priv->client);
 
-    trg_prefs_set_int(prefs, TRG_PREFS_KEY_WINDOW_HEIGHT, priv->height,
-                      TRG_PREFS_GLOBAL);
-    trg_prefs_set_int(prefs, TRG_PREFS_KEY_WINDOW_WIDTH, priv->width,
-                      TRG_PREFS_GLOBAL);
+    trg_prefs_set_int(prefs, TRG_PREFS_KEY_WINDOW_HEIGHT, priv->height, TRG_PREFS_GLOBAL);
+    trg_prefs_set_int(prefs, TRG_PREFS_KEY_WINDOW_WIDTH, priv->width, TRG_PREFS_GLOBAL);
     trg_prefs_set_int(prefs, TRG_PREFS_KEY_NOTEBOOK_PANED_POS,
-                      gtk_paned_get_position(GTK_PANED(priv->vpaned)),
-                      TRG_PREFS_GLOBAL);
+                      gtk_paned_get_position(GTK_PANED(priv->vpaned)), TRG_PREFS_GLOBAL);
     trg_prefs_set_int(prefs, TRG_PREFS_KEY_STATES_PANED_POS,
-                      gtk_paned_get_position(GTK_PANED(priv->hpaned)),
-                      TRG_PREFS_GLOBAL);
+                      gtk_paned_get_position(GTK_PANED(priv->hpaned)), TRG_PREFS_GLOBAL);
 
     trg_tree_view_persist(TRG_TREE_VIEW(priv->peersTreeView),
-                          TRG_TREE_VIEW_PERSIST_SORT |
-                          TRG_TREE_VIEW_PERSIST_LAYOUT);
+                          TRG_TREE_VIEW_PERSIST_SORT | TRG_TREE_VIEW_PERSIST_LAYOUT);
     trg_tree_view_persist(TRG_TREE_VIEW(priv->filesTreeView),
-                          TRG_TREE_VIEW_PERSIST_SORT |
-                          TRG_TREE_VIEW_PERSIST_LAYOUT);
-    trg_tree_view_persist(TRG_TREE_VIEW(priv->torrentTreeView),
-                          TRG_TREE_VIEW_PERSIST_SORT |
-                          TRG_TREE_VIEW_SORTABLE_PARENT |
-                          (trg_prefs_get_int
-                           (prefs, TRG_PREFS_KEY_STYLE,
-                            TRG_PREFS_GLOBAL) ==
-                           TRG_STYLE_CLASSIC ? TRG_TREE_VIEW_PERSIST_LAYOUT
-                           : 0));
+                          TRG_TREE_VIEW_PERSIST_SORT | TRG_TREE_VIEW_PERSIST_LAYOUT);
+    trg_tree_view_persist(
+        TRG_TREE_VIEW(priv->torrentTreeView),
+        TRG_TREE_VIEW_PERSIST_SORT | TRG_TREE_VIEW_SORTABLE_PARENT
+            | (trg_prefs_get_int(prefs, TRG_PREFS_KEY_STYLE, TRG_PREFS_GLOBAL) == TRG_STYLE_CLASSIC
+                   ? TRG_TREE_VIEW_PERSIST_LAYOUT
+                   : 0));
     trg_tree_view_persist(TRG_TREE_VIEW(priv->trackersTreeView),
-                          TRG_TREE_VIEW_PERSIST_SORT |
-                          TRG_TREE_VIEW_PERSIST_LAYOUT);
+                          TRG_TREE_VIEW_PERSIST_SORT | TRG_TREE_VIEW_PERSIST_LAYOUT);
     trg_prefs_save(prefs);
 
-    g_application_quit (g_application_get_default ());
+    g_application_quit(g_application_get_default());
 }
 
-static void open_props_cb(GtkWidget * w G_GNUC_UNUSED, TrgMainWindow * win)
+static void open_props_cb(GtkWidget *w G_GNUC_UNUSED, TrgMainWindow *win)
 {
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
     TrgTorrentPropsDialog *dialog;
@@ -409,15 +344,13 @@ static void open_props_cb(GtkWidget * w G_GNUC_UNUSED, TrgMainWindow * win)
     if (priv->selectedTorrentId < 0)
         return;
 
-    dialog = trg_torrent_props_dialog_new(GTK_WINDOW(win),
-                                          priv->torrentTreeView,
-                                          priv->torrentModel,
-                                          priv->client);
+    dialog = trg_torrent_props_dialog_new(GTK_WINDOW(win), priv->torrentTreeView,
+                                          priv->torrentModel, priv->client);
 
     gtk_widget_show_all(GTK_WIDGET(dialog));
 }
 
-static void copy_magnetlink_cb(GtkWidget * w G_GNUC_UNUSED, TrgMainWindow * win)
+static void copy_magnetlink_cb(GtkWidget *w G_GNUC_UNUSED, TrgMainWindow *win)
 {
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
     JsonObject *json = NULL;
@@ -426,32 +359,27 @@ static void copy_magnetlink_cb(GtkWidget * w G_GNUC_UNUSED, TrgMainWindow * win)
     if (priv->selectedTorrentId < 0)
         return;
 
-    if(get_torrent_data(trg_client_get_torrent_table(priv->client),
-                priv->selectedTorrentId, &json, NULL))
+    if (get_torrent_data(trg_client_get_torrent_table(priv->client), priv->selectedTorrentId, &json,
+                         NULL))
         gtk_clipboard_set_text(clip, torrent_get_magnetlink(json), -1);
 }
 
-static void
-torrent_tv_onRowActivated(GtkTreeView * treeview,
-                          GtkTreePath * path G_GNUC_UNUSED,
-                          GtkTreeViewColumn *
-                          col G_GNUC_UNUSED, gpointer userdata)
+static void torrent_tv_onRowActivated(GtkTreeView *treeview, GtkTreePath *path G_GNUC_UNUSED,
+                                      GtkTreeViewColumn *col G_GNUC_UNUSED, gpointer userdata)
 {
     open_props_cb(GTK_WIDGET(treeview), userdata);
 }
 
-static void add_url_cb(GtkWidget * w G_GNUC_UNUSED, gpointer data)
+static void add_url_cb(GtkWidget *w G_GNUC_UNUSED, gpointer data)
 {
     TrgMainWindow *win = TRG_MAIN_WINDOW(data);
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
 
-    TrgTorrentAddUrlDialog *dlg = trg_torrent_add_url_dialog_new(win,
-                                                                 priv->
-                                                                 client);
+    TrgTorrentAddUrlDialog *dlg = trg_torrent_add_url_dialog_new(win, priv->client);
     gtk_widget_show_all(GTK_WIDGET(dlg));
 }
 
-static void add_cb(GtkWidget * w G_GNUC_UNUSED, gpointer data)
+static void add_cb(GtkWidget *w G_GNUC_UNUSED, gpointer data)
 {
     TrgMainWindow *win = TRG_MAIN_WINDOW(data);
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
@@ -460,27 +388,25 @@ static void add_cb(GtkWidget * w G_GNUC_UNUSED, gpointer data)
         trg_torrent_add_dialog(win, priv->client);
 }
 
-static void pause_cb(GtkWidget * w G_GNUC_UNUSED, TrgMainWindow * win)
+static void pause_cb(GtkWidget *w G_GNUC_UNUSED, TrgMainWindow *win)
 {
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
 
     if (trg_client_is_connected(priv->client))
-        dispatch_async(priv->client,
-                       torrent_pause(build_json_id_array
-                                     (priv->torrentTreeView)),
+        dispatch_async(priv->client, torrent_pause(build_json_id_array(priv->torrentTreeView)),
                        on_generic_interactive_action_response, win);
 }
 
-static void pause_all_cb(GtkWidget * w G_GNUC_UNUSED, TrgMainWindow * win)
+static void pause_all_cb(GtkWidget *w G_GNUC_UNUSED, TrgMainWindow *win)
 {
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
 
     if (trg_client_is_connected(priv->client))
-        dispatch_async(priv->client, torrent_pause(NULL),
-                       on_generic_interactive_action_response, win);
+        dispatch_async(priv->client, torrent_pause(NULL), on_generic_interactive_action_response,
+                       win);
 }
 
-gint trg_add_from_filename(TrgMainWindow * win, gchar ** uris)
+gint trg_add_from_filename(TrgMainWindow *win, gchar **uris)
 {
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
     TrgClient *client = priv->client;
@@ -495,9 +421,9 @@ gint trg_add_from_filename(TrgMainWindow * win, gchar ** uris)
 
     if (uris) {
         for (i = 0; uris[i]; i++) {
-        	if (is_minimised_arg(uris[i]))
-        		g_free(uris[i]);
-        	else if (uris[i])
+            if (is_minimised_arg(uris[i]))
+                g_free(uris[i]);
+            else if (uris[i])
                 filesList = g_slist_append(filesList, uris[i]);
         }
     }
@@ -507,11 +433,9 @@ gint trg_add_from_filename(TrgMainWindow * win, gchar ** uris)
     if (!filesList)
         return EXIT_SUCCESS;
 
-    if (trg_prefs_get_bool(prefs, TRG_PREFS_KEY_ADD_OPTIONS_DIALOG,
-                           TRG_PREFS_GLOBAL)) {
-        TrgTorrentAddDialog *dialog =
-            trg_torrent_add_dialog_new_from_filenames(win, client,
-                                       filesList);
+    if (trg_prefs_get_bool(prefs, TRG_PREFS_KEY_ADD_OPTIONS_DIALOG, TRG_PREFS_GLOBAL)) {
+        TrgTorrentAddDialog *dialog
+            = trg_torrent_add_dialog_new_from_filenames(win, client, filesList);
 
         gtk_widget_show_all(GTK_WIDGET(dialog));
         gtk_window_present(GTK_WINDOW(dialog));
@@ -530,27 +454,25 @@ gint trg_add_from_filename(TrgMainWindow * win, gchar ** uris)
     return EXIT_SUCCESS;
 }
 
-static void resume_all_cb(GtkWidget * w G_GNUC_UNUSED, TrgMainWindow * win)
+static void resume_all_cb(GtkWidget *w G_GNUC_UNUSED, TrgMainWindow *win)
 {
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
 
     if (trg_client_is_connected(priv->client))
-        dispatch_async(priv->client, torrent_start(NULL),
-                       on_generic_interactive_action_response, win);
+        dispatch_async(priv->client, torrent_start(NULL), on_generic_interactive_action_response,
+                       win);
 }
 
-static void resume_cb(GtkWidget * w G_GNUC_UNUSED, TrgMainWindow * win)
+static void resume_cb(GtkWidget *w G_GNUC_UNUSED, TrgMainWindow *win)
 {
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
 
     if (trg_client_is_connected(priv->client))
-        dispatch_async(priv->client,
-                       torrent_start(build_json_id_array
-                                     (priv->torrentTreeView)),
+        dispatch_async(priv->client, torrent_start(build_json_id_array(priv->torrentTreeView)),
                        on_generic_interactive_action_response, win);
 }
 
-static void disconnect_cb(GtkWidget * w G_GNUC_UNUSED, gpointer data)
+static void disconnect_cb(GtkWidget *w G_GNUC_UNUSED, gpointer data)
 {
     TrgMainWindow *win = TRG_MAIN_WINDOW(data);
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
@@ -560,7 +482,7 @@ static void disconnect_cb(GtkWidget * w G_GNUC_UNUSED, gpointer data)
     trg_status_bar_reset(priv->statusBar);
 }
 
-void connect_cb(GtkWidget * w, gpointer data)
+void connect_cb(GtkWidget *w, gpointer data)
 {
     TrgMainWindow *win = TRG_MAIN_WINDOW(data);
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
@@ -572,7 +494,7 @@ void connect_cb(GtkWidget * w, gpointer data)
     int populate_result;
 
     if (w)
-        profile = (JsonObject *) g_object_get_data(G_OBJECT(w), "profile");
+        profile = (JsonObject *)g_object_get_data(G_OBJECT(w), "profile");
 
     if (trg_client_is_connected(priv->client))
         disconnect_cb(NULL, data);
@@ -596,201 +518,169 @@ void connect_cb(GtkWidget * w, gpointer data)
             break;
         }
 
-	dialog = gtk_message_dialog_new(GTK_WINDOW(data),
-					GTK_DIALOG_DESTROY_WITH_PARENT,
-					(populate_result == TRG_NO_HOSTNAME_SET) ? GTK_MESSAGE_INFO : GTK_MESSAGE_ERROR, 
-					GTK_BUTTONS_OK,
-					"%s", msg);
-	gtk_dialog_run(GTK_DIALOG(dialog));
-	gtk_widget_destroy(dialog);
+        dialog = gtk_message_dialog_new(
+            GTK_WINDOW(data), GTK_DIALOG_DESTROY_WITH_PARENT,
+            (populate_result == TRG_NO_HOSTNAME_SET) ? GTK_MESSAGE_INFO : GTK_MESSAGE_ERROR,
+            GTK_BUTTONS_OK, "%s", msg);
+        gtk_dialog_run(GTK_DIALOG(dialog));
+        gtk_widget_destroy(dialog);
         reset_connect_args(TRG_MAIN_WINDOW(data));
 
-	if (populate_result == TRG_NO_HOSTNAME_SET)
-	  open_local_prefs_cb (NULL, win);
+        if (populate_result == TRG_NO_HOSTNAME_SET)
+            open_local_prefs_cb(NULL, win);
 
         return;
     }
 
-    trg_status_bar_push_connection_msg(priv->statusBar,
-                                       _("Connecting..."));
+    trg_status_bar_push_connection_msg(priv->statusBar, _("Connecting..."));
     trg_client_inc_connid(priv->client);
     dispatch_async(priv->client, session_get(), on_session_get, data);
 }
 
-static void
-open_local_prefs_cb(GtkWidget * w G_GNUC_UNUSED, TrgMainWindow * win)
+static void open_local_prefs_cb(GtkWidget *w G_GNUC_UNUSED, TrgMainWindow *win)
 {
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
 
-    GtkWidget *dlg = trg_preferences_dialog_get_instance(win,
-                                                         priv->client);
+    GtkWidget *dlg = trg_preferences_dialog_get_instance(win, priv->client);
     gtk_widget_show_all(dlg);
 }
 
-static void
-open_remote_prefs_cb(GtkWidget * w G_GNUC_UNUSED, TrgMainWindow * win)
+static void open_remote_prefs_cb(GtkWidget *w G_GNUC_UNUSED, TrgMainWindow *win)
 {
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
 
     if (trg_client_is_connected(priv->client))
-        gtk_widget_show_all(GTK_WIDGET
-                            (trg_remote_prefs_dialog_get_instance
-                             (win, priv->client)));
+        gtk_widget_show_all(GTK_WIDGET(trg_remote_prefs_dialog_get_instance(win, priv->client)));
 }
 
-static void
-main_window_toggle_filter_dirs(GtkCheckMenuItem * w, gpointer data)
+static void main_window_toggle_filter_dirs(GtkCheckMenuItem *w, gpointer data)
 {
     TrgMainWindow *win = TRG_MAIN_WINDOW(data);
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
 
     if (gtk_widget_is_sensitive(GTK_WIDGET(w)))
-        trg_state_selector_set_show_dirs(priv->stateSelector,
-                                         gtk_check_menu_item_get_active
-                                         (w));
+        trg_state_selector_set_show_dirs(priv->stateSelector, gtk_check_menu_item_get_active(w));
 }
 
-static void
-main_window_toggle_filter_trackers(GtkCheckMenuItem * w, gpointer data)
+static void main_window_toggle_filter_trackers(GtkCheckMenuItem *w, gpointer data)
 {
     TrgMainWindow *win = TRG_MAIN_WINDOW(data);
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
 
     if (gtk_widget_is_sensitive(GTK_WIDGET(w)))
         trg_state_selector_set_show_trackers(priv->stateSelector,
-                                             gtk_check_menu_item_get_active
-                                             (w));
+                                             gtk_check_menu_item_get_active(w));
 }
 
-static void
-main_window_toggle_directories_first(GtkCheckMenuItem * w, gpointer data){
-	TrgMainWindow *win = TRG_MAIN_WINDOW(data);
-	TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
+static void main_window_toggle_directories_first(GtkCheckMenuItem *w, gpointer data)
+{
+    TrgMainWindow *win = TRG_MAIN_WINDOW(data);
+    TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
 
-	if (gtk_widget_is_sensitive(GTK_WIDGET(w)))
-		trg_state_selector_set_directories_first(priv->stateSelector,
-											gtk_check_menu_item_get_active(w));
+    if (gtk_widget_is_sensitive(GTK_WIDGET(w)))
+        trg_state_selector_set_directories_first(priv->stateSelector,
+                                                 gtk_check_menu_item_get_active(w));
 }
 
-static TrgToolbar *trg_main_window_toolbar_new(TrgMainWindow * win)
+static TrgToolbar *trg_main_window_toolbar_new(TrgMainWindow *win)
 {
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
     TrgPrefs *prefs = trg_client_get_prefs(priv->client);
 
     GObject *b_connect, *b_disconnect, *b_add, *b_resume, *b_pause;
-    GObject *b_remove, *b_delete, *b_props, *b_local_prefs,
-        *b_remote_prefs;
+    GObject *b_remove, *b_delete, *b_props, *b_local_prefs, *b_remote_prefs;
 
     TrgToolbar *toolBar = trg_toolbar_new(win, prefs);
 
-    g_object_get(toolBar, "connect-button", &b_connect,
-                 "disconnect-button", &b_disconnect, "add-button", &b_add,
-                 "resume-button", &b_resume, "pause-button", &b_pause,
-                 "delete-button", &b_delete, "remove-button", &b_remove,
-                 "props-button", &b_props, "remote-prefs-button",
-                 &b_remote_prefs, "local-prefs-button", &b_local_prefs,
+    g_object_get(toolBar, "connect-button", &b_connect, "disconnect-button", &b_disconnect,
+                 "add-button", &b_add, "resume-button", &b_resume, "pause-button", &b_pause,
+                 "delete-button", &b_delete, "remove-button", &b_remove, "props-button", &b_props,
+                 "remote-prefs-button", &b_remote_prefs, "local-prefs-button", &b_local_prefs,
                  NULL);
 
     g_signal_connect(b_connect, "clicked", G_CALLBACK(connect_cb), win);
-    g_signal_connect(b_disconnect, "clicked", G_CALLBACK(disconnect_cb),
-                     win);
+    g_signal_connect(b_disconnect, "clicked", G_CALLBACK(disconnect_cb), win);
     g_signal_connect(b_add, "clicked", G_CALLBACK(add_cb), win);
     g_signal_connect(b_resume, "clicked", G_CALLBACK(resume_cb), win);
     g_signal_connect(b_pause, "clicked", G_CALLBACK(pause_cb), win);
     g_signal_connect(b_delete, "clicked", G_CALLBACK(delete_cb), win);
     g_signal_connect(b_remove, "clicked", G_CALLBACK(remove_cb), win);
     g_signal_connect(b_props, "clicked", G_CALLBACK(open_props_cb), win);
-    g_signal_connect(b_local_prefs, "clicked",
-                     G_CALLBACK(open_local_prefs_cb), win);
-    g_signal_connect(b_remote_prefs, "clicked",
-                     G_CALLBACK(open_remote_prefs_cb), win);
+    g_signal_connect(b_local_prefs, "clicked", G_CALLBACK(open_local_prefs_cb), win);
+    g_signal_connect(b_remote_prefs, "clicked", G_CALLBACK(open_remote_prefs_cb), win);
 
     return toolBar;
 }
 
-static void reannounce_cb(GtkWidget * w G_GNUC_UNUSED, TrgMainWindow * win)
+static void reannounce_cb(GtkWidget *w G_GNUC_UNUSED, TrgMainWindow *win)
 {
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
 
     if (trg_client_is_connected(priv->client))
-        dispatch_async(priv->client,
-                       torrent_reannounce(build_json_id_array
-                                          (priv->torrentTreeView)),
+        dispatch_async(priv->client, torrent_reannounce(build_json_id_array(priv->torrentTreeView)),
                        on_generic_interactive_action_response, win);
 }
 
-static void verify_cb(GtkWidget * w G_GNUC_UNUSED, TrgMainWindow * win)
+static void verify_cb(GtkWidget *w G_GNUC_UNUSED, TrgMainWindow *win)
 {
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
 
     if (is_ready_for_torrent_action(win))
-        dispatch_async(priv->client,
-                       torrent_verify(build_json_id_array
-                                      (priv->torrentTreeView)),
+        dispatch_async(priv->client, torrent_verify(build_json_id_array(priv->torrentTreeView)),
                        on_generic_interactive_action_response, win);
 }
 
-static void start_now_cb(GtkWidget * w G_GNUC_UNUSED, TrgMainWindow * win)
+static void start_now_cb(GtkWidget *w G_GNUC_UNUSED, TrgMainWindow *win)
 {
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
 
     if (is_ready_for_torrent_action(win))
-        dispatch_async(priv->client,
-                       torrent_start_now(build_json_id_array
-                                         (priv->torrentTreeView)),
+        dispatch_async(priv->client, torrent_start_now(build_json_id_array(priv->torrentTreeView)),
                        on_generic_interactive_action_response, win);
 }
 
-static void up_queue_cb(GtkWidget * w G_GNUC_UNUSED, TrgMainWindow * win)
+static void up_queue_cb(GtkWidget *w G_GNUC_UNUSED, TrgMainWindow *win)
 {
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
 
     if (priv->queuesEnabled && is_ready_for_torrent_action(win))
         dispatch_async(priv->client,
-                       torrent_queue_move_up(build_json_id_array
-                                             (priv->torrentTreeView)),
+                       torrent_queue_move_up(build_json_id_array(priv->torrentTreeView)),
                        on_generic_interactive_action_response, win);
 }
 
-static void top_queue_cb(GtkWidget * w G_GNUC_UNUSED, TrgMainWindow * win)
+static void top_queue_cb(GtkWidget *w G_GNUC_UNUSED, TrgMainWindow *win)
 {
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
 
     if (priv->queuesEnabled && is_ready_for_torrent_action(win))
         dispatch_async(priv->client,
-                       torrent_queue_move_top(build_json_id_array
-                                              (priv->torrentTreeView)),
+                       torrent_queue_move_top(build_json_id_array(priv->torrentTreeView)),
                        on_generic_interactive_action_response, win);
 }
 
-static void
-bottom_queue_cb(GtkWidget * w G_GNUC_UNUSED, TrgMainWindow * win)
+static void bottom_queue_cb(GtkWidget *w G_GNUC_UNUSED, TrgMainWindow *win)
 {
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
 
     if (priv->queuesEnabled && is_ready_for_torrent_action(win))
         dispatch_async(priv->client,
-                       torrent_queue_move_bottom(build_json_id_array
-                                                 (priv->torrentTreeView)),
+                       torrent_queue_move_bottom(build_json_id_array(priv->torrentTreeView)),
                        on_generic_interactive_action_response, win);
 }
 
-static void down_queue_cb(GtkWidget * w G_GNUC_UNUSED, TrgMainWindow * win)
+static void down_queue_cb(GtkWidget *w G_GNUC_UNUSED, TrgMainWindow *win)
 {
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
 
     if (priv->queuesEnabled && is_ready_for_torrent_action(win))
         dispatch_async(priv->client,
-                       torrent_queue_move_down(build_json_id_array
-                                               (priv->torrentTreeView)),
+                       torrent_queue_move_down(build_json_id_array(priv->torrentTreeView)),
                        on_generic_interactive_action_response, win);
 }
 
-static gint
-confirm_action_dialog(GtkWindow * gtk_win,
-                      GtkTreeSelection * selection,
-                      const gchar * action_name,
-                      const gchar * action_label)
+static gint confirm_action_dialog(GtkWindow *gtk_win, GtkTreeSelection *selection,
+                                  const gchar *action_name, const gchar *action_label)
 {
     TrgMainWindow *win = TRG_MAIN_WINDOW(gtk_win);
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
@@ -809,61 +699,50 @@ confirm_action_dialog(GtkWindow * gtk_win,
         list = gtk_tree_selection_get_selected_rows(selection, NULL);
         firstNode = g_list_first(list);
 
-        gtk_tree_model_get_iter(GTK_TREE_MODEL
-                                (priv->filteredTorrentModel), &firstIter,
+        gtk_tree_model_get_iter(GTK_TREE_MODEL(priv->filteredTorrentModel), &firstIter,
                                 firstNode->data);
-        gtk_tree_model_get(GTK_TREE_MODEL(priv->filteredTorrentModel),
-                           &firstIter, TORRENT_COLUMN_NAME, &name, -1);
-        g_list_free_full(list, (GDestroyNotify) gtk_tree_path_free);
+        gtk_tree_model_get(GTK_TREE_MODEL(priv->filteredTorrentModel), &firstIter,
+                           TORRENT_COLUMN_NAME, &name, -1);
+        g_list_free_full(list, (GDestroyNotify)gtk_tree_path_free);
 
-        dialog = gtk_message_dialog_new_with_markup(GTK_WINDOW(win),
-                                                    GTK_DIALOG_DESTROY_WITH_PARENT,
-                                                    GTK_MESSAGE_QUESTION,
-                                                    GTK_BUTTONS_NONE,
-                                                    _("<big><b>%s \"%s\"?</b></big>"),
-                                                    action_name, name);
+        dialog = gtk_message_dialog_new_with_markup(
+            GTK_WINDOW(win), GTK_DIALOG_DESTROY_WITH_PARENT, GTK_MESSAGE_QUESTION, GTK_BUTTONS_NONE,
+            _("<big><b>%s \"%s\"?</b></big>"), action_name, name);
         g_free(name);
     } else if (selectCount > 1) {
-        dialog = gtk_message_dialog_new_with_markup(GTK_WINDOW(win),
-                                                    GTK_DIALOG_DESTROY_WITH_PARENT,
-                                                    GTK_MESSAGE_QUESTION,
-                                                    GTK_BUTTONS_NONE,
-                                                    _("<big><b>%s %d torrents?</b></big>"),
-                                                    action_name, selectCount);
+        dialog = gtk_message_dialog_new_with_markup(
+            GTK_WINDOW(win), GTK_DIALOG_DESTROY_WITH_PARENT, GTK_MESSAGE_QUESTION, GTK_BUTTONS_NONE,
+            _("<big><b>%s %d torrents?</b></big>"), action_name, selectCount);
 
     } else {
         return 0;
     }
 
-    gtk_dialog_add_buttons(GTK_DIALOG(dialog), _("_Cancel"),
-                           GTK_RESPONSE_CANCEL, action_label,
+    gtk_dialog_add_buttons(GTK_DIALOG(dialog), _("_Cancel"), GTK_RESPONSE_CANCEL, action_label,
                            GTK_RESPONSE_ACCEPT, NULL);
-    gtk_dialog_set_default_response(GTK_DIALOG(dialog),
-                                    GTK_RESPONSE_CANCEL);
+    gtk_dialog_set_default_response(GTK_DIALOG(dialog), GTK_RESPONSE_CANCEL);
 
     response = gtk_dialog_run(GTK_DIALOG(dialog));
     gtk_widget_destroy(dialog);
     return response;
 }
 
-static gboolean is_ready_for_torrent_action(TrgMainWindow * win)
+static gboolean is_ready_for_torrent_action(TrgMainWindow *win)
 {
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
-    return priv->selectedTorrentId >= 0
-        && trg_client_is_connected(priv->client);
+    return priv->selectedTorrentId >= 0 && trg_client_is_connected(priv->client);
 }
 
-static void move_cb(GtkWidget * w G_GNUC_UNUSED, TrgMainWindow * win)
+static void move_cb(GtkWidget *w G_GNUC_UNUSED, TrgMainWindow *win)
 {
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
 
     if (is_ready_for_torrent_action(win))
-        gtk_widget_show_all(GTK_WIDGET
-                            (trg_torrent_move_dialog_new
-                             (win, priv->client, priv->torrentTreeView)));
+        gtk_widget_show_all(
+            GTK_WIDGET(trg_torrent_move_dialog_new(win, priv->client, priv->torrentTreeView)));
 }
 
-static void remove_cb(GtkWidget * w G_GNUC_UNUSED, TrgMainWindow * win)
+static void remove_cb(GtkWidget *w G_GNUC_UNUSED, TrgMainWindow *win)
 {
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
     GtkTreeSelection *selection;
@@ -872,63 +751,56 @@ static void remove_cb(GtkWidget * w G_GNUC_UNUSED, TrgMainWindow * win)
     if (!is_ready_for_torrent_action(win))
         return;
 
-    selection =
-        gtk_tree_view_get_selection(GTK_TREE_VIEW(priv->torrentTreeView));
+    selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(priv->torrentTreeView));
     ids = build_json_id_array(priv->torrentTreeView);
 
-    if (confirm_action_dialog(GTK_WINDOW(win), selection, _("Remove"),
-                              _("_Remove")) == GTK_RESPONSE_ACCEPT)
+    if (confirm_action_dialog(GTK_WINDOW(win), selection, _("Remove"), _("_Remove"))
+        == GTK_RESPONSE_ACCEPT)
         dispatch_async(priv->client, torrent_remove(ids, FALSE),
                        on_generic_interactive_action_response, win);
     else
         json_array_unref(ids);
 }
 
-static void delete_cb(GtkWidget * w G_GNUC_UNUSED, TrgMainWindow * win)
+static void delete_cb(GtkWidget *w G_GNUC_UNUSED, TrgMainWindow *win)
 {
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
     GtkTreeSelection *selection;
     JsonArray *ids;
 
-    selection =
-        gtk_tree_view_get_selection(GTK_TREE_VIEW(priv->torrentTreeView));
+    selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(priv->torrentTreeView));
     ids = build_json_id_array(priv->torrentTreeView);
 
     if (!is_ready_for_torrent_action(win))
         return;
 
-    if (confirm_action_dialog(GTK_WINDOW(win), selection,
-                              _("Remove and delete"),
-                              _("_Delete")) == GTK_RESPONSE_ACCEPT)
-        dispatch_async(priv->client, torrent_remove(ids, TRUE),
-                       on_delete_complete, win);
+    if (confirm_action_dialog(GTK_WINDOW(win), selection, _("Remove and delete"), _("_Delete"))
+        == GTK_RESPONSE_ACCEPT)
+        dispatch_async(priv->client, torrent_remove(ids, TRUE), on_delete_complete, win);
     else
         json_array_unref(ids);
 }
 
-static void view_stats_toggled_cb(GtkWidget * w, gpointer data)
+static void view_stats_toggled_cb(GtkWidget *w, gpointer data)
 {
     TrgMainWindow *win = TRG_MAIN_WINDOW(data);
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
 
     if (trg_client_is_connected(priv->client)) {
-        TrgStatsDialog *dlg =
-            trg_stats_dialog_get_instance(TRG_MAIN_WINDOW(data),
-                                          priv->client);
+        TrgStatsDialog *dlg = trg_stats_dialog_get_instance(TRG_MAIN_WINDOW(data), priv->client);
 
         gtk_widget_show_all(GTK_WIDGET(dlg));
     }
 }
 
 #if HAVE_RSS
-static void view_rss_toggled_cb(GtkWidget * w, gpointer data)
+static void view_rss_toggled_cb(GtkWidget *w, gpointer data)
 {
     TrgMainWindow *win = TRG_MAIN_WINDOW(data);
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
 
     if (trg_client_is_connected(priv->client)) {
-        TrgRssWindow *rss =
-            trg_rss_window_get_instance(TRG_MAIN_WINDOW(data), priv->client);
+        TrgRssWindow *rss = trg_rss_window_get_instance(TRG_MAIN_WINDOW(data), priv->client);
 
         gtk_widget_show_all(GTK_WIDGET(rss));
         gtk_window_present(GTK_WINDOW(rss));
@@ -936,27 +808,22 @@ static void view_rss_toggled_cb(GtkWidget * w, gpointer data)
 }
 #endif
 
-static void
-view_states_toggled_cb(GtkCheckMenuItem * w, TrgMainWindow * win)
+static void view_states_toggled_cb(GtkCheckMenuItem *w, TrgMainWindow *win)
 {
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
 
-    trg_widget_set_visible(priv->stateSelectorScroller,
-                           gtk_check_menu_item_get_active(w));
+    trg_widget_set_visible(priv->stateSelectorScroller, gtk_check_menu_item_get_active(w));
 }
 
-static void
-view_notebook_toggled_cb(GtkCheckMenuItem * w, TrgMainWindow * win)
+static void view_notebook_toggled_cb(GtkCheckMenuItem *w, TrgMainWindow *win)
 {
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
 
-    trg_widget_set_visible(priv->notebook,
-                           gtk_check_menu_item_get_active(w));
+    trg_widget_set_visible(priv->notebook, gtk_check_menu_item_get_active(w));
 }
 
 #if TRG_WITH_GRAPH
-static void
-trg_main_window_toggle_graph_cb(GtkCheckMenuItem * w, gpointer data)
+static void trg_main_window_toggle_graph_cb(GtkCheckMenuItem *w, gpointer data)
 {
     TrgMainWindow *win = TRG_MAIN_WINDOW(data);
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
@@ -972,14 +839,13 @@ trg_main_window_toggle_graph_cb(GtkCheckMenuItem * w, gpointer data)
 }
 #endif
 
-void
-trg_main_window_notebook_set_visible(TrgMainWindow * win, gboolean visible)
+void trg_main_window_notebook_set_visible(TrgMainWindow *win, gboolean visible)
 {
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
     trg_widget_set_visible(priv->notebook, visible);
 }
 
-static GtkWidget *trg_main_window_notebook_new(TrgMainWindow * win)
+static GtkWidget *trg_main_window_notebook_new(TrgMainWindow *win)
 {
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
     TrgPrefs *prefs = trg_client_get_prefs(priv->client);
@@ -987,45 +853,33 @@ static GtkWidget *trg_main_window_notebook_new(TrgMainWindow * win)
     GtkWidget *notebook = priv->notebook = gtk_notebook_new();
     GtkWidget *genScrolledWin = gtk_scrolled_window_new(NULL, NULL);
 
-    priv->genDetails =
-        trg_general_panel_new(GTK_TREE_MODEL(priv->torrentModel),
-                              priv->client);
-    gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(genScrolledWin),
-                                   GTK_POLICY_AUTOMATIC,
+    priv->genDetails = trg_general_panel_new(GTK_TREE_MODEL(priv->torrentModel), priv->client);
+    gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(genScrolledWin), GTK_POLICY_AUTOMATIC,
                                    GTK_POLICY_AUTOMATIC);
-    gtk_container_add(GTK_CONTAINER(genScrolledWin),
-                      GTK_WIDGET(priv->genDetails));
-    gtk_notebook_append_page(GTK_NOTEBOOK(notebook), genScrolledWin,
-                             gtk_label_new(_("General")));
+    gtk_container_add(GTK_CONTAINER(genScrolledWin), GTK_WIDGET(priv->genDetails));
+    gtk_notebook_append_page(GTK_NOTEBOOK(notebook), genScrolledWin, gtk_label_new(_("General")));
 
     priv->trackersModel = trg_trackers_model_new();
-    priv->trackersTreeView =
-        trg_trackers_tree_view_new(priv->trackersModel, priv->client, win,
-                                   NULL);
+    priv->trackersTreeView
+        = trg_trackers_tree_view_new(priv->trackersModel, priv->client, win, NULL);
     gtk_notebook_append_page(GTK_NOTEBOOK(notebook),
-                             my_scrolledwin_new(GTK_WIDGET
-                                                (priv->trackersTreeView)),
+                             my_scrolledwin_new(GTK_WIDGET(priv->trackersTreeView)),
                              gtk_label_new(_("Trackers")));
 
     priv->filesModel = trg_files_model_new();
-    priv->filesTreeView = trg_files_tree_view_new(priv->filesModel, win,
-                                                  priv->client, NULL);
+    priv->filesTreeView = trg_files_tree_view_new(priv->filesModel, win, priv->client, NULL);
     gtk_notebook_append_page(GTK_NOTEBOOK(notebook),
-                             my_scrolledwin_new(GTK_WIDGET
-                                                (priv->filesTreeView)),
+                             my_scrolledwin_new(GTK_WIDGET(priv->filesTreeView)),
                              gtk_label_new(_("Files")));
 
     priv->peersModel = trg_peers_model_new();
-    priv->peersTreeView =
-        trg_peers_tree_view_new(prefs, priv->peersModel, NULL);
+    priv->peersTreeView = trg_peers_tree_view_new(prefs, priv->peersModel, NULL);
     gtk_notebook_append_page(GTK_NOTEBOOK(notebook),
-                             my_scrolledwin_new(GTK_WIDGET
-                                                (priv->peersTreeView)),
+                             my_scrolledwin_new(GTK_WIDGET(priv->peersTreeView)),
                              gtk_label_new(_("Peers")));
 
 #if TRG_WITH_GRAPH
-    if (trg_prefs_get_bool
-        (prefs, TRG_PREFS_KEY_SHOW_GRAPH, TRG_PREFS_GLOBAL))
+    if (trg_prefs_get_bool(prefs, TRG_PREFS_KEY_SHOW_GRAPH, TRG_PREFS_GLOBAL))
         trg_main_window_add_graph(win, FALSE);
     else
         priv->graphNotebookIndex = -1;
@@ -1036,14 +890,12 @@ static GtkWidget *trg_main_window_notebook_new(TrgMainWindow * win)
 
 gboolean on_session_set(gpointer data)
 {
-    trg_response *response = (trg_response *) data;
+    trg_response *response = (trg_response *)data;
     TrgMainWindow *win = TRG_MAIN_WINDOW(response->cb_data);
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
 
-    if (response->status == CURLE_OK
-        || response->status == FAIL_RESPONSE_UNSUCCESSFUL)
-        trg_client_update_session(priv->client, on_session_get,
-                                  response->cb_data);
+    if (response->status == CURLE_OK || response->status == FAIL_RESPONSE_UNSUCCESSFUL)
+        trg_client_update_session(priv->client, on_session_get, response->cb_data);
 
     trg_dialog_error_handler(TRG_MAIN_WINDOW(response->cb_data), response);
     trg_response_free(response);
@@ -1051,34 +903,30 @@ gboolean on_session_set(gpointer data)
     return FALSE;
 }
 
-static gboolean
-hasEnabledChanged(JsonObject * a, JsonObject * b, const gchar * key)
+static gboolean hasEnabledChanged(JsonObject *a, JsonObject *b, const gchar *key)
 {
-    return json_object_get_boolean_member(a, key) !=
-        json_object_get_boolean_member(b, key);
+    return json_object_get_boolean_member(a, key) != json_object_get_boolean_member(b, key);
 }
 
 static gboolean on_session_get_timer(gpointer data)
 {
-    trg_response *response = (trg_response *) data;
+    trg_response *response = (trg_response *)data;
     TrgMainWindow *win = TRG_MAIN_WINDOW(response->cb_data);
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
     TrgPrefs *prefs = trg_client_get_prefs(priv->client);
 
     on_session_get(data);
 
-    priv->sessionTimerId = g_timeout_add_seconds(trg_prefs_get_int(prefs,
-                                                                   TRG_PREFS_KEY_SESSION_UPDATE_INTERVAL,
-                                                                   TRG_PREFS_CONNECTION),
-                                                 trg_session_update_timerfunc,
-                                                 win);
+    priv->sessionTimerId = g_timeout_add_seconds(
+        trg_prefs_get_int(prefs, TRG_PREFS_KEY_SESSION_UPDATE_INTERVAL, TRG_PREFS_CONNECTION),
+        trg_session_update_timerfunc, win);
 
     return FALSE;
 }
 
 static gboolean on_session_get(gpointer data)
 {
-    trg_response *response = (trg_response *) data;
+    trg_response *response = (trg_response *)data;
     TrgMainWindow *win = TRG_MAIN_WINDOW(response->cb_data);
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
 
@@ -1099,19 +947,12 @@ static gboolean on_session_get(gpointer data)
             return FALSE;
         }
 
-        if ((version =
-             session_get_version(newSession)) < TRANSMISSION_MIN_SUPPORTED)
-        {
-            gchar *msg =
-                g_strdup_printf(_
-                                ("This application supports Transmission %g and later, you have %g."),
-TRANSMISSION_MIN_SUPPORTED, version);
-            GtkWidget *dialog = gtk_message_dialog_new(GTK_WINDOW(win),
-                                                       GTK_DIALOG_MODAL,
-                                                       GTK_MESSAGE_ERROR,
-                                                       GTK_BUTTONS_OK,
-                                                       "%s",
-                                                       msg);
+        if ((version = session_get_version(newSession)) < TRANSMISSION_MIN_SUPPORTED) {
+            gchar *msg = g_strdup_printf(
+                _("This application supports Transmission %g and later, you have %g."),
+                TRANSMISSION_MIN_SUPPORTED, version);
+            GtkWidget *dialog = gtk_message_dialog_new(
+                GTK_WINDOW(win), GTK_DIALOG_MODAL, GTK_MESSAGE_ERROR, GTK_BUTTONS_OK, "%s", msg);
             gtk_window_set_title(GTK_WINDOW(dialog), _("Error"));
             gtk_dialog_run(GTK_DIALOG(dialog));
             gtk_widget_destroy(dialog);
@@ -1129,13 +970,9 @@ TRANSMISSION_MIN_SUPPORTED, version);
             && g_strcmp0(session_get_download_dir(lastSession),
                          session_get_download_dir(newSession));
         gboolean refreshSpeed = lastSession
-            &&
-            (hasEnabledChanged
-             (lastSession, newSession, SGET_ALT_SPEED_ENABLED)
-             || hasEnabledChanged(lastSession, newSession,
-                                  SGET_SPEED_LIMIT_DOWN_ENABLED)
-             || hasEnabledChanged(lastSession, newSession,
-                                  SGET_SPEED_LIMIT_UP_ENABLED));
+            && (hasEnabledChanged(lastSession, newSession, SGET_ALT_SPEED_ENABLED)
+                || hasEnabledChanged(lastSession, newSession, SGET_SPEED_LIMIT_DOWN_ENABLED)
+                || hasEnabledChanged(lastSession, newSession, SGET_SPEED_LIMIT_UP_ENABLED));
 
         trg_client_set_session(client, newSession);
 
@@ -1143,18 +980,14 @@ TRANSMISSION_MIN_SUPPORTED, version);
             trg_main_window_reload_dir_aliases(win);
 
         if (refreshSpeed)
-            trg_status_bar_update_speed(priv->statusBar,
-                                        trg_torrent_model_get_stats
-                                        (priv->torrentModel),
-                                        priv->client);
+            trg_status_bar_update_speed(
+                priv->statusBar, trg_torrent_model_get_stats(priv->torrentModel), priv->client);
     }
 
     if (!isConnected) {
         trg_main_window_conn_changed(win, TRUE);
-        trg_trackers_tree_view_new_connection(priv->trackersTreeView,
-                                              client);
-        dispatch_async(client, torrent_get(TORRENT_GET_TAG_MODE_FULL),
-                       on_torrent_get_first, win);
+        trg_trackers_tree_view_new_connection(priv->trackersTreeView, client);
+        dispatch_async(client, torrent_get(TORRENT_GET_TAG_MODE_FULL), on_torrent_get_first, win);
     }
 
     trg_response_free(response);
@@ -1162,16 +995,14 @@ TRANSMISSION_MIN_SUPPORTED, version);
     return FALSE;
 }
 
-static void
-connchange_whatever_tray(TrgMainWindow * win, gboolean connected)
+static void connchange_whatever_tray(TrgMainWindow *win, gboolean connected)
 {
 #if HAVE_LIBAPPINDICATOR
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
     TrgPrefs *prefs = trg_client_get_prefs(priv->client);
-    gchar *display = connected ?
-        trg_prefs_get_string(prefs, TRG_PREFS_KEY_PROFILE_NAME,
-                             TRG_PREFS_CONNECTION) :
-        g_strdup(_("Disconnected"));
+    gchar *display = connected
+        ? trg_prefs_get_string(prefs, TRG_PREFS_KEY_PROFILE_NAME, TRG_PREFS_CONNECTION)
+        : g_strdup(_("Disconnected"));
 
     if (priv->appIndicator) {
         GtkMenu *menu = trg_tray_view_menu(win, display);
@@ -1182,9 +1013,7 @@ connchange_whatever_tray(TrgMainWindow * win, gboolean connected)
 #endif
 }
 
-static void
-update_whatever_tray(TrgMainWindow * win,
-                     trg_torrent_model_update_stats * stats)
+static void update_whatever_tray(TrgMainWindow *win, trg_torrent_model_update_stats *stats)
 {
 #if HAVE_LIBAPPINDICATOR
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
@@ -1202,17 +1031,13 @@ update_whatever_tray(TrgMainWindow * win,
         gchar buf[32];
 
         trg_strlspeed(buf, stats->downRateTotal / disk_K);
-        downloadingLabel = g_strdup_printf(_("%d Downloading @ %s"),
-                                           stats->down, buf);
-        gtk_menu_item_set_label(GTK_MENU_ITEM(priv->iconDownloadingItem),
-                                downloadingLabel);
+        downloadingLabel = g_strdup_printf(_("%d Downloading @ %s"), stats->down, buf);
+        gtk_menu_item_set_label(GTK_MENU_ITEM(priv->iconDownloadingItem), downloadingLabel);
         g_free(downloadingLabel);
 
         trg_strlspeed(buf, stats->upRateTotal / disk_K);
-        seedingLabel = g_strdup_printf(_("%d Seeding @ %s"),
-                                       stats->seeding, buf);
-        gtk_menu_item_set_label(GTK_MENU_ITEM(priv->iconSeedingItem),
-                                seedingLabel);
+        seedingLabel = g_strdup_printf(_("%d Seeding @ %s"), stats->seeding, buf);
+        gtk_menu_item_set_label(GTK_MENU_ITEM(priv->iconSeedingItem), seedingLabel);
         g_free(seedingLabel);
     }
 #endif
@@ -1224,7 +1049,7 @@ update_whatever_tray(TrgMainWindow * win,
 
 static gboolean on_torrent_get(gpointer data, int mode)
 {
-    trg_response *response = (trg_response *) data;
+    trg_response *response = (trg_response *)data;
     TrgMainWindow *win = TRG_MAIN_WINDOW(response->cb_data);
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
     TrgClient *client = priv->client;
@@ -1240,37 +1065,27 @@ static gboolean on_torrent_get(gpointer data, int mode)
         return FALSE;
     }
 
-    interval =
-        gtk_widget_get_visible(GTK_WIDGET(win)) ? trg_prefs_get_int(prefs,
-                                                                    TRG_PREFS_KEY_UPDATE_INTERVAL,
-                                                                    TRG_PREFS_CONNECTION)
-        : trg_prefs_get_int(prefs, TRG_PREFS_KEY_MINUPDATE_INTERVAL,
-                            TRG_PREFS_CONNECTION);
+    interval = gtk_widget_get_visible(GTK_WIDGET(win))
+        ? trg_prefs_get_int(prefs, TRG_PREFS_KEY_UPDATE_INTERVAL, TRG_PREFS_CONNECTION)
+        : trg_prefs_get_int(prefs, TRG_PREFS_KEY_MINUPDATE_INTERVAL, TRG_PREFS_CONNECTION);
     if (interval < 1)
         interval = TRG_INTERVAL_DEFAULT;
 
     if (response->status != CURLE_OK) {
-        gint64 max_retries =
-            trg_prefs_get_int(prefs, TRG_PREFS_KEY_RETRIES,
-                              TRG_PREFS_CONNECTION);
+        gint64 max_retries = trg_prefs_get_int(prefs, TRG_PREFS_KEY_RETRIES, TRG_PREFS_CONNECTION);
 
         if (trg_client_inc_failcount(client) >= max_retries) {
             trg_main_window_conn_changed(win, FALSE);
             trg_dialog_error_handler(win, response);
         } else {
-            gchar *msg =
-                make_error_message(response->obj, response->status);
-            gchar *statusBarMsg =
-                g_strdup_printf(_("Request %d/%d failed: %s"),
-                                trg_client_get_failcount(client),
-                                (gint) max_retries, msg);
-            trg_status_bar_push_connection_msg(priv->statusBar,
-                                               statusBarMsg);
+            gchar *msg = make_error_message(response->obj, response->status);
+            gchar *statusBarMsg
+                = g_strdup_printf(_("Request %d/%d failed: %s"), trg_client_get_failcount(client),
+                                  (gint)max_retries, msg);
+            trg_status_bar_push_connection_msg(priv->statusBar, statusBarMsg);
             g_free(msg);
             g_free(statusBarMsg);
-            priv->timerId = g_timeout_add_seconds(interval,
-                                                  trg_update_torrents_timerfunc,
-                                                  win);
+            priv->timerId = g_timeout_add_seconds(interval, trg_update_torrents_timerfunc, win);
         }
 
         trg_response_free(response);
@@ -1284,21 +1099,16 @@ static gboolean on_torrent_get(gpointer data, int mode)
     if (mode != TORRENT_GET_MODE_FIRST)
         gtk_widget_freeze_child_notify(GTK_WIDGET(priv->torrentTreeView));
 
-    gtk_tree_sortable_get_sort_column_id(GTK_TREE_SORTABLE
-                                         (priv->sortedTorrentModel),
-                                         &old_sort_id, &old_order);
-    gtk_tree_sortable_set_sort_column_id(GTK_TREE_SORTABLE
-                                         (priv->sortedTorrentModel),
+    gtk_tree_sortable_get_sort_column_id(GTK_TREE_SORTABLE(priv->sortedTorrentModel), &old_sort_id,
+                                         &old_order);
+    gtk_tree_sortable_set_sort_column_id(GTK_TREE_SORTABLE(priv->sortedTorrentModel),
                                          GTK_TREE_SORTABLE_DEFAULT_SORT_COLUMN_ID,
                                          GTK_SORT_ASCENDING);
 
-    stats =
-        trg_torrent_model_update(priv->torrentModel, client, response->obj,
-                                 mode);
+    stats = trg_torrent_model_update(priv->torrentModel, client, response->obj, mode);
 
-    gtk_tree_sortable_set_sort_column_id(GTK_TREE_SORTABLE
-                                         (priv->sortedTorrentModel),
-                                         old_sort_id, old_order);
+    gtk_tree_sortable_set_sort_column_id(GTK_TREE_SORTABLE(priv->sortedTorrentModel), old_sort_id,
+                                         old_order);
 
     if (mode != TORRENT_GET_MODE_FIRST)
         gtk_widget_thaw_child_notify(GTK_WIDGET(priv->torrentTreeView));
@@ -1313,9 +1123,7 @@ static gboolean on_torrent_get(gpointer data, int mode)
 #endif
 
     if (mode != TORRENT_GET_MODE_INTERACTION)
-        priv->timerId = g_timeout_add_seconds(interval,
-                                              trg_update_torrents_timerfunc,
-                                              win);
+        priv->timerId = g_timeout_add_seconds(interval, trg_update_torrents_timerfunc, win);
 
     trg_response_free(response);
     return FALSE;
@@ -1328,7 +1136,7 @@ static gboolean on_torrent_get_active(gpointer data)
 
 static gboolean on_torrent_get_first(gpointer data)
 {
-    trg_response *response = (trg_response *) data;
+    trg_response *response = (trg_response *)data;
     TrgMainWindow *win = TRG_MAIN_WINDOW(response->cb_data);
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
 
@@ -1366,8 +1174,8 @@ static gboolean trg_update_torrents_timerfunc(gpointer data)
 {
     /* Check if the TrgMainWindow* has already been destroyed
      * and, in that case, stop polling the server. */
-    if (!TRG_IS_MAIN_WINDOW (data))
-      return FALSE;
+    if (!TRG_IS_MAIN_WINDOW(data))
+        return FALSE;
 
     TrgMainWindow *win = TRG_MAIN_WINDOW(data);
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
@@ -1375,27 +1183,23 @@ static gboolean trg_update_torrents_timerfunc(gpointer data)
     TrgPrefs *prefs = trg_client_get_prefs(tc);
 
     if (trg_client_is_connected(tc)) {
-        gboolean activeOnly = trg_prefs_get_bool(prefs,
-                                                 TRG_PREFS_KEY_UPDATE_ACTIVE_ONLY,
-                                                 TRG_PREFS_CONNECTION)
-            && (!trg_prefs_get_bool(prefs,
-                                    TRG_PREFS_ACTIVEONLY_FULLSYNC_ENABLED,
+        gboolean activeOnly
+            = trg_prefs_get_bool(prefs, TRG_PREFS_KEY_UPDATE_ACTIVE_ONLY, TRG_PREFS_CONNECTION)
+            && (!trg_prefs_get_bool(prefs, TRG_PREFS_ACTIVEONLY_FULLSYNC_ENABLED,
                                     TRG_PREFS_CONNECTION)
-                || (trg_client_get_serial(tc) % trg_prefs_get_int(prefs,
-                                                                  TRG_PREFS_ACTIVEONLY_FULLSYNC_EVERY,
-                                                                  TRG_PREFS_CONNECTION)
+                || (trg_client_get_serial(tc)
+                        % trg_prefs_get_int(prefs, TRG_PREFS_ACTIVEONLY_FULLSYNC_EVERY,
+                                            TRG_PREFS_CONNECTION)
                     != 0));
-        dispatch_async(tc,
-                       torrent_get(activeOnly ? TORRENT_GET_TAG_MODE_UPDATE
-                                   : TORRENT_GET_TAG_MODE_FULL),
-                       activeOnly ? on_torrent_get_active :
-                       on_torrent_get_update, data);
+        dispatch_async(
+            tc, torrent_get(activeOnly ? TORRENT_GET_TAG_MODE_UPDATE : TORRENT_GET_TAG_MODE_FULL),
+            activeOnly ? on_torrent_get_active : on_torrent_get_update, data);
     }
 
     return FALSE;
 }
 
-static void open_about_cb(GtkWidget * w G_GNUC_UNUSED, GtkWindow * parent)
+static void open_about_cb(GtkWidget *w G_GNUC_UNUSED, GtkWindow *parent)
 {
     GtkWidget *aboutDialog = trg_about_window_new(parent);
 
@@ -1403,9 +1207,8 @@ static void open_about_cb(GtkWidget * w G_GNUC_UNUSED, GtkWindow * parent)
     gtk_widget_destroy(aboutDialog);
 }
 
-static gboolean
-trg_torrent_tree_view_visible_func(GtkTreeModel * model,
-                                   GtkTreeIter * iter, gpointer data)
+static gboolean trg_torrent_tree_view_visible_func(GtkTreeModel *model, GtkTreeIter *iter,
+                                                   gpointer data)
 {
     TrgMainWindow *win = TRG_MAIN_WINDOW(data);
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
@@ -1419,28 +1222,22 @@ trg_torrent_tree_view_visible_func(GtkTreeModel * model,
 
     if (criteria != 0) {
         if (criteria & FILTER_FLAG_TRACKER) {
-            gchar *text =
-                trg_state_selector_get_selected_text(priv->stateSelector);
+            gchar *text = trg_state_selector_get_selected_text(priv->stateSelector);
             JsonObject *json = NULL;
             gboolean matchesTracker;
-            gtk_tree_model_get(model, iter, TORRENT_COLUMN_JSON, &json,
-                               -1);
-            matchesTracker = (!json
-                              || !torrent_has_tracker(json,
-                                                      trg_state_selector_get_url_host_regex
-                                                      (priv->
-                                                       stateSelector),
-                                                      text));
+            gtk_tree_model_get(model, iter, TORRENT_COLUMN_JSON, &json, -1);
+            matchesTracker
+                = (!json
+                   || !torrent_has_tracker(
+                       json, trg_state_selector_get_url_host_regex(priv->stateSelector), text));
             g_free(text);
             if (matchesTracker)
                 return FALSE;
         } else if (criteria & FILTER_FLAG_DIR) {
-            gchar *text =
-                trg_state_selector_get_selected_text(priv->stateSelector);
+            gchar *text = trg_state_selector_get_selected_text(priv->stateSelector);
             gchar *dd;
             int cmp;
-            gtk_tree_model_get(model, iter,
-                               TORRENT_COLUMN_DOWNLOADDIR_SHORT, &dd, -1);
+            gtk_tree_model_get(model, iter, TORRENT_COLUMN_DOWNLOADDIR_SHORT, &dd, -1);
             cmp = g_strcmp0(text, dd);
             g_free(dd);
             g_free(text);
@@ -1473,33 +1270,26 @@ trg_torrent_tree_view_visible_func(GtkTreeModel * model,
     return visible;
 }
 
-void trg_main_window_reload_dir_aliases(TrgMainWindow * win)
+void trg_main_window_reload_dir_aliases(TrgMainWindow *win)
 {
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
-    trg_torrent_model_reload_dir_aliases(priv->client, GTK_TREE_MODEL
-                                         (priv->torrentModel));
+    trg_torrent_model_reload_dir_aliases(priv->client, GTK_TREE_MODEL(priv->torrentModel));
 }
 
-static TrgTorrentTreeView
-    * trg_main_window_torrent_tree_view_new(TrgMainWindow * win,
-                                            GtkTreeModel * model)
+static TrgTorrentTreeView *trg_main_window_torrent_tree_view_new(TrgMainWindow *win,
+                                                                 GtkTreeModel *model)
 {
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
-    TrgTorrentTreeView *torrentTreeView =
-        trg_torrent_tree_view_new(priv->client,
-                                  model);
+    TrgTorrentTreeView *torrentTreeView = trg_torrent_tree_view_new(priv->client, model);
 
-    GtkTreeSelection *selection =
-        gtk_tree_view_get_selection(GTK_TREE_VIEW(torrentTreeView));
+    GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(torrentTreeView));
 
-    g_signal_connect(G_OBJECT(selection), "changed",
-                     G_CALLBACK(torrent_selection_changed), win);
+    g_signal_connect(G_OBJECT(selection), "changed", G_CALLBACK(torrent_selection_changed), win);
 
     return torrentTreeView;
 }
 
-static gboolean
-trg_dialog_error_handler(TrgMainWindow * win, trg_response * response)
+static gboolean trg_dialog_error_handler(TrgMainWindow *win, trg_response *response)
 {
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
 
@@ -1510,22 +1300,19 @@ trg_dialog_error_handler(TrgMainWindow * win, trg_response * response)
         msg = make_error_message(response->obj, response->status);
         trg_status_bar_clear_indicators(priv->statusBar);
         trg_status_bar_push_connection_msg(priv->statusBar, msg);
-        dialog = gtk_message_dialog_new(GTK_WINDOW(win), GTK_DIALOG_MODAL,
-                                        GTK_MESSAGE_ERROR, GTK_BUTTONS_OK,
-                                        "%s", msg);
+        dialog = gtk_message_dialog_new(GTK_WINDOW(win), GTK_DIALOG_MODAL, GTK_MESSAGE_ERROR,
+                                        GTK_BUTTONS_OK, "%s", msg);
         gtk_window_set_title(GTK_WINDOW(dialog), _("Error"));
         gtk_dialog_run(GTK_DIALOG(dialog));
         gtk_widget_destroy(dialog);
-        g_free((gpointer) msg);
+        g_free((gpointer)msg);
         return TRUE;
     } else {
         return FALSE;
     }
 }
 
-static gboolean
-torrent_selection_changed(GtkTreeSelection * selection,
-                          TrgMainWindow * win)
+static gboolean torrent_selection_changed(GtkTreeSelection *selection, TrgMainWindow *win)
 {
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
     GList *selectionList;
@@ -1544,13 +1331,12 @@ torrent_selection_changed(GtkTreeSelection * selection,
     if (firstNode) {
         GtkTreeIter iter;
         if (gtk_tree_model_get_iter(priv->filteredTorrentModel, &iter,
-                                    (GtkTreePath *) firstNode->data)) {
-            gtk_tree_model_get(priv->filteredTorrentModel, &iter,
-                               TORRENT_COLUMN_ID, &id, -1);
+                                    (GtkTreePath *)firstNode->data)) {
+            gtk_tree_model_get(priv->filteredTorrentModel, &iter, TORRENT_COLUMN_ID, &id, -1);
         }
     }
 
-    g_list_free_full(selectionList, (GDestroyNotify) gtk_tree_path_free);
+    g_list_free_full(selectionList, (GDestroyNotify)gtk_tree_path_free);
 
     update_selected_torrent_notebook(win, TORRENT_GET_MODE_FIRST, id);
 
@@ -1559,19 +1345,19 @@ torrent_selection_changed(GtkTreeSelection * selection,
 
 gboolean on_delete_complete(gpointer data)
 {
-    trg_response *response = (trg_response *) data;
+    trg_response *response = (trg_response *)data;
     TrgMainWindow *win = TRG_MAIN_WINDOW(response->cb_data);
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
     TrgClient *tc = priv->client;
 
     if (trg_client_is_connected(tc) && response->status == CURLE_OK)
-        trg_client_update_session(priv->client, on_session_get,
-                                  response->cb_data);
+        trg_client_update_session(priv->client, on_session_get, response->cb_data);
 
     return on_generic_interactive_action_response(data);
 }
 
-void on_generic_interactive_action(TrgMainWindow *win, trg_response *response) {
+void on_generic_interactive_action(TrgMainWindow *win, trg_response *response)
+{
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
     TrgClient *tc = priv->client;
 
@@ -1585,8 +1371,7 @@ void on_generic_interactive_action(TrgMainWindow *win, trg_response *response) {
             else
                 id = TORRENT_GET_TAG_MODE_FULL;
 
-            dispatch_async(tc, torrent_get(id), on_torrent_get_interactive,
-                           win);
+            dispatch_async(tc, torrent_get(id), on_torrent_get_interactive, win);
         }
     }
 
@@ -1595,7 +1380,7 @@ void on_generic_interactive_action(TrgMainWindow *win, trg_response *response) {
 
 gboolean on_generic_interactive_action_response(gpointer data)
 {
-    trg_response *response = (trg_response *) data;
+    trg_response *response = (trg_response *)data;
     TrgMainWindow *win = TRG_MAIN_WINDOW(response->cb_data);
 
     on_generic_interactive_action(win, response);
@@ -1603,7 +1388,7 @@ gboolean on_generic_interactive_action_response(gpointer data)
     return FALSE;
 }
 
-static void trg_main_window_torrent_scrub(TrgMainWindow * win)
+static void trg_main_window_torrent_scrub(TrgMainWindow *win)
 {
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
 
@@ -1611,35 +1396,29 @@ static void trg_main_window_torrent_scrub(TrgMainWindow * win)
     gtk_list_store_clear(GTK_LIST_STORE(priv->trackersModel));
     gtk_list_store_clear(GTK_LIST_STORE(priv->peersModel));
     trg_general_panel_clear(priv->genDetails);
-    trg_trackers_model_set_no_selection(TRG_TRACKERS_MODEL
-                                        (priv->trackersModel));
+    trg_trackers_model_set_no_selection(TRG_TRACKERS_MODEL(priv->trackersModel));
 
     trg_toolbar_torrent_actions_sensitive(priv->toolBar, FALSE);
     trg_menu_bar_torrent_actions_sensitive(priv->menuBar, FALSE);
 }
 
-static void entry_filter_changed_cb(GtkWidget * w, TrgMainWindow * win)
+static void entry_filter_changed_cb(GtkWidget *w, TrgMainWindow *win)
 {
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
     gboolean clearSensitive = gtk_entry_get_text_length(GTK_ENTRY(w)) > 0;
 
-    gtk_tree_model_filter_refilter(GTK_TREE_MODEL_FILTER
-                                   (priv->filteredTorrentModel));
+    gtk_tree_model_filter_refilter(GTK_TREE_MODEL_FILTER(priv->filteredTorrentModel));
 
-    g_object_set(priv->filterEntry, "secondary-icon-sensitive",
-                 clearSensitive, NULL);
+    g_object_set(priv->filterEntry, "secondary-icon-sensitive", clearSensitive, NULL);
 }
 
-static void
-torrent_state_selection_changed(TrgStateSelector *
-                                selector G_GNUC_UNUSED,
-                                guint flag G_GNUC_UNUSED, gpointer data)
+static void torrent_state_selection_changed(TrgStateSelector *selector G_GNUC_UNUSED,
+                                            guint flag G_GNUC_UNUSED, gpointer data)
 {
     gtk_tree_model_filter_refilter(GTK_TREE_MODEL_FILTER(data));
 }
 
-static void
-trg_main_window_conn_changed(TrgMainWindow * win, gboolean connected)
+static void trg_main_window_conn_changed(TrgMainWindow *win, gboolean connected)
 {
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
     TrgClient *tc = priv->client;
@@ -1650,18 +1429,14 @@ trg_main_window_conn_changed(TrgMainWindow * win, gboolean connected)
     gtk_widget_set_sensitive(GTK_WIDGET(priv->torrentTreeView), connected);
     gtk_widget_set_sensitive(GTK_WIDGET(priv->peersTreeView), connected);
     gtk_widget_set_sensitive(GTK_WIDGET(priv->filesTreeView), connected);
-    gtk_widget_set_sensitive(GTK_WIDGET(priv->trackersTreeView),
-                             connected);
+    gtk_widget_set_sensitive(GTK_WIDGET(priv->trackersTreeView), connected);
     gtk_widget_set_sensitive(GTK_WIDGET(priv->genDetails), connected);
 
     if (connected) {
         TrgPrefs *prefs = trg_client_get_prefs(priv->client);
-        priv->sessionTimerId =
-            g_timeout_add_seconds(trg_prefs_get_int
-                                  (prefs,
-                                   TRG_PREFS_KEY_SESSION_UPDATE_INTERVAL,
-                                   TRG_PREFS_CONNECTION),
-                                  trg_session_update_timerfunc, win);
+        priv->sessionTimerId = g_timeout_add_seconds(
+            trg_prefs_get_int(prefs, TRG_PREFS_KEY_SESSION_UPDATE_INTERVAL, TRG_PREFS_CONNECTION),
+            trg_session_update_timerfunc, win);
     } else {
         trg_main_window_torrent_scrub(win);
         trg_state_selector_disconnect(priv->stateSelector);
@@ -1680,10 +1455,8 @@ trg_main_window_conn_changed(TrgMainWindow * win, gboolean connected)
     connchange_whatever_tray(win, connected);
 }
 
-static void
-trg_main_window_get_property(GObject * object,
-                             guint property_id, GValue * value,
-                             GParamSpec * pspec)
+static void trg_main_window_get_property(GObject *object, guint property_id, GValue *value,
+                                         GParamSpec *pspec)
 {
     TrgMainWindow *win = TRG_MAIN_WINDOW(object);
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
@@ -1701,10 +1474,8 @@ trg_main_window_get_property(GObject * object,
     }
 }
 
-static void
-trg_main_window_set_property(GObject * object,
-                             guint property_id,
-                             const GValue * value, GParamSpec * pspec)
+static void trg_main_window_set_property(GObject *object, guint property_id, const GValue *value,
+                                         GParamSpec *pspec)
 {
     TrgMainWindow *win = TRG_MAIN_WINDOW(object);
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
@@ -1722,51 +1493,45 @@ trg_main_window_set_property(GObject * object,
     }
 }
 
-static void quit_cb(GtkWidget * w G_GNUC_UNUSED, gpointer data)
+static void quit_cb(GtkWidget *w G_GNUC_UNUSED, gpointer data)
 {
     gtk_widget_destroy(GTK_WIDGET(data));
 }
 
-static TrgMenuBar *trg_main_window_menu_bar_new(TrgMainWindow * win)
+static TrgMenuBar *trg_main_window_menu_bar_new(TrgMainWindow *win)
 {
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
 
-    GObject *b_disconnect, *b_add, *b_resume, *b_pause, *b_verify,
-        *b_remove, *b_delete, *b_props, *b_local_prefs, *b_remote_prefs,
-        *b_about, *b_view_states, *b_view_notebook, *b_view_stats,
-        *b_add_url, *b_quit, *b_move, *b_reannounce, *b_pause_all,
-        *b_resume_all, *b_dir_filters, *b_tracker_filters, *b_directories_first,
-        *b_up_queue, *b_down_queue, *b_top_queue, *b_bottom_queue,
+    GObject *b_disconnect, *b_add, *b_resume, *b_pause, *b_verify, *b_remove, *b_delete, *b_props,
+        *b_local_prefs, *b_remote_prefs, *b_about, *b_view_states, *b_view_notebook, *b_view_stats,
+        *b_add_url, *b_quit, *b_move, *b_reannounce, *b_pause_all, *b_resume_all, *b_dir_filters,
+        *b_tracker_filters, *b_directories_first, *b_up_queue, *b_down_queue, *b_top_queue,
+        *b_bottom_queue,
 #if TRG_WITH_GRAPH
-    *b_show_graph,
+        *b_show_graph,
 #endif
 #if HAVE_RSS
-    *b_view_rss,
+        *b_view_rss,
 #endif
-    *b_start_now, *b_copy_magnetlink;
+        *b_start_now, *b_copy_magnetlink;
 
     TrgMenuBar *menuBar;
     GtkAccelGroup *accel_group;
 
     accel_group = gtk_accel_group_new();
 
-    menuBar =
-        trg_menu_bar_new(win, trg_client_get_prefs(priv->client),
-                         priv->torrentTreeView, accel_group);
+    menuBar = trg_menu_bar_new(win, trg_client_get_prefs(priv->client), priv->torrentTreeView,
+                               accel_group);
 
-    g_object_get(menuBar, "disconnect-button", &b_disconnect, "add-button",
-                 &b_add, "add-url-button", &b_add_url, "resume-button",
-                 &b_resume, "resume-all-button", &b_resume_all,
-                 "pause-button", &b_pause, "pause-all-button",
-                 &b_pause_all, "delete-button", &b_delete, "remove-button",
-                 &b_remove, "move-button", &b_move, "verify-button",
-                 &b_verify, "reannounce-button", &b_reannounce,
-                 "props-button", &b_props, "remote-prefs-button",
-                 &b_remote_prefs, "local-prefs-button", &b_local_prefs,
-                 "view-notebook-button", &b_view_notebook,
-                 "view-states-button", &b_view_states, "view-stats-button",
-                 &b_view_stats, "about-button", &b_about, "quit-button",
-                 &b_quit, "dir-filters", &b_dir_filters, "tracker-filters",
+    g_object_get(menuBar, "disconnect-button", &b_disconnect, "add-button", &b_add,
+                 "add-url-button", &b_add_url, "resume-button", &b_resume, "resume-all-button",
+                 &b_resume_all, "pause-button", &b_pause, "pause-all-button", &b_pause_all,
+                 "delete-button", &b_delete, "remove-button", &b_remove, "move-button", &b_move,
+                 "verify-button", &b_verify, "reannounce-button", &b_reannounce, "props-button",
+                 &b_props, "remote-prefs-button", &b_remote_prefs, "local-prefs-button",
+                 &b_local_prefs, "view-notebook-button", &b_view_notebook, "view-states-button",
+                 &b_view_states, "view-stats-button", &b_view_stats, "about-button", &b_about,
+                 "quit-button", &b_quit, "dir-filters", &b_dir_filters, "tracker-filters",
                  &b_tracker_filters, TRG_PREFS_KEY_DIRECTORIES_FIRST, &b_directories_first,
 #if TRG_WITH_GRAPH
                  "show-graph", &b_show_graph,
@@ -1774,60 +1539,43 @@ static TrgMenuBar *trg_main_window_menu_bar_new(TrgMainWindow * win)
 #if HAVE_RSS
                  "view-rss-button", &b_view_rss,
 #endif
-                 "up-queue", &b_up_queue, "down-queue", &b_down_queue,
-                 "top-queue", &b_top_queue, "bottom-queue",
-                 &b_bottom_queue, "start-now", &b_start_now,
-                 "copymagnet-button", &b_copy_magnetlink, NULL);
+                 "up-queue", &b_up_queue, "down-queue", &b_down_queue, "top-queue", &b_top_queue,
+                 "bottom-queue", &b_bottom_queue, "start-now", &b_start_now, "copymagnet-button",
+                 &b_copy_magnetlink, NULL);
 
-    g_signal_connect(b_disconnect, "activate", G_CALLBACK(disconnect_cb),
-                     win);
+    g_signal_connect(b_disconnect, "activate", G_CALLBACK(disconnect_cb), win);
     g_signal_connect(b_add, "activate", G_CALLBACK(add_cb), win);
     g_signal_connect(b_add_url, "activate", G_CALLBACK(add_url_cb), win);
     g_signal_connect(b_resume, "activate", G_CALLBACK(resume_cb), win);
-    g_signal_connect(b_resume_all, "activate", G_CALLBACK(resume_all_cb),
-                     win);
+    g_signal_connect(b_resume_all, "activate", G_CALLBACK(resume_all_cb), win);
     g_signal_connect(b_pause, "activate", G_CALLBACK(pause_cb), win);
-    g_signal_connect(b_pause_all, "activate", G_CALLBACK(pause_all_cb),
-                     win);
+    g_signal_connect(b_pause_all, "activate", G_CALLBACK(pause_all_cb), win);
     g_signal_connect(b_verify, "activate", G_CALLBACK(verify_cb), win);
-    g_signal_connect(b_reannounce, "activate", G_CALLBACK(reannounce_cb),
-                     win);
+    g_signal_connect(b_reannounce, "activate", G_CALLBACK(reannounce_cb), win);
     g_signal_connect(b_delete, "activate", G_CALLBACK(delete_cb), win);
     g_signal_connect(b_remove, "activate", G_CALLBACK(remove_cb), win);
     g_signal_connect(b_up_queue, "activate", G_CALLBACK(up_queue_cb), win);
-    g_signal_connect(b_down_queue, "activate", G_CALLBACK(down_queue_cb),
-                     win);
-    g_signal_connect(b_top_queue, "activate", G_CALLBACK(top_queue_cb),
-                     win);
-    g_signal_connect(b_bottom_queue, "activate",
-                     G_CALLBACK(bottom_queue_cb), win);
-    g_signal_connect(b_start_now, "activate", G_CALLBACK(start_now_cb),
-                     win);
+    g_signal_connect(b_down_queue, "activate", G_CALLBACK(down_queue_cb), win);
+    g_signal_connect(b_top_queue, "activate", G_CALLBACK(top_queue_cb), win);
+    g_signal_connect(b_bottom_queue, "activate", G_CALLBACK(bottom_queue_cb), win);
+    g_signal_connect(b_start_now, "activate", G_CALLBACK(start_now_cb), win);
     g_signal_connect(b_move, "activate", G_CALLBACK(move_cb), win);
     g_signal_connect(b_about, "activate", G_CALLBACK(open_about_cb), win);
-    g_signal_connect(b_local_prefs, "activate",
-                     G_CALLBACK(open_local_prefs_cb), win);
-    g_signal_connect(b_remote_prefs, "activate",
-                     G_CALLBACK(open_remote_prefs_cb), win);
-    g_signal_connect(b_view_notebook, "toggled",
-                     G_CALLBACK(view_notebook_toggled_cb), win);
-    g_signal_connect(b_dir_filters, "toggled",
-                     G_CALLBACK(main_window_toggle_filter_dirs), win);
-    g_signal_connect(b_tracker_filters, "toggled",
-                     G_CALLBACK(main_window_toggle_filter_trackers), win);
-	g_signal_connect(b_directories_first, "toggled",
-					 G_CALLBACK(main_window_toggle_directories_first), win);
-    g_signal_connect(b_view_states, "toggled",
-                     G_CALLBACK(view_states_toggled_cb), win);
-    g_signal_connect(b_view_stats, "activate",
-                     G_CALLBACK(view_stats_toggled_cb), win);
+    g_signal_connect(b_local_prefs, "activate", G_CALLBACK(open_local_prefs_cb), win);
+    g_signal_connect(b_remote_prefs, "activate", G_CALLBACK(open_remote_prefs_cb), win);
+    g_signal_connect(b_view_notebook, "toggled", G_CALLBACK(view_notebook_toggled_cb), win);
+    g_signal_connect(b_dir_filters, "toggled", G_CALLBACK(main_window_toggle_filter_dirs), win);
+    g_signal_connect(b_tracker_filters, "toggled", G_CALLBACK(main_window_toggle_filter_trackers),
+                     win);
+    g_signal_connect(b_directories_first, "toggled",
+                     G_CALLBACK(main_window_toggle_directories_first), win);
+    g_signal_connect(b_view_states, "toggled", G_CALLBACK(view_states_toggled_cb), win);
+    g_signal_connect(b_view_stats, "activate", G_CALLBACK(view_stats_toggled_cb), win);
 #if HAVE_RSS
-    g_signal_connect(b_view_rss, "activate",
-                     G_CALLBACK(view_rss_toggled_cb), win);
+    g_signal_connect(b_view_rss, "activate", G_CALLBACK(view_rss_toggled_cb), win);
 #endif
 #if TRG_WITH_GRAPH
-    g_signal_connect(b_show_graph, "toggled",
-                     G_CALLBACK(trg_main_window_toggle_graph_cb), win);
+    g_signal_connect(b_show_graph, "toggled", G_CALLBACK(trg_main_window_toggle_graph_cb), win);
 #endif
     g_signal_connect(b_props, "activate", G_CALLBACK(open_props_cb), win);
     g_signal_connect(b_copy_magnetlink, "activate", G_CALLBACK(copy_magnetlink_cb), win);
@@ -1838,16 +1586,13 @@ static TrgMenuBar *trg_main_window_menu_bar_new(TrgMainWindow * win)
     return menuBar;
 }
 
-static void
-clear_filter_entry_cb(GtkEntry * entry,
-                      GtkEntryIconPosition icon_pos,
-                      GdkEvent * event, gpointer user_data)
+static void clear_filter_entry_cb(GtkEntry *entry, GtkEntryIconPosition icon_pos, GdkEvent *event,
+                                  gpointer user_data)
 {
     gtk_entry_set_text(entry, "");
 }
 
-static GtkWidget *trg_imagemenuitem_box(const gchar * text,
-                                        char *icon_name)
+static GtkWidget *trg_imagemenuitem_box(const gchar *text, char *icon_name)
 {
     GtkWidget *item, *box, *label, *icon;
 
@@ -1864,10 +1609,8 @@ static GtkWidget *trg_imagemenuitem_box(const gchar * text,
     return item;
 }
 
-static GtkWidget *trg_imagemenuitem_new(GtkMenuShell * shell,
-                                        const gchar * text, char *icon_name,
-                                        gboolean sensitive, GCallback cb,
-                                        gpointer cbdata)
+static GtkWidget *trg_imagemenuitem_new(GtkMenuShell *shell, const gchar *text, char *icon_name,
+                                        gboolean sensitive, GCallback cb, gpointer cbdata)
 {
 
     GtkWidget *item = trg_imagemenuitem_box(text, icon_name);
@@ -1878,7 +1621,7 @@ static GtkWidget *trg_imagemenuitem_new(GtkMenuShell * shell,
     return item;
 }
 
-static void set_limit_cb(GtkWidget * w, TrgMainWindow * win)
+static void set_limit_cb(GtkWidget *w, TrgMainWindow *win)
 {
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
 
@@ -1893,7 +1636,7 @@ static void set_limit_cb(GtkWidget * w, TrgMainWindow * win)
     JsonObject *args;
 
     if (limitIds)
-        req = torrent_set((JsonArray *) limitIds);
+        req = torrent_set((JsonArray *)limitIds);
     else
         req = session_set();
 
@@ -1905,26 +1648,24 @@ static void set_limit_cb(GtkWidget * w, TrgMainWindow * win)
     json_object_set_boolean_member(args, enabledKey, speed >= 0);
 
     if (limitIds)
-        dispatch_async(priv->client, req, on_generic_interactive_action_response,
-                       win);
+        dispatch_async(priv->client, req, on_generic_interactive_action_response, win);
     else
         dispatch_async(priv->client, req, on_session_set, win);
 }
 
-static void set_priority_cb(GtkWidget * w, TrgMainWindow * win)
+static void set_priority_cb(GtkWidget *w, TrgMainWindow *win)
 {
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
 
     GtkWidget *parent = gtk_widget_get_parent(w);
 
-    gint priority =
-        GPOINTER_TO_INT(g_object_get_data(G_OBJECT(w), "priority"));
+    gint priority = GPOINTER_TO_INT(g_object_get_data(G_OBJECT(w), "priority"));
     gpointer limitIds = g_object_get_data(G_OBJECT(parent), "pri-ids");
 
     JsonNode *req = NULL;
     JsonObject *args;
 
-    req = torrent_set((JsonArray *) limitIds);
+    req = torrent_set((JsonArray *)limitIds);
 
     args = node_get_arguments(req);
 
@@ -1933,19 +1674,18 @@ static void set_priority_cb(GtkWidget * w, TrgMainWindow * win)
     dispatch_async(priv->client, req, on_generic_interactive_action_response, win);
 }
 
-static GtkWidget *limit_item_new(TrgMainWindow * win, GtkWidget * menu,
-                                 gint64 currentLimit, gfloat limit)
+static GtkWidget *limit_item_new(TrgMainWindow *win, GtkWidget *menu, gint64 currentLimit,
+                                 gfloat limit)
 {
     char speed[32];
     GtkWidget *item;
-    gboolean active = limit < 0 ? FALSE : (currentLimit == (gint64) limit);
+    gboolean active = limit < 0 ? FALSE : (currentLimit == (gint64)limit);
 
     trg_strlspeed(speed, limit);
 
     item = gtk_check_menu_item_new_with_label(speed);
 
-    g_object_set_data(G_OBJECT(item), "limit",
-                      GINT_TO_POINTER((gint) limit));
+    g_object_set_data(G_OBJECT(item), "limit", GINT_TO_POINTER((gint)limit));
     gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(item), active);
     g_signal_connect(item, "activate", G_CALLBACK(set_limit_cb), win);
 
@@ -1953,15 +1693,12 @@ static GtkWidget *limit_item_new(TrgMainWindow * win, GtkWidget * menu,
     return item;
 }
 
-static GtkWidget *priority_menu_item_new(TrgMainWindow * win,
-                                         GtkMenuShell * menu,
-                                         const gchar * label, gint value,
-                                         gint current_value)
+static GtkWidget *priority_menu_item_new(TrgMainWindow *win, GtkMenuShell *menu, const gchar *label,
+                                         gint value, gint current_value)
 {
     GtkWidget *item = gtk_check_menu_item_new_with_label(label);
 
-    gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(item),
-                                   value == current_value);
+    gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(item), value == current_value);
     g_object_set_data(G_OBJECT(item), "priority", GINT_TO_POINTER(value));
     g_signal_connect(item, "activate", G_CALLBACK(set_priority_cb), win);
 
@@ -1970,7 +1707,7 @@ static GtkWidget *priority_menu_item_new(TrgMainWindow * win,
     return item;
 }
 
-static GtkWidget *priority_menu_new(TrgMainWindow * win, JsonArray * ids)
+static GtkWidget *priority_menu_new(TrgMainWindow *win, JsonArray *ids)
 {
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
     TrgClient *client = priv->client;
@@ -1978,32 +1715,26 @@ static GtkWidget *priority_menu_new(TrgMainWindow * win, JsonArray * ids)
     gint selected_pri = TR_PRI_UNSET;
     GtkWidget *toplevel, *menu;
 
-    if (get_torrent_data(trg_client_get_torrent_table(client),
-                         priv->selectedTorrentId, &t, NULL))
+    if (get_torrent_data(trg_client_get_torrent_table(client), priv->selectedTorrentId, &t, NULL))
         selected_pri = torrent_get_bandwidth_priority(t);
 
     toplevel = trg_imagemenuitem_box(_("Priority"), "network-workgroup");
 
     menu = gtk_menu_new();
 
-    g_object_set_data_full(G_OBJECT(menu), "pri-ids", ids,
-                           (GDestroyNotify) json_array_unref);
+    g_object_set_data_full(G_OBJECT(menu), "pri-ids", ids, (GDestroyNotify)json_array_unref);
 
-    priority_menu_item_new(win, GTK_MENU_SHELL(menu), _("High"),
-                           TR_PRI_HIGH, selected_pri);
-    priority_menu_item_new(win, GTK_MENU_SHELL(menu), _("Normal"),
-                           TR_PRI_NORMAL, selected_pri);
-    priority_menu_item_new(win, GTK_MENU_SHELL(menu), _("Low"), TR_PRI_LOW,
-                           selected_pri);
+    priority_menu_item_new(win, GTK_MENU_SHELL(menu), _("High"), TR_PRI_HIGH, selected_pri);
+    priority_menu_item_new(win, GTK_MENU_SHELL(menu), _("Normal"), TR_PRI_NORMAL, selected_pri);
+    priority_menu_item_new(win, GTK_MENU_SHELL(menu), _("Low"), TR_PRI_LOW, selected_pri);
 
     gtk_menu_item_set_submenu(GTK_MENU_ITEM(toplevel), menu);
 
     return toplevel;
 }
 
-static GtkWidget *limit_menu_new(TrgMainWindow * win, gchar * title,
-                                 gchar * enabledKey, gchar * speedKey,
-                                 JsonArray * ids)
+static GtkWidget *limit_menu_new(TrgMainWindow *win, gchar *title, gchar *enabledKey,
+                                 gchar *speedKey, JsonArray *ids)
 {
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
     TrgClient *client = priv->client;
@@ -2013,26 +1744,22 @@ static GtkWidget *limit_menu_new(TrgMainWindow * win, gchar * title,
     gint64 limit;
 
     if (ids)
-        get_torrent_data(trg_client_get_torrent_table(client),
-                         priv->selectedTorrentId, &current, &iter);
+        get_torrent_data(trg_client_get_torrent_table(client), priv->selectedTorrentId, &current,
+                         &iter);
     else
         current = trg_client_get_session(client);
 
-    limit =
-        json_object_get_boolean_member(current,
-                                       enabledKey) ?
-        json_object_get_int_member(current, speedKey) : -1;
+    limit = json_object_get_boolean_member(current, enabledKey)
+        ? json_object_get_int_member(current, speedKey)
+        : -1;
 
     toplevel = trg_imagemenuitem_box(title, "network-workgroup");
 
     menu = gtk_menu_new();
 
-    g_object_set_data_full(G_OBJECT(menu), "speedKey", g_strdup(speedKey),
-                           g_free);
-    g_object_set_data_full(G_OBJECT(menu), "enabledKey",
-                           g_strdup(enabledKey), g_free);
-    g_object_set_data_full(G_OBJECT(menu), "limit-ids", ids,
-                           (GDestroyNotify) json_array_unref);
+    g_object_set_data_full(G_OBJECT(menu), "speedKey", g_strdup(speedKey), g_free);
+    g_object_set_data_full(G_OBJECT(menu), "enabledKey", g_strdup(enabledKey), g_free);
+    g_object_set_data_full(G_OBJECT(menu), "limit-ids", ids, (GDestroyNotify)json_array_unref);
 
     item = gtk_check_menu_item_new_with_label(_("No Limit"));
     gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(item), limit < 0);
@@ -2040,8 +1767,7 @@ static GtkWidget *limit_menu_new(TrgMainWindow * win, gchar * title,
     g_signal_connect(item, "activate", G_CALLBACK(set_limit_cb), win);
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), item);
 
-    gtk_menu_shell_append(GTK_MENU_SHELL(menu),
-                          gtk_separator_menu_item_new());
+    gtk_menu_shell_append(GTK_MENU_SHELL(menu), gtk_separator_menu_item_new());
 
     limit_item_new(win, menu, limit, 0);
     limit_item_new(win, menu, limit, 5);
@@ -2068,39 +1794,33 @@ static GtkWidget *limit_menu_new(TrgMainWindow * win, gchar * title,
     return toplevel;
 }
 
-static void exec_cmd_cb(GtkWidget * w, TrgMainWindow * win)
+static void exec_cmd_cb(GtkWidget *w, TrgMainWindow *win)
 {
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
-    JsonObject *cmd_obj = (JsonObject *) g_object_get_data(G_OBJECT(w),
-                                                           "cmd-object");
-    GtkTreeSelection *selection =
-        gtk_tree_view_get_selection(GTK_TREE_VIEW(priv->torrentTreeView));
+    JsonObject *cmd_obj = (JsonObject *)g_object_get_data(G_OBJECT(w), "cmd-object");
+    GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(priv->torrentTreeView));
     GtkTreeModel *model;
-    GList *selectedRows = gtk_tree_selection_get_selected_rows(selection,
-                                                               &model);
+    GList *selectedRows = gtk_tree_selection_get_selected_rows(selection, &model);
     GError *cmd_error = NULL;
     gchar *cmd_line = NULL;
     gchar **argv = NULL;
 
-    cmd_line = build_remote_exec_cmd(priv->client,
-                                     model,
-                                     selectedRows,
-                                     json_object_get_string_member(cmd_obj,
-                                                                   TRG_PREFS_KEY_EXEC_COMMANDS_SUBKEY_CMD));
+    cmd_line = build_remote_exec_cmd(
+        priv->client, model, selectedRows,
+        json_object_get_string_member(cmd_obj, TRG_PREFS_KEY_EXEC_COMMANDS_SUBKEY_CMD));
 
     g_debug("Exec: %s", cmd_line);
 
     if (!cmd_line)
         return;
 
-    /* GTK has bug, won't let you pass a string here containing a quoted param, so use parse and then spawn
-     * rather than g_spawn_command_line_async(cmd_line,&cmd_error); */
+    /* GTK has bug, won't let you pass a string here containing a quoted param, so use parse and
+     * then spawn rather than g_spawn_command_line_async(cmd_line,&cmd_error); */
 
     g_shell_parse_argv(cmd_line, NULL, &argv, NULL);
-    g_spawn_async(NULL, argv, NULL, G_SPAWN_SEARCH_PATH, NULL, NULL, NULL,
-                  &cmd_error);
+    g_spawn_async(NULL, argv, NULL, G_SPAWN_SEARCH_PATH, NULL, NULL, NULL, &cmd_error);
 
-    g_list_free_full(selectedRows, (GDestroyNotify) gtk_tree_path_free);
+    g_list_free_full(selectedRows, (GDestroyNotify)gtk_tree_path_free);
 
     if (argv)
         g_strfreev(argv);
@@ -2108,11 +1828,9 @@ static void exec_cmd_cb(GtkWidget * w, TrgMainWindow * win)
     g_free(cmd_line);
 
     if (cmd_error) {
-        GtkWidget *dialog = gtk_message_dialog_new(GTK_WINDOW(win),
-                                                   GTK_DIALOG_MODAL,
-                                                   GTK_MESSAGE_ERROR,
-                                                   GTK_BUTTONS_OK, "%s",
-                                                   cmd_error->message);
+        GtkWidget *dialog
+            = gtk_message_dialog_new(GTK_WINDOW(win), GTK_DIALOG_MODAL, GTK_MESSAGE_ERROR,
+                                     GTK_BUTTONS_OK, "%s", cmd_error->message);
         gtk_window_set_title(GTK_WINDOW(dialog), _("Error"));
         gtk_dialog_run(GTK_DIALOG(dialog));
         gtk_widget_destroy(dialog);
@@ -2120,9 +1838,7 @@ static void exec_cmd_cb(GtkWidget * w, TrgMainWindow * win)
     }
 }
 
-static void
-trg_torrent_tv_view_menu(GtkWidget * treeview,
-                         GdkEventButton * event, TrgMainWindow * win)
+static void trg_torrent_tv_view_menu(GtkWidget *treeview, GdkEventButton *event, TrgMainWindow *win)
 {
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
     TrgPrefs *prefs = trg_client_get_prefs(priv->client);
@@ -2136,36 +1852,26 @@ trg_torrent_tv_view_menu(GtkWidget * treeview,
 
     ids = build_json_id_array(TRG_TORRENT_TREE_VIEW(treeview));
 
-    trg_imagemenuitem_new(GTK_MENU_SHELL(menu), _("Properties"),
-                          "document-properties", TRUE,
+    trg_imagemenuitem_new(GTK_MENU_SHELL(menu), _("Properties"), "document-properties", TRUE,
                           G_CALLBACK(open_props_cb), win);
-    trg_imagemenuitem_new(GTK_MENU_SHELL(menu), _("Copy Magnet Link"),
-                          "edit-copy", TRUE,
+    trg_imagemenuitem_new(GTK_MENU_SHELL(menu), _("Copy Magnet Link"), "edit-copy", TRUE,
                           G_CALLBACK(copy_magnetlink_cb), win);
-    trg_imagemenuitem_new(GTK_MENU_SHELL(menu), _("Resume"),
-                          "media-playback-start", TRUE,
+    trg_imagemenuitem_new(GTK_MENU_SHELL(menu), _("Resume"), "media-playback-start", TRUE,
                           G_CALLBACK(resume_cb), win);
-    trg_imagemenuitem_new(GTK_MENU_SHELL(menu), _("Pause"),
-                          "media-playback-pause", TRUE,
+    trg_imagemenuitem_new(GTK_MENU_SHELL(menu), _("Pause"), "media-playback-pause", TRUE,
                           G_CALLBACK(pause_cb), win);
-    trg_imagemenuitem_new(GTK_MENU_SHELL(menu), _("Verify"),
-                          "view-refresh", TRUE, G_CALLBACK(verify_cb),
-                          win);
-    trg_imagemenuitem_new(GTK_MENU_SHELL(menu), _("Re-announce"),
-                          "network-server", TRUE,
+    trg_imagemenuitem_new(GTK_MENU_SHELL(menu), _("Verify"), "view-refresh", TRUE,
+                          G_CALLBACK(verify_cb), win);
+    trg_imagemenuitem_new(GTK_MENU_SHELL(menu), _("Re-announce"), "network-server", TRUE,
                           G_CALLBACK(reannounce_cb), win);
-    trg_imagemenuitem_new(GTK_MENU_SHELL(menu), _("Move"),
-                          "drive-harddisk", TRUE, G_CALLBACK(move_cb),
-                          win);
-    trg_imagemenuitem_new(GTK_MENU_SHELL(menu), _("Remove"),
-                          "list-remove", TRUE, G_CALLBACK(remove_cb),
-                          win);
-    trg_imagemenuitem_new(GTK_MENU_SHELL(menu), _("Remove and delete data"),
-                          "edit-delete", TRUE, G_CALLBACK(delete_cb),
-                          win);
+    trg_imagemenuitem_new(GTK_MENU_SHELL(menu), _("Move"), "drive-harddisk", TRUE,
+                          G_CALLBACK(move_cb), win);
+    trg_imagemenuitem_new(GTK_MENU_SHELL(menu), _("Remove"), "list-remove", TRUE,
+                          G_CALLBACK(remove_cb), win);
+    trg_imagemenuitem_new(GTK_MENU_SHELL(menu), _("Remove and delete data"), "edit-delete", TRUE,
+                          G_CALLBACK(delete_cb), win);
 
-    cmds = trg_prefs_get_array(prefs, TRG_PREFS_KEY_EXEC_COMMANDS,
-                               TRG_PREFS_CONNECTION);
+    cmds = trg_prefs_get_array(prefs, TRG_PREFS_KEY_EXEC_COMMANDS, TRG_PREFS_CONNECTION);
     n_cmds = json_array_get_length(cmds);
 
     if (n_cmds > 0) {
@@ -2174,71 +1880,50 @@ trg_torrent_tv_view_menu(GtkWidget * treeview,
         GList *cmds_li;
 
         if (n_cmds < 3) {
-            gtk_menu_shell_append(GTK_MENU_SHELL(menu),
-                                  gtk_separator_menu_item_new());
+            gtk_menu_shell_append(GTK_MENU_SHELL(menu), gtk_separator_menu_item_new());
             cmds_shell = GTK_MENU_SHELL(menu);
         } else {
-            GtkMenuItem *cmds_menu =
-                GTK_MENU_ITEM(gtk_menu_item_new_with_label(_("Execute")));
+            GtkMenuItem *cmds_menu = GTK_MENU_ITEM(gtk_menu_item_new_with_label(_("Execute")));
 
             cmds_shell = GTK_MENU_SHELL(gtk_menu_new());
-            gtk_menu_item_set_submenu(GTK_MENU_ITEM(cmds_menu),
-                                      GTK_WIDGET(cmds_shell));
-            gtk_menu_shell_append(GTK_MENU_SHELL(menu),
-                                  GTK_WIDGET(cmds_menu));
+            gtk_menu_item_set_submenu(GTK_MENU_ITEM(cmds_menu), GTK_WIDGET(cmds_shell));
+            gtk_menu_shell_append(GTK_MENU_SHELL(menu), GTK_WIDGET(cmds_menu));
         }
 
         for (cmds_li = cmds_list; cmds_li; cmds_li = g_list_next(cmds_li)) {
-            JsonObject *cmd_obj = json_node_get_object((JsonNode *)
-                                                       cmds_li->data);
-            const gchar *cmd_label = json_object_get_string_member(cmd_obj,
-                                                                   "label");
-            GtkWidget *item = trg_imagemenuitem_new(cmds_shell, cmd_label,
-                                                    "system-run",
-                                                    TRUE,
-                                                    G_CALLBACK
-                                                    (exec_cmd_cb), win);
+            JsonObject *cmd_obj = json_node_get_object((JsonNode *)cmds_li->data);
+            const gchar *cmd_label = json_object_get_string_member(cmd_obj, "label");
+            GtkWidget *item = trg_imagemenuitem_new(cmds_shell, cmd_label, "system-run", TRUE,
+                                                    G_CALLBACK(exec_cmd_cb), win);
             g_object_set_data(G_OBJECT(item), "cmd-object", cmd_obj);
         }
 
         g_list_free(cmds_list);
     }
 
-    gtk_menu_shell_append(GTK_MENU_SHELL(menu),
-                          gtk_separator_menu_item_new());
+    gtk_menu_shell_append(GTK_MENU_SHELL(menu), gtk_separator_menu_item_new());
 
     if (priv->queuesEnabled) {
-        trg_imagemenuitem_new(GTK_MENU_SHELL(menu), _("Start Now"),
-                              "media-playback-start", TRUE,
+        trg_imagemenuitem_new(GTK_MENU_SHELL(menu), _("Start Now"), "media-playback-start", TRUE,
                               G_CALLBACK(start_now_cb), win);
-        trg_imagemenuitem_new(GTK_MENU_SHELL(menu), _("Move Up Queue"),
-                              "go-up", TRUE,
+        trg_imagemenuitem_new(GTK_MENU_SHELL(menu), _("Move Up Queue"), "go-up", TRUE,
                               G_CALLBACK(up_queue_cb), win);
-        trg_imagemenuitem_new(GTK_MENU_SHELL(menu), _("Move Down Queue"),
-                              "go-down", TRUE,
+        trg_imagemenuitem_new(GTK_MENU_SHELL(menu), _("Move Down Queue"), "go-down", TRUE,
                               G_CALLBACK(down_queue_cb), win);
-        trg_imagemenuitem_new(GTK_MENU_SHELL(menu), _("Bottom Of Queue"),
-                              "go-bottom", TRUE,
+        trg_imagemenuitem_new(GTK_MENU_SHELL(menu), _("Bottom Of Queue"), "go-bottom", TRUE,
                               G_CALLBACK(bottom_queue_cb), win);
-        trg_imagemenuitem_new(GTK_MENU_SHELL(menu), _("Top Of Queue"),
-                              "go-top", TRUE,
+        trg_imagemenuitem_new(GTK_MENU_SHELL(menu), _("Top Of Queue"), "go-top", TRUE,
                               G_CALLBACK(top_queue_cb), win);
-        gtk_menu_shell_append(GTK_MENU_SHELL(menu),
-                              gtk_separator_menu_item_new());
+        gtk_menu_shell_append(GTK_MENU_SHELL(menu), gtk_separator_menu_item_new());
     }
 
-    gtk_menu_shell_append(GTK_MENU_SHELL(menu),
-                          limit_menu_new(win,
-                                         _("Down Limit"),
-                                         FIELD_DOWNLOAD_LIMITED,
-                                         FIELD_DOWNLOAD_LIMIT, ids));
-    gtk_menu_shell_append(GTK_MENU_SHELL(menu),
-                          limit_menu_new(win,
-                                         _("Up Limit"),
-                                         FIELD_UPLOAD_LIMITED,
-                                         FIELD_UPLOAD_LIMIT, ids));
-    gtk_menu_shell_append(GTK_MENU_SHELL(menu),
-                          priority_menu_new(win, ids));
+    gtk_menu_shell_append(
+        GTK_MENU_SHELL(menu),
+        limit_menu_new(win, _("Down Limit"), FIELD_DOWNLOAD_LIMITED, FIELD_DOWNLOAD_LIMIT, ids));
+    gtk_menu_shell_append(
+        GTK_MENU_SHELL(menu),
+        limit_menu_new(win, _("Up Limit"), FIELD_UPLOAD_LIMITED, FIELD_UPLOAD_LIMIT, ids));
+    gtk_menu_shell_append(GTK_MENU_SHELL(menu), priority_menu_new(win, ids));
 
     gtk_widget_show_all(menu);
 
@@ -2246,7 +1931,7 @@ trg_torrent_tv_view_menu(GtkWidget * treeview,
 }
 
 #if HAVE_LIBAPPINDICATOR
-static GtkMenu *trg_tray_view_menu(TrgMainWindow * win, const gchar * msg)
+static GtkMenu *trg_tray_view_menu(TrgMainWindow *win, const gchar *msg)
 {
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
     TrgPrefs *prefs = trg_client_get_prefs(priv->client);
@@ -2260,15 +1945,12 @@ static GtkMenu *trg_tray_view_menu(TrgMainWindow * win, const gchar * msg)
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), priv->iconStatusItem);
 
     if (connected) {
-        priv->iconDownloadingItem =
-            gtk_menu_item_new_with_label(_("Updating..."));
+        priv->iconDownloadingItem = gtk_menu_item_new_with_label(_("Updating..."));
         gtk_widget_set_visible(priv->iconDownloadingItem, FALSE);
         gtk_widget_set_sensitive(priv->iconDownloadingItem, FALSE);
-        gtk_menu_shell_append(GTK_MENU_SHELL(menu),
-                              priv->iconDownloadingItem);
+        gtk_menu_shell_append(GTK_MENU_SHELL(menu), priv->iconDownloadingItem);
 
-        priv->iconSeedingItem =
-            gtk_menu_item_new_with_label(_("Updating..."));
+        priv->iconSeedingItem = gtk_menu_item_new_with_label(_("Updating..."));
         gtk_widget_set_visible(priv->iconSeedingItem, FALSE);
         gtk_widget_set_sensitive(priv->iconSeedingItem, FALSE);
         gtk_menu_shell_append(GTK_MENU_SHELL(menu), priv->iconSeedingItem);
@@ -2280,45 +1962,36 @@ static GtkMenu *trg_tray_view_menu(TrgMainWindow * win, const gchar * msg)
 
     connect = trg_imagemenuitem_box(_("Connect"), "trg-gtk-connect");
     gtk_menu_item_set_submenu(GTK_MENU_ITEM(connect),
-                              trg_menu_bar_file_connect_menu_new(win,
-                                                                 prefs));
+                              trg_menu_bar_file_connect_menu_new(win, prefs));
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), connect);
 
     if (connected) {
-        trg_imagemenuitem_new(GTK_MENU_SHELL(menu), _("Disconnect"),
-                              "trg-gtk-disconnect", connected,
-                              G_CALLBACK(disconnect_cb), win);
+        trg_imagemenuitem_new(GTK_MENU_SHELL(menu), _("Disconnect"), "trg-gtk-disconnect",
+                              connected, G_CALLBACK(disconnect_cb), win);
 
-        trg_imagemenuitem_new(GTK_MENU_SHELL(menu), _("Add"),
-                              "list-add", connected, G_CALLBACK(add_cb),
-                              win);
+        trg_imagemenuitem_new(GTK_MENU_SHELL(menu), _("Add"), "list-add", connected,
+                              G_CALLBACK(add_cb), win);
 
-        trg_imagemenuitem_new(GTK_MENU_SHELL(menu), _("Add from URL"),
-                              "list-add", connected,
+        trg_imagemenuitem_new(GTK_MENU_SHELL(menu), _("Add from URL"), "list-add", connected,
                               G_CALLBACK(add_url_cb), win);
 
-        trg_imagemenuitem_new(GTK_MENU_SHELL(menu), _("Resume All"),
-                              "media-playback-start", connected,
-                              G_CALLBACK(resume_all_cb), win);
+        trg_imagemenuitem_new(GTK_MENU_SHELL(menu), _("Resume All"), "media-playback-start",
+                              connected, G_CALLBACK(resume_all_cb), win);
 
-        trg_imagemenuitem_new(GTK_MENU_SHELL(menu), _("Pause All"),
-                              "media-playback-pause", connected,
-                              G_CALLBACK(pause_all_cb), win);
+        trg_imagemenuitem_new(GTK_MENU_SHELL(menu), _("Pause All"), "media-playback-pause",
+                              connected, G_CALLBACK(pause_all_cb), win);
 
         gtk_menu_shell_append(GTK_MENU_SHELL(menu),
-                              limit_menu_new(win, _("Down Limit"),
-                                             SGET_SPEED_LIMIT_DOWN_ENABLED,
+                              limit_menu_new(win, _("Down Limit"), SGET_SPEED_LIMIT_DOWN_ENABLED,
                                              SGET_SPEED_LIMIT_DOWN, NULL));
         gtk_menu_shell_append(GTK_MENU_SHELL(menu),
-                              limit_menu_new(win, _("Up Limit"),
-                                             SGET_SPEED_LIMIT_UP_ENABLED,
+                              limit_menu_new(win, _("Up Limit"), SGET_SPEED_LIMIT_UP_ENABLED,
                                              SGET_SPEED_LIMIT_UP, NULL));
     }
 
-    gtk_menu_shell_append(GTK_MENU_SHELL(menu),
-                          gtk_separator_menu_item_new());
-    trg_imagemenuitem_new(GTK_MENU_SHELL(menu), _("Quit"), "application-exit",
-                          TRUE, G_CALLBACK(quit_cb), win);
+    gtk_menu_shell_append(GTK_MENU_SHELL(menu), gtk_separator_menu_item_new());
+    trg_imagemenuitem_new(GTK_MENU_SHELL(menu), _("Quit"), "application-exit", TRUE,
+                          G_CALLBACK(quit_cb), win);
 
     gtk_widget_show_all(menu);
 
@@ -2326,9 +1999,8 @@ static GtkMenu *trg_tray_view_menu(TrgMainWindow * win, const gchar * msg)
 }
 #endif
 
-static gboolean
-torrent_tv_button_pressed_cb(GtkWidget * treeview,
-                             GdkEventButton * event, gpointer userdata)
+static gboolean torrent_tv_button_pressed_cb(GtkWidget *treeview, GdkEventButton *event,
+                                             gpointer userdata)
 {
     GtkTreeSelection *selection;
     GtkTreePath *path;
@@ -2336,8 +2008,7 @@ torrent_tv_button_pressed_cb(GtkWidget * treeview,
     if (event->type == GDK_BUTTON_PRESS && event->button == 3) {
         selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(treeview));
 
-        if (gtk_tree_view_get_path_at_pos(GTK_TREE_VIEW(treeview),
-                                          (gint) event->x, (gint) event->y,
+        if (gtk_tree_view_get_path_at_pos(GTK_TREE_VIEW(treeview), (gint)event->x, (gint)event->y,
                                           &path, NULL, NULL, NULL)) {
             if (!gtk_tree_selection_path_is_selected(selection, path)) {
                 gtk_tree_selection_unselect_all(selection);
@@ -2354,15 +2025,13 @@ torrent_tv_button_pressed_cb(GtkWidget * treeview,
     return FALSE;
 }
 
-static gboolean
-torrent_tv_popup_menu_cb(GtkWidget * treeview, gpointer userdata)
+static gboolean torrent_tv_popup_menu_cb(GtkWidget *treeview, gpointer userdata)
 {
     trg_torrent_tv_view_menu(treeview, NULL, userdata);
     return TRUE;
 }
 
-static void trg_main_window_set_hidden_to_tray(TrgMainWindow * win,
-                                               gboolean hidden)
+static void trg_main_window_set_hidden_to_tray(TrgMainWindow *win, gboolean hidden)
 {
 
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
@@ -2373,11 +2042,9 @@ static void trg_main_window_set_hidden_to_tray(TrgMainWindow * win,
         gtk_window_deiconify(GTK_WINDOW(win));
         gtk_window_present(GTK_WINDOW(win));
 
-
         if (priv->timerId > 0) {
             g_clear_handle_id(&priv->timerId, g_source_remove);
-            dispatch_async(priv->client,
-                           torrent_get(TORRENT_GET_TAG_MODE_FULL),
+            dispatch_async(priv->client, torrent_get(TORRENT_GET_TAG_MODE_FULL),
                            on_torrent_get_update, win);
         }
     }
@@ -2385,31 +2052,26 @@ static void trg_main_window_set_hidden_to_tray(TrgMainWindow * win,
     priv->hidden = hidden;
 }
 
-
-void trg_main_window_remove_tray(TrgMainWindow * win)
+void trg_main_window_remove_tray(TrgMainWindow *win)
 {
 #if HAVE_LIBAPPINDICATOR
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
 
     if (priv->appIndicator)
-        app_indicator_set_status(priv->appIndicator,
-                                 APP_INDICATOR_STATUS_PASSIVE);
+        app_indicator_set_status(priv->appIndicator, APP_INDICATOR_STATUS_PASSIVE);
 
     g_clear_object(&priv->appIndicator);
 #endif
 }
 
 #if TRG_WITH_GRAPH
-void trg_main_window_add_graph(TrgMainWindow * win, gboolean show)
+void trg_main_window_add_graph(TrgMainWindow *win, gboolean show)
 {
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
 
-    priv->graph =
-        trg_torrent_graph_new(gtk_widget_get_style(priv->notebook));
-    priv->graphNotebookIndex =
-        gtk_notebook_append_page(GTK_NOTEBOOK(priv->notebook),
-                                 GTK_WIDGET(priv->graph),
-                                 gtk_label_new(_("Graph")));
+    priv->graph = trg_torrent_graph_new(gtk_widget_get_style(priv->notebook));
+    priv->graphNotebookIndex = gtk_notebook_append_page(
+        GTK_NOTEBOOK(priv->notebook), GTK_WIDGET(priv->graph), gtk_label_new(_("Graph")));
 
     if (show)
         gtk_widget_show_all(priv->notebook);
@@ -2417,19 +2079,18 @@ void trg_main_window_add_graph(TrgMainWindow * win, gboolean show)
     trg_torrent_graph_start(priv->graph);
 }
 
-void trg_main_window_remove_graph(TrgMainWindow * win)
+void trg_main_window_remove_graph(TrgMainWindow *win)
 {
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
 
     if (priv->graphNotebookIndex >= 0) {
-        gtk_notebook_remove_page(GTK_NOTEBOOK(priv->notebook),
-                                 priv->graphNotebookIndex);
+        gtk_notebook_remove_page(GTK_NOTEBOOK(priv->notebook), priv->graphNotebookIndex);
         priv->graphNotebookIndex = -1;
     }
 }
 #endif
 
-void trg_main_window_add_tray(TrgMainWindow * win)
+void trg_main_window_add_tray(TrgMainWindow *win)
 {
 #if HAVE_LIBAPPINDICATOR
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
@@ -2438,8 +2099,7 @@ void trg_main_window_add_tray(TrgMainWindow * win)
         priv->appIndicator = app_indicator_new(PACKAGE_NAME, PACKAGE_NAME,
                                                APP_INDICATOR_CATEGORY_APPLICATION_STATUS);
 
-       app_indicator_set_menu(priv->appIndicator,
-                              trg_tray_view_menu(win, NULL));
+        app_indicator_set_menu(priv->appIndicator, trg_tray_view_menu(win, NULL));
     }
 
     app_indicator_set_status(priv->appIndicator, APP_INDICATOR_STATUS_ACTIVE);
@@ -2447,7 +2107,7 @@ void trg_main_window_add_tray(TrgMainWindow * win)
 #endif
 }
 
-TrgStateSelector *trg_main_window_get_state_selector(TrgMainWindow * win)
+TrgStateSelector *trg_main_window_get_state_selector(TrgMainWindow *win)
 {
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
     return priv->stateSelector;
@@ -2455,10 +2115,8 @@ TrgStateSelector *trg_main_window_get_state_selector(TrgMainWindow * win)
 
 /* Couldn't find a way to get the width/height on exit, so save the
  * values of this event for when that happens. */
-static gboolean
-trg_main_window_config_event(TrgMainWindow * win,
-                             GdkEvent * event,
-                             gpointer user_data G_GNUC_UNUSED)
+static gboolean trg_main_window_config_event(TrgMainWindow *win, GdkEvent *event,
+                                             gpointer user_data G_GNUC_UNUSED)
 {
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
     priv->width = event->configure.width;
@@ -2466,9 +2124,7 @@ trg_main_window_config_event(TrgMainWindow * win,
     return FALSE;
 }
 
-static void
-trg_client_session_updated_cb(TrgClient * tc,
-                              JsonObject * session, TrgMainWindow * win)
+static void trg_client_session_updated_cb(TrgClient *tc, JsonObject *session, TrgMainWindow *win)
 {
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
     gboolean queuesEnabled;
@@ -2476,18 +2132,15 @@ trg_client_session_updated_cb(TrgClient * tc,
     trg_status_bar_session_update(priv->statusBar, session);
 
     if (json_object_has_member(session, SGET_DOWNLOAD_QUEUE_ENABLED)) {
-        queuesEnabled = json_object_get_boolean_member(session,
-                                                       SGET_DOWNLOAD_QUEUE_ENABLED)
-            || json_object_get_boolean_member(session,
-                                              SGET_SEED_QUEUE_ENABLED);
+        queuesEnabled = json_object_get_boolean_member(session, SGET_DOWNLOAD_QUEUE_ENABLED)
+            || json_object_get_boolean_member(session, SGET_SEED_QUEUE_ENABLED);
     } else {
         queuesEnabled = FALSE;
     }
 
     if (priv->queuesEnabled != queuesEnabled) {
         trg_menu_bar_set_supports_queues(priv->menuBar, queuesEnabled);
-        trg_state_selector_set_queues_enabled(priv->stateSelector,
-                                              queuesEnabled);
+        trg_state_selector_set_queues_enabled(priv->stateSelector, queuesEnabled);
     }
 
     priv->queuesEnabled = queuesEnabled;
@@ -2495,20 +2148,18 @@ trg_client_session_updated_cb(TrgClient * tc,
 
 /* Drag & Drop support */
 static GtkTargetEntry target_list[] = {
-/* datatype (string), restrictions on DnD (GtkTargetFlags), datatype (int) */
-    {"text/uri-list", GTK_TARGET_OTHER_APP | GTK_TARGET_OTHER_WIDGET, 0}
+    /* datatype (string), restrictions on DnD (GtkTargetFlags), datatype (int) */
+    { "text/uri-list", GTK_TARGET_OTHER_APP | GTK_TARGET_OTHER_WIDGET, 0 }
 };
 
 static guint n_targets = G_N_ELEMENTS(target_list);
 
-static void on_dropped_file(GtkWidget * widget, GdkDragContext * context,
-                            gint x, gint y, GtkSelectionData * data,
-                            guint info, guint time, gpointer user_data)
+static void on_dropped_file(GtkWidget *widget, GdkDragContext *context, gint x, gint y,
+                            GtkSelectionData *data, guint info, guint time, gpointer user_data)
 {
     TrgMainWindow *win = user_data;
 
-    if ((gtk_selection_data_get_length(data) >= 0)
-        && (gtk_selection_data_get_format(data) == 8)) {
+    if ((gtk_selection_data_get_length(data) >= 0) && (gtk_selection_data_get_format(data) == 8)) {
         gchar **uri_list = gtk_selection_data_get_uris(data);
         guint num_files = g_strv_length(uri_list);
         gchar **file_list = g_new0(gchar *, num_files + 1);
@@ -2524,15 +2175,12 @@ static void on_dropped_file(GtkWidget * widget, GdkDragContext * context,
     }
 }
 
-static gboolean window_key_press_handler(GtkWidget * widget,
-                                         GdkEvent * event,
-                                         gpointer user_data)
+static gboolean window_key_press_handler(GtkWidget *widget, GdkEvent *event, gpointer user_data)
 {
     TrgMainWindow *win = TRG_MAIN_WINDOW(widget);
-	TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
+    TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
 
-    if ((event->key.state & GDK_CONTROL_MASK)
-        && event->key.keyval == GDK_k) {
+    if ((event->key.state & GDK_CONTROL_MASK) && event->key.keyval == GDK_k) {
         gtk_widget_grab_focus(priv->filterEntry);
         return TRUE;
     }
@@ -2540,23 +2188,18 @@ static gboolean window_key_press_handler(GtkWidget * widget,
     return FALSE;
 }
 
-static GObject *trg_main_window_constructor(GType type,
-                                            guint n_construct_properties,
-                                            GObjectConstructParam *
-                                            construct_params)
+static GObject *trg_main_window_constructor(GType type, guint n_construct_properties,
+                                            GObjectConstructParam *construct_params)
 {
-    TrgMainWindow *self = TRG_MAIN_WINDOW(G_OBJECT_CLASS
-                                          (trg_main_window_parent_class)->
-                                          constructor(type,
-                                                      n_construct_properties,
-                                                      construct_params));
-    TrgMainWindowPrivate *priv =
-        G_TYPE_INSTANCE_GET_PRIVATE(self, TRG_TYPE_MAIN_WINDOW,
-                                    TrgMainWindowPrivate);
+    TrgMainWindow *self
+        = TRG_MAIN_WINDOW(G_OBJECT_CLASS(trg_main_window_parent_class)
+                              ->constructor(type, n_construct_properties, construct_params));
+    TrgMainWindowPrivate *priv
+        = G_TYPE_INSTANCE_GET_PRIVATE(self, TRG_TYPE_MAIN_WINDOW, TrgMainWindowPrivate);
     GtkWidget *w;
     GtkWidget *outerVbox;
     GtkWidget *toolbarHbox;
-    //GtkWidget *outerAlignment;
+    // GtkWidget *outerAlignment;
     gint width, height, pos;
     gboolean tray;
     TrgPrefs *prefs;
@@ -2570,73 +2213,57 @@ static GObject *trg_main_window_constructor(GType type,
     gtk_window_set_title(GTK_WINDOW(self), _("Transmission Remote"));
     gtk_window_set_default_size(GTK_WINDOW(self), 1000, 600);
 
-    g_signal_connect(G_OBJECT(self), "delete-event",
-                     G_CALLBACK(delete_event), NULL);
-    g_signal_connect(G_OBJECT(self), "destroy", G_CALLBACK(destroy_window),
+    g_signal_connect(G_OBJECT(self), "delete-event", G_CALLBACK(delete_event), NULL);
+    g_signal_connect(G_OBJECT(self), "destroy", G_CALLBACK(destroy_window), NULL);
+    g_signal_connect(G_OBJECT(self), "configure-event", G_CALLBACK(trg_main_window_config_event),
                      NULL);
-    g_signal_connect(G_OBJECT(self), "configure-event",
-                     G_CALLBACK(trg_main_window_config_event), NULL);
-    g_signal_connect(G_OBJECT(self), "key-press-event",
-                     G_CALLBACK(window_key_press_handler), NULL);
+    g_signal_connect(G_OBJECT(self), "key-press-event", G_CALLBACK(window_key_press_handler), NULL);
 
     priv->torrentModel = trg_torrent_model_new();
-    trg_client_set_torrent_table(priv->client,
-                                 get_torrent_table(priv->torrentModel));
+    trg_client_set_torrent_table(priv->client, get_torrent_table(priv->torrentModel));
 
-    g_signal_connect(priv->torrentModel, "torrent-completed",
-                     G_CALLBACK(on_torrent_completed), self);
-    g_signal_connect(priv->torrentModel, "torrent-added",
-                     G_CALLBACK(on_torrent_added), self);
+    g_signal_connect(priv->torrentModel, "torrent-completed", G_CALLBACK(on_torrent_completed),
+                     self);
+    g_signal_connect(priv->torrentModel, "torrent-added", G_CALLBACK(on_torrent_added), self);
 
-    priv->sortedTorrentModel =
-        gtk_tree_model_sort_new_with_model(GTK_TREE_MODEL
-                                           (priv->torrentModel));
+    priv->sortedTorrentModel
+        = gtk_tree_model_sort_new_with_model(GTK_TREE_MODEL(priv->torrentModel));
 
-    priv->filteredTorrentModel =
-        trg_sortable_filtered_model_new(GTK_TREE_SORTABLE
-                                        (priv->sortedTorrentModel), NULL);
-    gtk_tree_model_filter_set_visible_func(GTK_TREE_MODEL_FILTER
-                                           (priv->filteredTorrentModel),
-                                           trg_torrent_tree_view_visible_func,
-                                           self, NULL);
+    priv->filteredTorrentModel
+        = trg_sortable_filtered_model_new(GTK_TREE_SORTABLE(priv->sortedTorrentModel), NULL);
+    gtk_tree_model_filter_set_visible_func(GTK_TREE_MODEL_FILTER(priv->filteredTorrentModel),
+                                           trg_torrent_tree_view_visible_func, self, NULL);
 
-    priv->torrentTreeView = trg_main_window_torrent_tree_view_new(self,
-                                                                  priv->
-                                                                  filteredTorrentModel);
-    g_signal_connect(priv->torrentTreeView, "popup-menu",
-                     G_CALLBACK(torrent_tv_popup_menu_cb), self);
+    priv->torrentTreeView = trg_main_window_torrent_tree_view_new(self, priv->filteredTorrentModel);
+    g_signal_connect(priv->torrentTreeView, "popup-menu", G_CALLBACK(torrent_tv_popup_menu_cb),
+                     self);
     g_signal_connect(priv->torrentTreeView, "button-press-event",
                      G_CALLBACK(torrent_tv_button_pressed_cb), self);
-    g_signal_connect(priv->torrentTreeView, "row-activated",
-                     G_CALLBACK(torrent_tv_onRowActivated), self);
+    g_signal_connect(priv->torrentTreeView, "row-activated", G_CALLBACK(torrent_tv_onRowActivated),
+                     self);
 
     outerVbox = trg_vbox_new(FALSE, 0);
 
     gtk_container_add(GTK_CONTAINER(self), outerVbox);
 
     priv->menuBar = trg_main_window_menu_bar_new(self);
-    gtk_box_pack_start(GTK_BOX(outerVbox), GTK_WIDGET(priv->menuBar),
-                       FALSE, FALSE, 0);
+    gtk_box_pack_start(GTK_BOX(outerVbox), GTK_WIDGET(priv->menuBar), FALSE, FALSE, 0);
 
     toolbarHbox = trg_hbox_new(FALSE, 0);
     priv->toolBar = trg_main_window_toolbar_new(self);
-    gtk_box_pack_start(GTK_BOX(toolbarHbox), GTK_WIDGET(priv->toolBar),
-                       TRUE, TRUE, 0);
+    gtk_box_pack_start(GTK_BOX(toolbarHbox), GTK_WIDGET(priv->toolBar), TRUE, TRUE, 0);
 
     w = gtk_entry_new();
-    gtk_entry_set_icon_from_icon_name(GTK_ENTRY(w), GTK_ENTRY_ICON_SECONDARY,
-                                      "edit-clear");
-    g_signal_connect(w, "icon-release", G_CALLBACK(clear_filter_entry_cb),
-                     NULL);
+    gtk_entry_set_icon_from_icon_name(GTK_ENTRY(w), GTK_ENTRY_ICON_SECONDARY, "edit-clear");
+    g_signal_connect(w, "icon-release", G_CALLBACK(clear_filter_entry_cb), NULL);
     gtk_box_pack_start(GTK_BOX(toolbarHbox), w, FALSE, FALSE, 0);
     g_object_set(w, "secondary-icon-sensitive", FALSE, NULL);
     priv->filterEntry = w;
 
-    g_signal_connect(G_OBJECT(priv->filterEntry), "changed",
-                     G_CALLBACK(entry_filter_changed_cb), self);
+    g_signal_connect(G_OBJECT(priv->filterEntry), "changed", G_CALLBACK(entry_filter_changed_cb),
+                     self);
 
-    gtk_box_pack_start(GTK_BOX(outerVbox), GTK_WIDGET(toolbarHbox), FALSE,
-                       FALSE, 0);
+    gtk_box_pack_start(GTK_BOX(outerVbox), GTK_WIDGET(toolbarHbox), FALSE, FALSE, 0);
 
     priv->hpaned = gtk_paned_new(GTK_ORIENTATION_HORIZONTAL);
     priv->vpaned = gtk_paned_new(GTK_ORIENTATION_VERTICAL);
@@ -2644,47 +2271,35 @@ static GObject *trg_main_window_constructor(GType type,
     gtk_box_pack_start(GTK_BOX(outerVbox), priv->vpaned, TRUE, TRUE, 0);
     gtk_paned_pack1(GTK_PANED(priv->vpaned), priv->hpaned, TRUE, TRUE);
 
-    priv->stateSelector = trg_state_selector_new(priv->client,
-                                                 priv->torrentModel);
-    priv->stateSelectorScroller =
-        my_scrolledwin_new(GTK_WIDGET(priv->stateSelector));
-    gtk_paned_pack1(GTK_PANED(priv->hpaned), priv->stateSelectorScroller,
-                    FALSE, FALSE);
+    priv->stateSelector = trg_state_selector_new(priv->client, priv->torrentModel);
+    priv->stateSelectorScroller = my_scrolledwin_new(GTK_WIDGET(priv->stateSelector));
+    gtk_paned_pack1(GTK_PANED(priv->hpaned), priv->stateSelectorScroller, FALSE, FALSE);
 
-    gtk_paned_pack2(GTK_PANED(priv->hpaned), my_scrolledwin_new(GTK_WIDGET
-                                                                (priv->
-                                                                 torrentTreeView)),
+    gtk_paned_pack2(GTK_PANED(priv->hpaned), my_scrolledwin_new(GTK_WIDGET(priv->torrentTreeView)),
                     TRUE, TRUE);
 
-    g_signal_connect(G_OBJECT(priv->stateSelector),
-                     "torrent-state-changed",
-                     G_CALLBACK(torrent_state_selection_changed),
-                     priv->filteredTorrentModel);
+    g_signal_connect(G_OBJECT(priv->stateSelector), "torrent-state-changed",
+                     G_CALLBACK(torrent_state_selection_changed), priv->filteredTorrentModel);
 
     priv->notebook = trg_main_window_notebook_new(self);
     gtk_paned_pack2(GTK_PANED(priv->vpaned), priv->notebook, FALSE, FALSE);
 
-    tray = trg_prefs_get_bool(prefs, TRG_PREFS_KEY_SYSTEM_TRAY,
-                              TRG_PREFS_GLOBAL);
+    tray = trg_prefs_get_bool(prefs, TRG_PREFS_KEY_SYSTEM_TRAY, TRG_PREFS_GLOBAL);
     if (tray)
         trg_main_window_add_tray(self);
     else
         trg_main_window_remove_tray(self);
 
     priv->statusBar = trg_status_bar_new(self, priv->client);
-    g_signal_connect(priv->client, "session-updated",
-                     G_CALLBACK(trg_client_session_updated_cb), self);
+    g_signal_connect(priv->client, "session-updated", G_CALLBACK(trg_client_session_updated_cb),
+                     self);
 
-    gtk_box_pack_start(GTK_BOX(outerVbox), GTK_WIDGET(priv->statusBar),
-                       FALSE, FALSE, 2);
+    gtk_box_pack_start(GTK_BOX(outerVbox), GTK_WIDGET(priv->statusBar), FALSE, FALSE, 2);
 
-    width = trg_prefs_get_int(prefs, TRG_PREFS_KEY_WINDOW_WIDTH,
-                              TRG_PREFS_GLOBAL);
-    height = trg_prefs_get_int(prefs, TRG_PREFS_KEY_WINDOW_HEIGHT,
-                               TRG_PREFS_GLOBAL);
+    width = trg_prefs_get_int(prefs, TRG_PREFS_KEY_WINDOW_WIDTH, TRG_PREFS_GLOBAL);
+    height = trg_prefs_get_int(prefs, TRG_PREFS_KEY_WINDOW_HEIGHT, TRG_PREFS_GLOBAL);
 
-    pos = trg_prefs_get_int(prefs, TRG_PREFS_KEY_NOTEBOOK_PANED_POS,
-                            TRG_PREFS_GLOBAL);
+    pos = trg_prefs_get_int(prefs, TRG_PREFS_KEY_NOTEBOOK_PANED_POS, TRG_PREFS_GLOBAL);
 
     if (width > 0 && height > 0)
         gtk_window_set_default_size(GTK_WINDOW(self), width, height);
@@ -2696,17 +2311,13 @@ static GObject *trg_main_window_constructor(GType type,
 
     gtk_widget_show_all(GTK_WIDGET(self));
 
-    trg_widget_set_visible(priv->stateSelectorScroller,
-                           trg_prefs_get_bool(prefs,
-                                              TRG_PREFS_KEY_SHOW_STATE_SELECTOR,
-                                              TRG_PREFS_GLOBAL));
-    trg_widget_set_visible(priv->notebook,
-                           trg_prefs_get_bool(prefs,
-                                              TRG_PREFS_KEY_SHOW_NOTEBOOK,
-                                              TRG_PREFS_GLOBAL));
+    trg_widget_set_visible(
+        priv->stateSelectorScroller,
+        trg_prefs_get_bool(prefs, TRG_PREFS_KEY_SHOW_STATE_SELECTOR, TRG_PREFS_GLOBAL));
+    trg_widget_set_visible(
+        priv->notebook, trg_prefs_get_bool(prefs, TRG_PREFS_KEY_SHOW_NOTEBOOK, TRG_PREFS_GLOBAL));
 
-    pos = trg_prefs_get_int(prefs, TRG_PREFS_KEY_STATES_PANED_POS,
-                            TRG_PREFS_GLOBAL);
+    pos = trg_prefs_get_int(prefs, TRG_PREFS_KEY_STATES_PANED_POS, TRG_PREFS_GLOBAL);
     if (pos > 0)
         gtk_paned_set_position(GTK_PANED(priv->hpaned), pos);
 
@@ -2714,21 +2325,21 @@ static GObject *trg_main_window_constructor(GType type,
         trg_main_window_set_hidden_to_tray(self, TRUE);
 
     /* Drag and Drop */
-    gtk_drag_dest_set(GTK_WIDGET(self), /* widget that will accept a drop */
-                      GTK_DEST_DEFAULT_ALL,     /* default actions for dest on DnD */
-                      target_list,      /* lists of target to support */
-                      n_targets,        /* size of list */
-                      GDK_ACTION_MOVE   /* what to do with data after dropped */
-                      /* | GDK_ACTION_COPY ... seems that file managers only need ACTION_MOVE, not ACTION_COPY */
-        );
+    gtk_drag_dest_set(
+        GTK_WIDGET(self), /* widget that will accept a drop */
+        GTK_DEST_DEFAULT_ALL, /* default actions for dest on DnD */
+        target_list, /* lists of target to support */
+        n_targets, /* size of list */
+        GDK_ACTION_MOVE /* what to do with data after dropped */
+        /* | GDK_ACTION_COPY ... seems that file managers only need ACTION_MOVE, not ACTION_COPY */
+    );
 
-    g_signal_connect(self, "drag-data-received",
-                     G_CALLBACK(on_dropped_file), self);
+    g_signal_connect(self, "drag-data-received", G_CALLBACK(on_dropped_file), self);
 
     return G_OBJECT(self);
 }
 
-static void trg_main_window_class_init(TrgMainWindowClass * klass)
+static void trg_main_window_class_init(TrgMainWindowClass *klass)
 {
     GObjectClass *object_class = G_OBJECT_CLASS(klass);
 
@@ -2736,53 +2347,39 @@ static void trg_main_window_class_init(TrgMainWindowClass * klass)
     object_class->get_property = trg_main_window_get_property;
     object_class->set_property = trg_main_window_set_property;
 
-    g_object_class_install_property(object_class,
-                                    PROP_CLIENT,
-                                    g_param_spec_pointer("trg-client",
-                                                         "TClient",
-                                                         "Client",
-                                                         G_PARAM_READWRITE|
-                                                         G_PARAM_CONSTRUCT_ONLY|
-                                                         G_PARAM_STATIC_STRINGS));
+    g_object_class_install_property(
+        object_class, PROP_CLIENT,
+        g_param_spec_pointer("trg-client", "TClient", "Client",
+                             G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS));
 
-    g_object_class_install_property(object_class,
-                                    PROP_MINIMISE_ON_START,
-                                    g_param_spec_boolean("min-on-start",
-                                                         "Min On Start",
-                                                         "Min On Start",
-                                                         FALSE,
-                                                         G_PARAM_READWRITE|
-                                                         G_PARAM_CONSTRUCT_ONLY|
-                                                         G_PARAM_STATIC_STRINGS));
+    g_object_class_install_property(
+        object_class, PROP_MINIMISE_ON_START,
+        g_param_spec_boolean("min-on-start", "Min On Start", "Min On Start", FALSE,
+                             G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS));
 }
 
-void trg_main_window_set_start_args(TrgMainWindow * win, gchar ** args)
+void trg_main_window_set_start_args(TrgMainWindow *win, gchar **args)
 {
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
     priv->args = args;
 }
 
-void auto_connect_if_required(TrgMainWindow * win)
+void auto_connect_if_required(TrgMainWindow *win)
 {
     TrgMainWindowPrivate *priv = trg_main_window_get_instance_private(win);
     TrgPrefs *prefs = trg_client_get_prefs(priv->client);
-    gchar *host = trg_prefs_get_string(prefs, TRG_PREFS_KEY_HOSTNAME,
-                                       TRG_PREFS_PROFILE);
+    gchar *host = trg_prefs_get_string(prefs, TRG_PREFS_KEY_HOSTNAME, TRG_PREFS_PROFILE);
 
     if (host) {
         gint len = strlen(host);
         g_free(host);
-        if (len > 0
-            && trg_prefs_get_bool(prefs, TRG_PREFS_KEY_AUTO_CONNECT,
-                                  TRG_PREFS_PROFILE)) {
+        if (len > 0 && trg_prefs_get_bool(prefs, TRG_PREFS_KEY_AUTO_CONNECT, TRG_PREFS_PROFILE)) {
             connect_cb(NULL, win);
         }
     }
 }
 
-TrgMainWindow *trg_main_window_new(TrgClient * tc, gboolean minonstart)
+TrgMainWindow *trg_main_window_new(TrgClient *tc, gboolean minonstart)
 {
-    return g_object_new(TRG_TYPE_MAIN_WINDOW, "trg-client", tc,
-                        "min-on-start", minonstart, NULL);
+    return g_object_new(TRG_TYPE_MAIN_WINDOW, "trg-client", tc, "min-on-start", minonstart, NULL);
 }
-

--- a/src/trg-main-window.h
+++ b/src/trg-main-window.h
@@ -19,40 +19,39 @@
 
 #pragma once
 
-#include <json-glib/json-glib.h>
 #include <gtk/gtk.h>
+#include <json-glib/json-glib.h>
 
-#include "trg-torrent-model.h"
-#include "trg-peers-model.h"
-#include "trg-files-model.h"
-#include "trg-trackers-model.h"
-#include "trg-general-panel.h"
-#include "trg-torrent-tree-view.h"
 #include "trg-client.h"
+#include "trg-files-model.h"
+#include "trg-general-panel.h"
+#include "trg-peers-model.h"
+#include "trg-torrent-model.h"
+#include "trg-torrent-tree-view.h"
+#include "trg-trackers-model.h"
 
 G_BEGIN_DECLS
 
 #define TRG_TYPE_MAIN_WINDOW (trg_main_window_get_type())
-G_DECLARE_FINAL_TYPE (TrgMainWindow, trg_main_window, TRG, MAIN_WINDOW, GtkApplicationWindow)
+G_DECLARE_FINAL_TYPE(TrgMainWindow, trg_main_window, TRG, MAIN_WINDOW, GtkApplicationWindow)
 
-gint trg_add_from_filename(TrgMainWindow * win, gchar ** uris);
+gint trg_add_from_filename(TrgMainWindow *win, gchar **uris);
 gboolean on_session_set(gpointer data);
 gboolean on_delete_complete(gpointer data);
 void on_generic_interactive_action(TrgMainWindow *win, trg_response *response);
 gboolean on_generic_interactive_action_response(gpointer data);
-void auto_connect_if_required(TrgMainWindow * win);
-void trg_main_window_set_start_args(TrgMainWindow * win, gchar ** args);
-TrgMainWindow *trg_main_window_new(TrgClient * tc, gboolean minonstart);
-void trg_main_window_add_tray(TrgMainWindow * win);
-void trg_main_window_remove_tray(TrgMainWindow * win);
-void trg_main_window_add_graph(TrgMainWindow * win, gboolean show);
-void trg_main_window_remove_graph(TrgMainWindow * win);
-TrgStateSelector *trg_main_window_get_state_selector(TrgMainWindow * win);
-gint trg_mw_get_selected_torrent_id(TrgMainWindow * win);
-GtkTreeModel *trg_main_window_get_torrent_model(TrgMainWindow * win);
-void trg_main_window_notebook_set_visible(TrgMainWindow * win,
-                                          gboolean visible);
-void connect_cb(GtkWidget * w, gpointer data);
-void trg_main_window_reload_dir_aliases(TrgMainWindow * win);
+void auto_connect_if_required(TrgMainWindow *win);
+void trg_main_window_set_start_args(TrgMainWindow *win, gchar **args);
+TrgMainWindow *trg_main_window_new(TrgClient *tc, gboolean minonstart);
+void trg_main_window_add_tray(TrgMainWindow *win);
+void trg_main_window_remove_tray(TrgMainWindow *win);
+void trg_main_window_add_graph(TrgMainWindow *win, gboolean show);
+void trg_main_window_remove_graph(TrgMainWindow *win);
+TrgStateSelector *trg_main_window_get_state_selector(TrgMainWindow *win);
+gint trg_mw_get_selected_torrent_id(TrgMainWindow *win);
+GtkTreeModel *trg_main_window_get_torrent_model(TrgMainWindow *win);
+void trg_main_window_notebook_set_visible(TrgMainWindow *win, gboolean visible);
+void connect_cb(GtkWidget *w, gpointer data);
+void trg_main_window_reload_dir_aliases(TrgMainWindow *win);
 
 G_END_DECLS

--- a/src/trg-menu-bar.c
+++ b/src/trg-menu-bar.c
@@ -19,17 +19,17 @@
 
 #include "config.h"
 
+#include <gdk/gdkkeysyms-compat.h>
+#include <gdk/gdkkeysyms.h>
 #include <glib/gi18n.h>
 #include <gtk/gtk.h>
-#include <gdk/gdkkeysyms.h>
-#include <gdk/gdkkeysyms-compat.h>
 
-#include "trg-prefs.h"
-#include "trg-torrent-graph.h"
-#include "trg-tree-view.h"
-#include "trg-torrent-tree-view.h"
 #include "trg-main-window.h"
 #include "trg-menu-bar.h"
+#include "trg-prefs.h"
+#include "trg-torrent-graph.h"
+#include "trg-torrent-tree-view.h"
+#include "trg-tree-view.h"
 
 enum {
     PROP_0,
@@ -75,12 +75,12 @@ enum {
     PROP_START_NOW
 };
 
-#define G_DATAKEY_CONF_KEY "conf-key"
+#define G_DATAKEY_CONF_KEY   "conf-key"
 #define G_DATAKEY_PREF_VALUE "pref-index"
 
 G_DEFINE_TYPE(TrgMenuBar, trg_menu_bar, GTK_TYPE_MENU_BAR)
-#define TRG_MENU_BAR_GET_PRIVATE(o) \
-  (G_TYPE_INSTANCE_GET_PRIVATE ((o), TRG_TYPE_MENU_BAR, TrgMenuBarPrivate))
+#define TRG_MENU_BAR_GET_PRIVATE(o)                                                                \
+    (G_TYPE_INSTANCE_GET_PRIVATE((o), TRG_TYPE_MENU_BAR, TrgMenuBarPrivate))
 typedef struct _TrgMenuBarPrivate TrgMenuBarPrivate;
 
 struct _TrgMenuBarPrivate {
@@ -130,8 +130,7 @@ struct _TrgMenuBarPrivate {
     TrgTorrentTreeView *torrent_tree_view;
 };
 
-void trg_menu_bar_set_supports_queues(TrgMenuBar * mb,
-                                      gboolean supportsQueues)
+void trg_menu_bar_set_supports_queues(TrgMenuBar *mb, gboolean supportsQueues)
 {
     TrgMenuBarPrivate *priv = TRG_MENU_BAR_GET_PRIVATE(mb);
 
@@ -143,7 +142,7 @@ void trg_menu_bar_set_supports_queues(TrgMenuBar * mb,
     gtk_widget_set_visible(priv->mb_start_now, supportsQueues);
 }
 
-void trg_menu_bar_connected_change(TrgMenuBar * mb, gboolean connected)
+void trg_menu_bar_connected_change(TrgMenuBar *mb, gboolean connected)
 {
     TrgMenuBarPrivate *priv = TRG_MENU_BAR_GET_PRIVATE(mb);
 
@@ -159,8 +158,7 @@ void trg_menu_bar_connected_change(TrgMenuBar * mb, gboolean connected)
     gtk_widget_set_sensitive(priv->mb_pause_all, connected);
 }
 
-void
-trg_menu_bar_torrent_actions_sensitive(TrgMenuBar * mb, gboolean sensitive)
+void trg_menu_bar_torrent_actions_sensitive(TrgMenuBar *mb, gboolean sensitive)
 {
     TrgMenuBarPrivate *priv = TRG_MENU_BAR_GET_PRIVATE(mb);
 
@@ -180,10 +178,8 @@ trg_menu_bar_torrent_actions_sensitive(TrgMenuBar * mb, gboolean sensitive)
     gtk_widget_set_sensitive(priv->mb_bottom_queue, sensitive);
 }
 
-static void
-trg_menu_bar_set_property(GObject * object,
-                          guint prop_id, const GValue * value,
-                          GParamSpec * pspec G_GNUC_UNUSED)
+static void trg_menu_bar_set_property(GObject *object, guint prop_id, const GValue *value,
+                                      GParamSpec *pspec G_GNUC_UNUSED)
 {
     TrgMenuBarPrivate *priv = TRG_MENU_BAR_GET_PRIVATE(object);
 
@@ -203,9 +199,8 @@ trg_menu_bar_set_property(GObject * object,
     }
 }
 
-static void
-trg_menu_bar_get_property(GObject * object, guint property_id,
-                          GValue * value, GParamSpec * pspec)
+static void trg_menu_bar_get_property(GObject *object, guint property_id, GValue *value,
+                                      GParamSpec *pspec)
 {
     TrgMenuBarPrivate *priv = TRG_MENU_BAR_GET_PRIVATE(object);
     switch (property_id) {
@@ -306,36 +301,26 @@ trg_menu_bar_get_property(GObject * object, guint property_id,
     case PROP_TRACKER_FILTERS:
         g_value_set_object(value, priv->mb_tracker_filters);
         break;
-	case PROP_DIRECTORIES_FIRST:
-		g_value_set_object(value, priv->mb_directory_first);
-		break;
+    case PROP_DIRECTORIES_FIRST:
+        g_value_set_object(value, priv->mb_directory_first);
+        break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, property_id, pspec);
         break;
     }
 }
 
-static void
-trg_menu_bar_install_widget_prop(GObjectClass * class, guint propId,
-                                 const gchar * name, const gchar * nick)
+static void trg_menu_bar_install_widget_prop(GObjectClass *class, guint propId, const gchar *name,
+                                             const gchar *nick)
 {
-    g_object_class_install_property(class,
-                                    propId,
-                                    g_param_spec_object(name,
-                                                        nick,
-                                                        nick,
-                                                        GTK_TYPE_WIDGET,
-                                                        G_PARAM_READABLE
-                                                        |
-                                                        G_PARAM_STATIC_NAME
-                                                        |
-                                                        G_PARAM_STATIC_NICK
-                                                        |
-                                                        G_PARAM_STATIC_BLURB));
+    g_object_class_install_property(class, propId,
+                                    g_param_spec_object(name, nick, nick, GTK_TYPE_WIDGET,
+                                                        G_PARAM_READABLE | G_PARAM_STATIC_NAME
+                                                            | G_PARAM_STATIC_NICK
+                                                            | G_PARAM_STATIC_BLURB));
 }
 
-GtkWidget *trg_menu_bar_item_new(GtkMenuShell * shell, const gchar * text,
-                                 gboolean sensitive)
+GtkWidget *trg_menu_bar_item_new(GtkMenuShell *shell, const gchar *text, gboolean sensitive)
 {
     GtkWidget *item = gtk_menu_item_new_with_label(text);
     gtk_menu_item_set_use_underline(GTK_MENU_ITEM(item), TRUE);
@@ -345,137 +330,96 @@ GtkWidget *trg_menu_bar_item_new(GtkMenuShell * shell, const gchar * text,
     return item;
 }
 
-static void
-trg_menu_bar_accel_add(TrgMenuBar * menu, GtkWidget * item,
-                       guint key, GdkModifierType mods)
+static void trg_menu_bar_accel_add(TrgMenuBar *menu, GtkWidget *item, guint key,
+                                   GdkModifierType mods)
 {
     TrgMenuBarPrivate *priv = TRG_MENU_BAR_GET_PRIVATE(menu);
 
-    gtk_widget_add_accelerator(item, "activate", priv->accel_group,
-                               key, mods, GTK_ACCEL_VISIBLE);
-
+    gtk_widget_add_accelerator(item, "activate", priv->accel_group, key, mods, GTK_ACCEL_VISIBLE);
 }
 
-static void view_menu_radio_item_toggled_cb(GtkCheckMenuItem * w,
-                                            gpointer data)
+static void view_menu_radio_item_toggled_cb(GtkCheckMenuItem *w, gpointer data)
 {
     TrgPrefs *p = TRG_PREFS(data);
-    const gchar *key =
-        (gchar *) g_object_get_data(G_OBJECT(w), G_DATAKEY_CONF_KEY);
+    const gchar *key = (gchar *)g_object_get_data(G_OBJECT(w), G_DATAKEY_CONF_KEY);
 
     if (gtk_check_menu_item_get_active(w)) {
-        gint index =
-            GPOINTER_TO_INT(g_object_get_data
-                            (G_OBJECT(w), G_DATAKEY_PREF_VALUE));
+        gint index = GPOINTER_TO_INT(g_object_get_data(G_OBJECT(w), G_DATAKEY_PREF_VALUE));
         trg_prefs_set_int(p, key, index, TRG_PREFS_GLOBAL);
     }
 }
 
-static void view_menu_item_toggled_cb(GtkCheckMenuItem * w, gpointer data)
+static void view_menu_item_toggled_cb(GtkCheckMenuItem *w, gpointer data)
 {
     TrgPrefs *p = TRG_PREFS(data);
-    const gchar *key =
-        (gchar *) g_object_get_data(G_OBJECT(w), G_DATAKEY_CONF_KEY);
-    trg_prefs_set_bool(p, key, gtk_check_menu_item_get_active(w),
-                       TRG_PREFS_GLOBAL);
+    const gchar *key = (gchar *)g_object_get_data(G_OBJECT(w), G_DATAKEY_CONF_KEY);
+    trg_prefs_set_bool(p, key, gtk_check_menu_item_get_active(w), TRG_PREFS_GLOBAL);
 }
 
-static void
-view_menu_bar_toggled_dependency_cb(GtkCheckMenuItem * w, gpointer data)
+static void view_menu_bar_toggled_dependency_cb(GtkCheckMenuItem *w, gpointer data)
 {
     gtk_widget_set_sensitive(GTK_WIDGET(data),
-                             gtk_check_menu_item_get_active
-                             (GTK_CHECK_MENU_ITEM(w)));
+                             gtk_check_menu_item_get_active(GTK_CHECK_MENU_ITEM(w)));
 }
 
-static void
-trg_menu_bar_view_item_update(TrgPrefs * p, const gchar * updatedKey,
-                              gpointer data)
+static void trg_menu_bar_view_item_update(TrgPrefs *p, const gchar *updatedKey, gpointer data)
 {
-    const gchar *key =
-        (gchar *) g_object_get_data(G_OBJECT(data), G_DATAKEY_CONF_KEY);
+    const gchar *key = (gchar *)g_object_get_data(G_OBJECT(data), G_DATAKEY_CONF_KEY);
     if (!g_strcmp0(updatedKey, key))
         gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(data),
-                                       trg_prefs_get_bool(p, key,
-                                                          TRG_PREFS_GLOBAL));
+                                       trg_prefs_get_bool(p, key, TRG_PREFS_GLOBAL));
 }
 
-static void
-trg_menu_bar_view_radio_item_update(TrgPrefs * p, const gchar * updatedKey,
-                                    gpointer data)
+static void trg_menu_bar_view_radio_item_update(TrgPrefs *p, const gchar *updatedKey, gpointer data)
 {
-    const gchar *key =
-        (gchar *) g_object_get_data(G_OBJECT(data), G_DATAKEY_CONF_KEY);
-    gint myIndex =
-        GPOINTER_TO_INT(g_object_get_data
-                        (G_OBJECT(data), G_DATAKEY_PREF_VALUE));
+    const gchar *key = (gchar *)g_object_get_data(G_OBJECT(data), G_DATAKEY_CONF_KEY);
+    gint myIndex = GPOINTER_TO_INT(g_object_get_data(G_OBJECT(data), G_DATAKEY_PREF_VALUE));
 
     if (!g_strcmp0(updatedKey, key)) {
-        gboolean shouldBeActive =
-            trg_prefs_get_int(p, key, TRG_PREFS_GLOBAL) == myIndex;
-        if (shouldBeActive !=
-            gtk_check_menu_item_get_active(GTK_CHECK_MENU_ITEM(data)))
-            gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(data),
-                                           shouldBeActive);
+        gboolean shouldBeActive = trg_prefs_get_int(p, key, TRG_PREFS_GLOBAL) == myIndex;
+        if (shouldBeActive != gtk_check_menu_item_get_active(GTK_CHECK_MENU_ITEM(data)))
+            gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(data), shouldBeActive);
     }
 }
 
-static GtkWidget *trg_menu_bar_view_radio_item_new(TrgPrefs * prefs,
-                                                   GSList * group,
-                                                   const gchar * key,
-                                                   gint index,
-                                                   const gchar * label)
+static GtkWidget *trg_menu_bar_view_radio_item_new(TrgPrefs *prefs, GSList *group, const gchar *key,
+                                                   gint index, const gchar *label)
 {
     GtkWidget *w = gtk_radio_menu_item_new_with_label(group, label);
-    g_object_set_data_full(G_OBJECT(w), G_DATAKEY_CONF_KEY, g_strdup(key),
-                           g_free);
-    g_object_set_data(G_OBJECT(w), G_DATAKEY_PREF_VALUE,
-                      GINT_TO_POINTER(index));
+    g_object_set_data_full(G_OBJECT(w), G_DATAKEY_CONF_KEY, g_strdup(key), g_free);
+    g_object_set_data(G_OBJECT(w), G_DATAKEY_PREF_VALUE, GINT_TO_POINTER(index));
 
-    gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(w),
-                                   trg_prefs_get_int(prefs, key,
-                                                     TRG_PREFS_GLOBAL) ==
-                                   (gint64) index);
+    gtk_check_menu_item_set_active(
+        GTK_CHECK_MENU_ITEM(w), trg_prefs_get_int(prefs, key, TRG_PREFS_GLOBAL) == (gint64)index);
 
-    g_signal_connect(w, "toggled",
-                     G_CALLBACK(view_menu_radio_item_toggled_cb), prefs);
-    g_signal_connect(prefs, "pref-changed",
-                     G_CALLBACK(trg_menu_bar_view_radio_item_update), w);
+    g_signal_connect(w, "toggled", G_CALLBACK(view_menu_radio_item_toggled_cb), prefs);
+    g_signal_connect(prefs, "pref-changed", G_CALLBACK(trg_menu_bar_view_radio_item_update), w);
 
     return w;
 }
 
-static GtkWidget *trg_menu_bar_view_item_new(TrgPrefs * prefs,
-                                             const gchar * key,
-                                             const gchar * label,
-                                             GtkWidget * dependency)
+static GtkWidget *trg_menu_bar_view_item_new(TrgPrefs *prefs, const gchar *key, const gchar *label,
+                                             GtkWidget *dependency)
 {
     GtkWidget *w = gtk_check_menu_item_new_with_label(label);
-    g_object_set_data_full(G_OBJECT(w), G_DATAKEY_CONF_KEY, g_strdup(key),
-                           g_free);
+    g_object_set_data_full(G_OBJECT(w), G_DATAKEY_CONF_KEY, g_strdup(key), g_free);
 
     gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(w),
-                                   trg_prefs_get_bool(prefs, key,
-                                                      TRG_PREFS_GLOBAL));
+                                   trg_prefs_get_bool(prefs, key, TRG_PREFS_GLOBAL));
 
     if (dependency) {
         gtk_widget_set_sensitive(w,
-                                 gtk_check_menu_item_get_active
-                                 (GTK_CHECK_MENU_ITEM(dependency)));
-        g_signal_connect(dependency, "toggled",
-                         G_CALLBACK(view_menu_bar_toggled_dependency_cb),
-                         w);
+                                 gtk_check_menu_item_get_active(GTK_CHECK_MENU_ITEM(dependency)));
+        g_signal_connect(dependency, "toggled", G_CALLBACK(view_menu_bar_toggled_dependency_cb), w);
     }
 
-    g_signal_connect(w, "toggled",
-                     G_CALLBACK(view_menu_item_toggled_cb), prefs);
-    g_signal_connect(prefs, "pref-changed",
-                     G_CALLBACK(trg_menu_bar_view_item_update), w);
+    g_signal_connect(w, "toggled", G_CALLBACK(view_menu_item_toggled_cb), prefs);
+    g_signal_connect(prefs, "pref-changed", G_CALLBACK(trg_menu_bar_view_item_update), w);
 
     return w;
 }
 
-static GtkWidget *trg_menu_bar_view_menu_new(TrgMenuBar * mb)
+static GtkWidget *trg_menu_bar_view_menu_new(TrgMenuBar *mb)
 {
     TrgMenuBarPrivate *priv = TRG_MENU_BAR_GET_PRIVATE(mb);
 
@@ -485,95 +429,62 @@ static GtkWidget *trg_menu_bar_view_menu_new(TrgMenuBar * mb)
 
     gtk_menu_item_set_submenu(GTK_MENU_ITEM(view), viewMenu);
 
-    priv->mb_view_transmission =
-        trg_menu_bar_view_radio_item_new(priv->prefs, NULL,
-                                         TRG_PREFS_KEY_STYLE, TRG_STYLE_TR,
-                                         _("Transmission Style"));
-    gtk_menu_shell_append(GTK_MENU_SHELL(viewMenu),
-                          priv->mb_view_transmission);
-    group =
-        gtk_radio_menu_item_get_group(GTK_RADIO_MENU_ITEM
-                                      (priv->mb_view_transmission));
-    priv->mb_view_transmission_compact =
-        trg_menu_bar_view_radio_item_new(priv->prefs, group,
-                                         TRG_PREFS_KEY_STYLE,
-                                         TRG_STYLE_TR_COMPACT,
-                                         _("Transmission Compact Style"));
-    gtk_menu_shell_append(GTK_MENU_SHELL(viewMenu),
-                          priv->mb_view_transmission_compact);
-    group =
-        gtk_radio_menu_item_get_group(GTK_RADIO_MENU_ITEM
-                                      (priv->mb_view_transmission_compact));
-    priv->mb_view_classic =
-        trg_menu_bar_view_radio_item_new(priv->prefs, group,
-                                         TRG_PREFS_KEY_STYLE,
-                                         TRG_STYLE_CLASSIC,
-                                         _("Classic Style"));
+    priv->mb_view_transmission = trg_menu_bar_view_radio_item_new(
+        priv->prefs, NULL, TRG_PREFS_KEY_STYLE, TRG_STYLE_TR, _("Transmission Style"));
+    gtk_menu_shell_append(GTK_MENU_SHELL(viewMenu), priv->mb_view_transmission);
+    group = gtk_radio_menu_item_get_group(GTK_RADIO_MENU_ITEM(priv->mb_view_transmission));
+    priv->mb_view_transmission_compact
+        = trg_menu_bar_view_radio_item_new(priv->prefs, group, TRG_PREFS_KEY_STYLE,
+                                           TRG_STYLE_TR_COMPACT, _("Transmission Compact Style"));
+    gtk_menu_shell_append(GTK_MENU_SHELL(viewMenu), priv->mb_view_transmission_compact);
+    group = gtk_radio_menu_item_get_group(GTK_RADIO_MENU_ITEM(priv->mb_view_transmission_compact));
+    priv->mb_view_classic = trg_menu_bar_view_radio_item_new(
+        priv->prefs, group, TRG_PREFS_KEY_STYLE, TRG_STYLE_CLASSIC, _("Classic Style"));
     gtk_menu_shell_append(GTK_MENU_SHELL(viewMenu), priv->mb_view_classic);
 
-    gtk_menu_shell_append(GTK_MENU_SHELL(viewMenu),
-                          trg_tree_view_sort_menu(TRG_TREE_VIEW
-                                                  (priv->torrent_tree_view),
-                                                  _("Sort")));
+    gtk_menu_shell_append(
+        GTK_MENU_SHELL(viewMenu),
+        trg_tree_view_sort_menu(TRG_TREE_VIEW(priv->torrent_tree_view), _("Sort")));
 
-    priv->mb_view_states =
-        trg_menu_bar_view_item_new(priv->prefs,
-                                   TRG_PREFS_KEY_SHOW_STATE_SELECTOR,
-                                   _("State selector"), NULL);
+    priv->mb_view_states = trg_menu_bar_view_item_new(
+        priv->prefs, TRG_PREFS_KEY_SHOW_STATE_SELECTOR, _("State selector"), NULL);
     trg_menu_bar_accel_add(mb, priv->mb_view_states, GDK_F2, 0);
     gtk_menu_shell_append(GTK_MENU_SHELL(viewMenu), priv->mb_view_states);
 
-    priv->mb_directory_filters =
-        trg_menu_bar_view_item_new(priv->prefs, TRG_PREFS_KEY_FILTER_DIRS,
-                                   _("Directory filters"),
-                                   priv->mb_view_states);
+    priv->mb_directory_filters = trg_menu_bar_view_item_new(
+        priv->prefs, TRG_PREFS_KEY_FILTER_DIRS, _("Directory filters"), priv->mb_view_states);
     trg_menu_bar_accel_add(mb, priv->mb_directory_filters, GDK_F3, 0);
-    gtk_menu_shell_append(GTK_MENU_SHELL(viewMenu),
-                          priv->mb_directory_filters);
+    gtk_menu_shell_append(GTK_MENU_SHELL(viewMenu), priv->mb_directory_filters);
 
-    priv->mb_tracker_filters =
-        trg_menu_bar_view_item_new(priv->prefs,
-                                   TRG_PREFS_KEY_FILTER_TRACKERS,
-                                   _("Tracker filters"),
-                                   priv->mb_view_states);
+    priv->mb_tracker_filters = trg_menu_bar_view_item_new(
+        priv->prefs, TRG_PREFS_KEY_FILTER_TRACKERS, _("Tracker filters"), priv->mb_view_states);
     trg_menu_bar_accel_add(mb, priv->mb_tracker_filters, GDK_F4, 0);
-    gtk_menu_shell_append(GTK_MENU_SHELL(viewMenu),
-                          priv->mb_tracker_filters);
+    gtk_menu_shell_append(GTK_MENU_SHELL(viewMenu), priv->mb_tracker_filters);
 
-	priv->mb_directory_first =
-		trg_menu_bar_view_item_new(priv->prefs,
-									TRG_PREFS_KEY_DIRECTORIES_FIRST,
-									_("Directories first"),
-									priv->mb_view_states);
-	gtk_menu_shell_append(GTK_MENU_SHELL(viewMenu),
-							priv->mb_directory_first);
+    priv->mb_directory_first = trg_menu_bar_view_item_new(
+        priv->prefs, TRG_PREFS_KEY_DIRECTORIES_FIRST, _("Directories first"), priv->mb_view_states);
+    gtk_menu_shell_append(GTK_MENU_SHELL(viewMenu), priv->mb_directory_first);
 
-    priv->mb_view_notebook =
-        trg_menu_bar_view_item_new(priv->prefs,
-                                   TRG_PREFS_KEY_SHOW_NOTEBOOK,
-                                   _("Torrent Details"), NULL);
+    priv->mb_view_notebook = trg_menu_bar_view_item_new(priv->prefs, TRG_PREFS_KEY_SHOW_NOTEBOOK,
+                                                        _("Torrent Details"), NULL);
     trg_menu_bar_accel_add(mb, priv->mb_view_notebook, GDK_F5, 0);
-    gtk_menu_shell_append(GTK_MENU_SHELL(viewMenu),
-                          priv->mb_view_notebook);
+    gtk_menu_shell_append(GTK_MENU_SHELL(viewMenu), priv->mb_view_notebook);
 
 #if TRG_WITH_GRAPH
-    priv->mb_view_graph =
-        trg_menu_bar_view_item_new(priv->prefs, TRG_PREFS_KEY_SHOW_GRAPH,
-                                   _("Graph"), priv->mb_view_notebook);
+    priv->mb_view_graph = trg_menu_bar_view_item_new(priv->prefs, TRG_PREFS_KEY_SHOW_GRAPH,
+                                                     _("Graph"), priv->mb_view_notebook);
     trg_menu_bar_accel_add(mb, priv->mb_view_graph, GDK_F6, 0);
     gtk_menu_shell_append(GTK_MENU_SHELL(viewMenu), priv->mb_view_graph);
 #endif
 
-    priv->mb_view_stats =
-        gtk_menu_item_new_with_mnemonic(_("_Statistics"));
+    priv->mb_view_stats = gtk_menu_item_new_with_mnemonic(_("_Statistics"));
     trg_menu_bar_accel_add(mb, priv->mb_view_stats, GDK_F7, 0);
     gtk_widget_set_sensitive(priv->mb_view_stats, FALSE);
     gtk_menu_shell_append(GTK_MENU_SHELL(viewMenu), priv->mb_view_stats);
 
 #if HAVE_RSS
-    priv->mb_view_rss =
-        gtk_menu_item_new_with_mnemonic(_("_RSS"));
-    //trg_menu_bar_accel_add(mb, priv->mb_view_rss, GDK_F7, 0);
+    priv->mb_view_rss = gtk_menu_item_new_with_mnemonic(_("_RSS"));
+    // trg_menu_bar_accel_add(mb, priv->mb_view_rss, GDK_F7, 0);
     gtk_widget_set_sensitive(priv->mb_view_rss, FALSE);
     gtk_menu_shell_append(GTK_MENU_SHELL(viewMenu), priv->mb_view_rss);
 #endif
@@ -581,7 +492,7 @@ static GtkWidget *trg_menu_bar_view_menu_new(TrgMenuBar * mb)
     return view;
 }
 
-static GtkWidget *trg_menu_bar_options_menu_new(TrgMenuBar * menu)
+static GtkWidget *trg_menu_bar_options_menu_new(TrgMenuBar *menu)
 {
     TrgMenuBarPrivate *priv = TRG_MENU_BAR_GET_PRIVATE(menu);
 
@@ -589,43 +500,33 @@ static GtkWidget *trg_menu_bar_options_menu_new(TrgMenuBar * menu)
     GtkWidget *optsMenu = gtk_menu_new();
     gtk_menu_item_set_submenu(GTK_MENU_ITEM(opts), optsMenu);
 
-    priv->mb_local_prefs =
-        trg_menu_bar_item_new(GTK_MENU_SHELL(optsMenu),
-                              _("_Local Preferences"),
-                              TRUE);
-    trg_menu_bar_accel_add(menu, priv->mb_local_prefs, GDK_s,
-                           GDK_CONTROL_MASK);
+    priv->mb_local_prefs
+        = trg_menu_bar_item_new(GTK_MENU_SHELL(optsMenu), _("_Local Preferences"), TRUE);
+    trg_menu_bar_accel_add(menu, priv->mb_local_prefs, GDK_s, GDK_CONTROL_MASK);
 
-    priv->mb_remote_prefs =
-        trg_menu_bar_item_new(GTK_MENU_SHELL(optsMenu),
-                              _("_Remote Preferences"),
-                              FALSE);
-    trg_menu_bar_accel_add(menu, priv->mb_remote_prefs, GDK_s,
-                           GDK_MOD1_MASK);
+    priv->mb_remote_prefs
+        = trg_menu_bar_item_new(GTK_MENU_SHELL(optsMenu), _("_Remote Preferences"), FALSE);
+    trg_menu_bar_accel_add(menu, priv->mb_remote_prefs, GDK_s, GDK_MOD1_MASK);
 
     return opts;
 }
 
-static void
-trg_menu_bar_file_connect_item_new(TrgMainWindow * win,
-                                   GtkMenuShell * shell,
-                                   const gchar * text,
-                                   gboolean checked, JsonObject * profile)
+static void trg_menu_bar_file_connect_item_new(TrgMainWindow *win, GtkMenuShell *shell,
+                                               const gchar *text, gboolean checked,
+                                               JsonObject *profile)
 {
     GtkWidget *item = gtk_check_menu_item_new_with_label(text);
 
-    gtk_check_menu_item_set_active( GTK_CHECK_MENU_ITEM(item), checked);
+    gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(item), checked);
     g_object_set_data(G_OBJECT(item), "profile", profile);
     gtk_check_menu_item_set_draw_as_radio(GTK_CHECK_MENU_ITEM(item), TRUE);
 
-    g_signal_connect(G_OBJECT(item), "activate", G_CALLBACK(connect_cb),
-                     win);
+    g_signal_connect(G_OBJECT(item), "activate", G_CALLBACK(connect_cb), win);
 
     gtk_menu_shell_append(shell, item);
 }
 
-GtkWidget *trg_menu_bar_file_connect_menu_new(TrgMainWindow * win,
-                                              TrgPrefs * p)
+GtkWidget *trg_menu_bar_file_connect_menu_new(TrgMainWindow *win, TrgPrefs *p)
 {
     GtkWidget *menu = gtk_menu_new();
     GList *profiles = json_array_get_elements(trg_prefs_get_profiles(p));
@@ -633,20 +534,17 @@ GtkWidget *trg_menu_bar_file_connect_menu_new(TrgMainWindow * win,
     GList *li;
 
     for (li = profiles; li; li = g_list_next(li)) {
-        JsonObject *profile = json_node_get_object((JsonNode *) li->data);
+        JsonObject *profile = json_node_get_object((JsonNode *)li->data);
         const gchar *name_value;
 
         if (json_object_has_member(profile, TRG_PREFS_KEY_PROFILE_NAME)) {
-            name_value = json_object_get_string_member(profile,
-                                                       TRG_PREFS_KEY_PROFILE_NAME);
+            name_value = json_object_get_string_member(profile, TRG_PREFS_KEY_PROFILE_NAME);
         } else {
             name_value = _(TRG_PROFILE_NAME_DEFAULT);
         }
 
-        trg_menu_bar_file_connect_item_new(win, GTK_MENU_SHELL(menu),
-                                           name_value,
-                                           profile == currentProfile,
-                                           profile);
+        trg_menu_bar_file_connect_item_new(win, GTK_MENU_SHELL(menu), name_value,
+                                           profile == currentProfile, profile);
     }
 
     g_list_free(profiles);
@@ -654,51 +552,36 @@ GtkWidget *trg_menu_bar_file_connect_menu_new(TrgMainWindow * win,
     return menu;
 }
 
-static GtkWidget *trg_menu_bar_file_file_menu_new(TrgMenuBar * menu)
+static GtkWidget *trg_menu_bar_file_file_menu_new(TrgMenuBar *menu)
 {
     TrgMenuBarPrivate *priv = TRG_MENU_BAR_GET_PRIVATE(menu);
 
     GtkWidget *file = gtk_menu_item_new_with_mnemonic(_("_File"));
     GtkWidget *fileMenu = gtk_menu_new();
 
-    GtkWidget *connectMenu =
-        trg_menu_bar_file_connect_menu_new(priv->main_window, priv->prefs);
+    GtkWidget *connectMenu = trg_menu_bar_file_connect_menu_new(priv->main_window, priv->prefs);
 
-    priv->mb_connect =
-        trg_menu_bar_item_new(GTK_MENU_SHELL(fileMenu), _("Connect"),
-                              TRUE);
-    gtk_menu_item_set_submenu(GTK_MENU_ITEM(priv->mb_connect),
-                              connectMenu);
+    priv->mb_connect = trg_menu_bar_item_new(GTK_MENU_SHELL(fileMenu), _("Connect"), TRUE);
+    gtk_menu_item_set_submenu(GTK_MENU_ITEM(priv->mb_connect), connectMenu);
 
-    priv->mb_disconnect =
-        trg_menu_bar_item_new(GTK_MENU_SHELL(fileMenu), _("_Disconnect"),
-                              FALSE);
-    trg_menu_bar_accel_add(menu, priv->mb_disconnect, GDK_d,
-                           GDK_CONTROL_MASK);
+    priv->mb_disconnect = trg_menu_bar_item_new(GTK_MENU_SHELL(fileMenu), _("_Disconnect"), FALSE);
+    trg_menu_bar_accel_add(menu, priv->mb_disconnect, GDK_d, GDK_CONTROL_MASK);
 
-    priv->mb_add =
-        trg_menu_bar_item_new(GTK_MENU_SHELL(fileMenu), _("_Add"),
-                              FALSE);
+    priv->mb_add = trg_menu_bar_item_new(GTK_MENU_SHELL(fileMenu), _("_Add"), FALSE);
     trg_menu_bar_accel_add(menu, priv->mb_add, GDK_o, GDK_CONTROL_MASK);
 
-    priv->mb_add_url =
-        trg_menu_bar_item_new(GTK_MENU_SHELL(fileMenu), _("Add from _URL"),
-                              FALSE);
-    trg_menu_bar_accel_add(menu, priv->mb_add_url, GDK_u,
-                           GDK_CONTROL_MASK);
+    priv->mb_add_url = trg_menu_bar_item_new(GTK_MENU_SHELL(fileMenu), _("Add from _URL"), FALSE);
+    trg_menu_bar_accel_add(menu, priv->mb_add_url, GDK_u, GDK_CONTROL_MASK);
 
-    priv->mb_quit =
-        trg_menu_bar_item_new(GTK_MENU_SHELL(fileMenu), _("_Quit"),
-                              TRUE);
-    trg_menu_bar_accel_add(menu, priv->mb_quit, GDK_q,
-                           GDK_CONTROL_MASK);
+    priv->mb_quit = trg_menu_bar_item_new(GTK_MENU_SHELL(fileMenu), _("_Quit"), TRUE);
+    trg_menu_bar_accel_add(menu, priv->mb_quit, GDK_q, GDK_CONTROL_MASK);
 
     gtk_menu_item_set_submenu(GTK_MENU_ITEM(file), fileMenu);
 
     return file;
 }
 
-static GtkWidget *trg_menu_bar_torrent_menu_new(TrgMenuBar * menu)
+static GtkWidget *trg_menu_bar_torrent_menu_new(TrgMenuBar *menu)
 {
     TrgMenuBarPrivate *priv = TRG_MENU_BAR_GET_PRIVATE(menu);
     GtkWidget *torrent = gtk_menu_item_new_with_mnemonic(_("_Torrent"));
@@ -706,105 +589,68 @@ static GtkWidget *trg_menu_bar_torrent_menu_new(TrgMenuBar * menu)
 
     gtk_menu_item_set_submenu(GTK_MENU_ITEM(torrent), torrentMenu);
 
-    priv->mb_props =
-        trg_menu_bar_item_new(GTK_MENU_SHELL(torrentMenu),
-                              _("Properties"),
-                              FALSE);
+    priv->mb_props = trg_menu_bar_item_new(GTK_MENU_SHELL(torrentMenu), _("Properties"), FALSE);
     trg_menu_bar_accel_add(menu, priv->mb_props, GDK_i, GDK_CONTROL_MASK);
 
-    priv->mb_copy_magnetlink =
-        trg_menu_bar_item_new(GTK_MENU_SHELL(torrentMenu), _("_Copy Magnet Link"),
-                              FALSE);
+    priv->mb_copy_magnetlink
+        = trg_menu_bar_item_new(GTK_MENU_SHELL(torrentMenu), _("_Copy Magnet Link"), FALSE);
     trg_menu_bar_accel_add(menu, priv->mb_copy_magnetlink, GDK_c, GDK_CONTROL_MASK);
 
-    priv->mb_resume =
-        trg_menu_bar_item_new(GTK_MENU_SHELL(torrentMenu), _("_Resume"),
-                              FALSE);
+    priv->mb_resume = trg_menu_bar_item_new(GTK_MENU_SHELL(torrentMenu), _("_Resume"), FALSE);
     trg_menu_bar_accel_add(menu, priv->mb_resume, GDK_r, GDK_CONTROL_MASK);
 
-    priv->mb_pause =
-        trg_menu_bar_item_new(GTK_MENU_SHELL(torrentMenu), _("_Pause"),
-                              FALSE);
+    priv->mb_pause = trg_menu_bar_item_new(GTK_MENU_SHELL(torrentMenu), _("_Pause"), FALSE);
     trg_menu_bar_accel_add(menu, priv->mb_pause, GDK_p, GDK_CONTROL_MASK);
 
-    priv->mb_verify =
-        trg_menu_bar_item_new(GTK_MENU_SHELL(torrentMenu), _("_Verify"),
-                              FALSE);
+    priv->mb_verify = trg_menu_bar_item_new(GTK_MENU_SHELL(torrentMenu), _("_Verify"), FALSE);
     trg_menu_bar_accel_add(menu, priv->mb_verify, GDK_h, GDK_CONTROL_MASK);
 
-    priv->mb_reannounce =
-        trg_menu_bar_item_new(GTK_MENU_SHELL(torrentMenu),
-                              _("Re-_announce"), FALSE);
-    trg_menu_bar_accel_add(menu, priv->mb_reannounce, GDK_q,
-                           GDK_CONTROL_MASK);
+    priv->mb_reannounce
+        = trg_menu_bar_item_new(GTK_MENU_SHELL(torrentMenu), _("Re-_announce"), FALSE);
+    trg_menu_bar_accel_add(menu, priv->mb_reannounce, GDK_q, GDK_CONTROL_MASK);
 
-    priv->mb_move =
-        trg_menu_bar_item_new(GTK_MENU_SHELL(torrentMenu), _("_Move"),
-                              FALSE);
+    priv->mb_move = trg_menu_bar_item_new(GTK_MENU_SHELL(torrentMenu), _("_Move"), FALSE);
     trg_menu_bar_accel_add(menu, priv->mb_move, GDK_m, GDK_CONTROL_MASK);
 
-    priv->mb_remove =
-        trg_menu_bar_item_new(GTK_MENU_SHELL(torrentMenu), _("Remove"),
-                              FALSE);
+    priv->mb_remove = trg_menu_bar_item_new(GTK_MENU_SHELL(torrentMenu), _("Remove"), FALSE);
     trg_menu_bar_accel_add(menu, priv->mb_remove, GDK_Delete, 0);
 
-    priv->mb_delete =
-        trg_menu_bar_item_new(GTK_MENU_SHELL(torrentMenu),
-                              _("Remove and delete data"),
-                              FALSE);
-    trg_menu_bar_accel_add(menu, priv->mb_delete, GDK_Delete,
-                           GDK_SHIFT_MASK);
+    priv->mb_delete
+        = trg_menu_bar_item_new(GTK_MENU_SHELL(torrentMenu), _("Remove and delete data"), FALSE);
+    trg_menu_bar_accel_add(menu, priv->mb_delete, GDK_Delete, GDK_SHIFT_MASK);
 
     priv->mb_queues_seperator = gtk_separator_menu_item_new();
-    gtk_menu_shell_append(GTK_MENU_SHELL(torrentMenu),
-                          priv->mb_queues_seperator);
+    gtk_menu_shell_append(GTK_MENU_SHELL(torrentMenu), priv->mb_queues_seperator);
 
-    priv->mb_start_now = trg_menu_bar_item_new(GTK_MENU_SHELL(torrentMenu),
-                                               _("Start Now"),
-                                               FALSE);
+    priv->mb_start_now = trg_menu_bar_item_new(GTK_MENU_SHELL(torrentMenu), _("Start Now"), FALSE);
 
-    priv->mb_up_queue = trg_menu_bar_item_new(GTK_MENU_SHELL(torrentMenu),
-                                              _("Move Up Queue"),
-                                              FALSE);
-    trg_menu_bar_accel_add(menu, priv->mb_up_queue, GDK_Up,
-                           GDK_SHIFT_MASK);
+    priv->mb_up_queue
+        = trg_menu_bar_item_new(GTK_MENU_SHELL(torrentMenu), _("Move Up Queue"), FALSE);
+    trg_menu_bar_accel_add(menu, priv->mb_up_queue, GDK_Up, GDK_SHIFT_MASK);
 
-    priv->mb_down_queue =
-        trg_menu_bar_item_new(GTK_MENU_SHELL(torrentMenu),
-                              _("Move Down Queue"),
-                              FALSE);
-    trg_menu_bar_accel_add(menu, priv->mb_down_queue, GDK_Down,
-                           GDK_SHIFT_MASK);
+    priv->mb_down_queue
+        = trg_menu_bar_item_new(GTK_MENU_SHELL(torrentMenu), _("Move Down Queue"), FALSE);
+    trg_menu_bar_accel_add(menu, priv->mb_down_queue, GDK_Down, GDK_SHIFT_MASK);
 
-    priv->mb_bottom_queue =
-        trg_menu_bar_item_new(GTK_MENU_SHELL(torrentMenu),
-                              _("Bottom Of Queue"),
-                              FALSE);
+    priv->mb_bottom_queue
+        = trg_menu_bar_item_new(GTK_MENU_SHELL(torrentMenu), _("Bottom Of Queue"), FALSE);
 
-    priv->mb_top_queue = trg_menu_bar_item_new(GTK_MENU_SHELL(torrentMenu),
-                                               _("Top Of Queue"),
-                                               FALSE);
+    priv->mb_top_queue
+        = trg_menu_bar_item_new(GTK_MENU_SHELL(torrentMenu), _("Top Of Queue"), FALSE);
 
-    gtk_menu_shell_append(GTK_MENU_SHELL(torrentMenu),
-                          gtk_separator_menu_item_new());
+    gtk_menu_shell_append(GTK_MENU_SHELL(torrentMenu), gtk_separator_menu_item_new());
 
-    priv->mb_resume_all =
-        trg_menu_bar_item_new(GTK_MENU_SHELL(torrentMenu),
-                              _("_Resume All"),
-                              FALSE);
-    trg_menu_bar_accel_add(menu, priv->mb_resume_all, GDK_r,
-                           GDK_SHIFT_MASK | GDK_CONTROL_MASK);
+    priv->mb_resume_all
+        = trg_menu_bar_item_new(GTK_MENU_SHELL(torrentMenu), _("_Resume All"), FALSE);
+    trg_menu_bar_accel_add(menu, priv->mb_resume_all, GDK_r, GDK_SHIFT_MASK | GDK_CONTROL_MASK);
 
-    priv->mb_pause_all =
-        trg_menu_bar_item_new(GTK_MENU_SHELL(torrentMenu), _("_Pause All"),
-                              FALSE);
-    trg_menu_bar_accel_add(menu, priv->mb_pause_all, GDK_p,
-                           GDK_SHIFT_MASK | GDK_CONTROL_MASK);
+    priv->mb_pause_all = trg_menu_bar_item_new(GTK_MENU_SHELL(torrentMenu), _("_Pause All"), FALSE);
+    trg_menu_bar_accel_add(menu, priv->mb_pause_all, GDK_p, GDK_SHIFT_MASK | GDK_CONTROL_MASK);
 
     return torrent;
 }
 
-static GtkWidget *trg_menu_bar_help_menu_new(TrgMenuBar * menuBar)
+static GtkWidget *trg_menu_bar_help_menu_new(TrgMenuBar *menuBar)
 {
     TrgMenuBarPrivate *priv = TRG_MENU_BAR_GET_PRIVATE(menuBar);
 
@@ -813,50 +659,38 @@ static GtkWidget *trg_menu_bar_help_menu_new(TrgMenuBar * menuBar)
     gtk_menu_item_set_submenu(GTK_MENU_ITEM(help), helpMenu);
     gtk_menu_shell_append(GTK_MENU_SHELL(menuBar), help);
 
-    priv->mb_about =
-        trg_menu_bar_item_new(GTK_MENU_SHELL(helpMenu), _("_About"),
-                              TRUE);
+    priv->mb_about = trg_menu_bar_item_new(GTK_MENU_SHELL(helpMenu), _("_About"), TRUE);
 
     return helpMenu;
 }
 
-static void menu_bar_refresh_menu(GtkWidget * w, gpointer data)
+static void menu_bar_refresh_menu(GtkWidget *w, gpointer data)
 {
     TrgMenuBarPrivate *priv = TRG_MENU_BAR_GET_PRIVATE(data);
-    GtkWidget *old =
-        gtk_menu_item_get_submenu(GTK_MENU_ITEM(priv->mb_connect));
-    GtkWidget *new =
-        trg_menu_bar_file_connect_menu_new(priv->main_window, priv->prefs);
+    GtkWidget *old = gtk_menu_item_get_submenu(GTK_MENU_ITEM(priv->mb_connect));
+    GtkWidget *new = trg_menu_bar_file_connect_menu_new(priv->main_window, priv->prefs);
 
     gtk_widget_destroy(old);
     gtk_menu_item_set_submenu(GTK_MENU_ITEM(priv->mb_connect), new);
     gtk_widget_show_all(new);
 }
 
-static GObject *trg_menu_bar_constructor(GType type,
-                                         guint n_construct_properties,
-                                         GObjectConstructParam *
-                                         construct_params)
+static GObject *trg_menu_bar_constructor(GType type, guint n_construct_properties,
+                                         GObjectConstructParam *construct_params)
 {
     GObject *object;
     TrgMenuBarPrivate *priv;
     TrgMenuBar *menu;
 
-    object = G_OBJECT_CLASS
-        (trg_menu_bar_parent_class)->constructor(type,
-                                                 n_construct_properties,
-                                                 construct_params);
+    object = G_OBJECT_CLASS(trg_menu_bar_parent_class)
+                 ->constructor(type, n_construct_properties, construct_params);
     menu = TRG_MENU_BAR(object);
     priv = TRG_MENU_BAR_GET_PRIVATE(object);
 
-    gtk_menu_shell_append(GTK_MENU_SHELL(object),
-                          trg_menu_bar_file_file_menu_new(menu));
-    gtk_menu_shell_append(GTK_MENU_SHELL(object),
-                          trg_menu_bar_torrent_menu_new(menu));
-    gtk_menu_shell_append(GTK_MENU_SHELL(object),
-                          trg_menu_bar_options_menu_new(menu));
-    gtk_menu_shell_append(GTK_MENU_SHELL(object),
-                          trg_menu_bar_view_menu_new(menu));
+    gtk_menu_shell_append(GTK_MENU_SHELL(object), trg_menu_bar_file_file_menu_new(menu));
+    gtk_menu_shell_append(GTK_MENU_SHELL(object), trg_menu_bar_torrent_menu_new(menu));
+    gtk_menu_shell_append(GTK_MENU_SHELL(object), trg_menu_bar_options_menu_new(menu));
+    gtk_menu_shell_append(GTK_MENU_SHELL(object), trg_menu_bar_view_menu_new(menu));
     trg_menu_bar_help_menu_new(TRG_MENU_BAR(object));
 
     g_signal_connect(G_OBJECT(priv->prefs), "pref-profile-changed",
@@ -865,7 +699,7 @@ static GObject *trg_menu_bar_constructor(GType type,
     return object;
 }
 
-static void trg_menu_bar_class_init(TrgMenuBarClass * klass)
+static void trg_menu_bar_class_init(TrgMenuBarClass *klass)
 {
     GObjectClass *object_class = G_OBJECT_CLASS(klass);
     object_class->get_property = trg_menu_bar_get_property;
@@ -874,156 +708,101 @@ static void trg_menu_bar_class_init(TrgMenuBarClass * klass)
 
     g_type_class_add_private(klass, sizeof(TrgMenuBarPrivate));
 
-    trg_menu_bar_install_widget_prop(object_class, PROP_CONNECT_BUTTON,
-                                     "connect-button", "Connect Button");
-    trg_menu_bar_install_widget_prop(object_class,
-                                     PROP_DISCONNECT_BUTTON,
-                                     "disconnect-button",
+    trg_menu_bar_install_widget_prop(object_class, PROP_CONNECT_BUTTON, "connect-button",
+                                     "Connect Button");
+    trg_menu_bar_install_widget_prop(object_class, PROP_DISCONNECT_BUTTON, "disconnect-button",
                                      "Disconnect Button");
-    trg_menu_bar_install_widget_prop(object_class, PROP_ADD_BUTTON,
-                                     "add-button", "Add Button");
-    trg_menu_bar_install_widget_prop(object_class, PROP_ADD_URL_BUTTON,
-                                     "add-url-button", "Add URL Button");
-    trg_menu_bar_install_widget_prop(object_class, PROP_REMOVE_BUTTON,
-                                     "remove-button", "Remove Button");
-    trg_menu_bar_install_widget_prop(object_class, PROP_MOVE_BUTTON,
-                                     "move-button", "Move Button");
-    trg_menu_bar_install_widget_prop(object_class, PROP_DELETE_BUTTON,
-                                     "delete-button", "Delete Button");
-    trg_menu_bar_install_widget_prop(object_class, PROP_RESUME_BUTTON,
-                                     "resume-button", "Resume Button");
-    trg_menu_bar_install_widget_prop(object_class, PROP_RESUME_ALL_BUTTON,
-                                     "resume-all-button",
+    trg_menu_bar_install_widget_prop(object_class, PROP_ADD_BUTTON, "add-button", "Add Button");
+    trg_menu_bar_install_widget_prop(object_class, PROP_ADD_URL_BUTTON, "add-url-button",
+                                     "Add URL Button");
+    trg_menu_bar_install_widget_prop(object_class, PROP_REMOVE_BUTTON, "remove-button",
+                                     "Remove Button");
+    trg_menu_bar_install_widget_prop(object_class, PROP_MOVE_BUTTON, "move-button", "Move Button");
+    trg_menu_bar_install_widget_prop(object_class, PROP_DELETE_BUTTON, "delete-button",
+                                     "Delete Button");
+    trg_menu_bar_install_widget_prop(object_class, PROP_RESUME_BUTTON, "resume-button",
+                                     "Resume Button");
+    trg_menu_bar_install_widget_prop(object_class, PROP_RESUME_ALL_BUTTON, "resume-all-button",
                                      "Resume All Button");
-    trg_menu_bar_install_widget_prop(object_class, PROP_VERIFY_BUTTON,
-                                     "verify-button", "Verify Button");
-    trg_menu_bar_install_widget_prop(object_class, PROP_REANNOUNCE_BUTTON,
-                                     "reannounce-button",
+    trg_menu_bar_install_widget_prop(object_class, PROP_VERIFY_BUTTON, "verify-button",
+                                     "Verify Button");
+    trg_menu_bar_install_widget_prop(object_class, PROP_REANNOUNCE_BUTTON, "reannounce-button",
                                      "Re-announce Button");
-    trg_menu_bar_install_widget_prop(object_class, PROP_PAUSE_ALL_BUTTON,
-                                     "pause-all-button",
+    trg_menu_bar_install_widget_prop(object_class, PROP_PAUSE_ALL_BUTTON, "pause-all-button",
                                      "Pause All Button");
-    trg_menu_bar_install_widget_prop(object_class, PROP_PAUSE_BUTTON,
-                                     "pause-button", "Pause Button");
-    trg_menu_bar_install_widget_prop(object_class, PROP_PROPS_BUTTON,
-                                     "props-button", "Props Button");
-    trg_menu_bar_install_widget_prop(object_class, PROP_COPYMAGNET_BUTTON,
-                                     "copymagnet-button", "Copy-magnet Button");
-    trg_menu_bar_install_widget_prop(object_class, PROP_ABOUT_BUTTON,
-                                     "about-button", "About Button");
-    trg_menu_bar_install_widget_prop(object_class, PROP_VIEW_STATS_BUTTON,
-                                     "view-stats-button",
+    trg_menu_bar_install_widget_prop(object_class, PROP_PAUSE_BUTTON, "pause-button",
+                                     "Pause Button");
+    trg_menu_bar_install_widget_prop(object_class, PROP_PROPS_BUTTON, "props-button",
+                                     "Props Button");
+    trg_menu_bar_install_widget_prop(object_class, PROP_COPYMAGNET_BUTTON, "copymagnet-button",
+                                     "Copy-magnet Button");
+    trg_menu_bar_install_widget_prop(object_class, PROP_ABOUT_BUTTON, "about-button",
+                                     "About Button");
+    trg_menu_bar_install_widget_prop(object_class, PROP_VIEW_STATS_BUTTON, "view-stats-button",
                                      "View stats button");
 #if HAVE_RSS
-    trg_menu_bar_install_widget_prop(object_class, PROP_VIEW_RSS_BUTTON,
-                                     "view-rss-button",
+    trg_menu_bar_install_widget_prop(object_class, PROP_VIEW_RSS_BUTTON, "view-rss-button",
                                      "View rss button");
 #endif
-    trg_menu_bar_install_widget_prop(object_class, PROP_VIEW_STATES_BUTTON,
-                                     "view-states-button",
+    trg_menu_bar_install_widget_prop(object_class, PROP_VIEW_STATES_BUTTON, "view-states-button",
                                      "View states Button");
-    trg_menu_bar_install_widget_prop(object_class,
-                                     PROP_VIEW_NOTEBOOK_BUTTON,
-                                     "view-notebook-button",
-                                     "View notebook Button");
-    trg_menu_bar_install_widget_prop(object_class,
-                                     PROP_REMOTE_PREFS_BUTTON,
-                                     "remote-prefs-button",
+    trg_menu_bar_install_widget_prop(object_class, PROP_VIEW_NOTEBOOK_BUTTON,
+                                     "view-notebook-button", "View notebook Button");
+    trg_menu_bar_install_widget_prop(object_class, PROP_REMOTE_PREFS_BUTTON, "remote-prefs-button",
                                      "Remote Prefs Button");
-    trg_menu_bar_install_widget_prop(object_class, PROP_LOCAL_PREFS_BUTTON,
-                                     "local-prefs-button",
+    trg_menu_bar_install_widget_prop(object_class, PROP_LOCAL_PREFS_BUTTON, "local-prefs-button",
                                      "Local Prefs Button");
-    trg_menu_bar_install_widget_prop(object_class, PROP_QUIT,
-                                     "quit-button", "Quit Button");
-    trg_menu_bar_install_widget_prop(object_class, PROP_DIR_FILTERS,
-                                     "dir-filters", "Dir Filters");
-    trg_menu_bar_install_widget_prop(object_class, PROP_TRACKER_FILTERS,
-                                     "tracker-filters", "Tracker Filters");
-	trg_menu_bar_install_widget_prop(object_class, PROP_DIRECTORIES_FIRST,
-									 TRG_PREFS_KEY_DIRECTORIES_FIRST, "Directories first");
+    trg_menu_bar_install_widget_prop(object_class, PROP_QUIT, "quit-button", "Quit Button");
+    trg_menu_bar_install_widget_prop(object_class, PROP_DIR_FILTERS, "dir-filters", "Dir Filters");
+    trg_menu_bar_install_widget_prop(object_class, PROP_TRACKER_FILTERS, "tracker-filters",
+                                     "Tracker Filters");
+    trg_menu_bar_install_widget_prop(object_class, PROP_DIRECTORIES_FIRST,
+                                     TRG_PREFS_KEY_DIRECTORIES_FIRST, "Directories first");
 #if TRG_WITH_GRAPH
-    trg_menu_bar_install_widget_prop(object_class, PROP_VIEW_SHOW_GRAPH,
-                                     "show-graph", "Show Graph");
+    trg_menu_bar_install_widget_prop(object_class, PROP_VIEW_SHOW_GRAPH, "show-graph",
+                                     "Show Graph");
 #endif
-    trg_menu_bar_install_widget_prop(object_class, PROP_MOVE_DOWN_QUEUE,
-                                     "down-queue", "Down Queue");
-    trg_menu_bar_install_widget_prop(object_class, PROP_MOVE_UP_QUEUE,
-                                     "up-queue", "Up Queue");
-    trg_menu_bar_install_widget_prop(object_class, PROP_MOVE_BOTTOM_QUEUE,
-                                     "bottom-queue", "Bottom Queue");
-    trg_menu_bar_install_widget_prop(object_class, PROP_MOVE_TOP_QUEUE,
-                                     "top-queue", "Top Queue");
-    trg_menu_bar_install_widget_prop(object_class, PROP_START_NOW,
-                                     "start-now", "Start Now");
+    trg_menu_bar_install_widget_prop(object_class, PROP_MOVE_DOWN_QUEUE, "down-queue",
+                                     "Down Queue");
+    trg_menu_bar_install_widget_prop(object_class, PROP_MOVE_UP_QUEUE, "up-queue", "Up Queue");
+    trg_menu_bar_install_widget_prop(object_class, PROP_MOVE_BOTTOM_QUEUE, "bottom-queue",
+                                     "Bottom Queue");
+    trg_menu_bar_install_widget_prop(object_class, PROP_MOVE_TOP_QUEUE, "top-queue", "Top Queue");
+    trg_menu_bar_install_widget_prop(object_class, PROP_START_NOW, "start-now", "Start Now");
 
-    g_object_class_install_property(object_class,
-                                    PROP_PREFS,
-                                    g_param_spec_object("prefs",
-                                                        "prefs",
-                                                        "Prefs",
-                                                        TRG_TYPE_PREFS,
-                                                        G_PARAM_READWRITE |
-                                                        G_PARAM_CONSTRUCT_ONLY
-                                                        |
-                                                        G_PARAM_STATIC_NAME
-                                                        |
-                                                        G_PARAM_STATIC_NICK
-                                                        |
-                                                        G_PARAM_STATIC_BLURB));
+    g_object_class_install_property(
+        object_class, PROP_PREFS,
+        g_param_spec_object("prefs", "prefs", "Prefs", TRG_TYPE_PREFS,
+                            G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME
+                                | G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
 
-    g_object_class_install_property(object_class,
-                                    PROP_ACCEL_GROUP,
-                                    g_param_spec_object("accel-group",
-                                                        "accel-group",
-                                                        "accel-group",
-                                                        GTK_TYPE_ACCEL_GROUP,
-                                                        G_PARAM_READWRITE |
-                                                        G_PARAM_CONSTRUCT_ONLY
-                                                        |
-                                                        G_PARAM_STATIC_NAME
-                                                        |
-                                                        G_PARAM_STATIC_NICK
-                                                        |
-                                                        G_PARAM_STATIC_BLURB));
+    g_object_class_install_property(
+        object_class, PROP_ACCEL_GROUP,
+        g_param_spec_object("accel-group", "accel-group", "accel-group", GTK_TYPE_ACCEL_GROUP,
+                            G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME
+                                | G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
 
-    g_object_class_install_property(object_class,
-                                    PROP_MAIN_WINDOW,
-                                    g_param_spec_object("mainwin",
-                                                        "mainwin",
-                                                        "mainwin",
-                                                        TRG_TYPE_MAIN_WINDOW,
-                                                        G_PARAM_READWRITE |
-                                                        G_PARAM_CONSTRUCT_ONLY
-                                                        |
-                                                        G_PARAM_STATIC_NAME
-                                                        |
-                                                        G_PARAM_STATIC_NICK
-                                                        |
-                                                        G_PARAM_STATIC_BLURB));
+    g_object_class_install_property(
+        object_class, PROP_MAIN_WINDOW,
+        g_param_spec_object("mainwin", "mainwin", "mainwin", TRG_TYPE_MAIN_WINDOW,
+                            G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME
+                                | G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
 
-    g_object_class_install_property(object_class,
-                                    PROP_TORRENT_TREE_VIEW,
-                                    g_param_spec_object
-                                    ("torrent-tree-view",
-                                     "torrent-tree-view",
-                                     "torrent-tree-view",
-                                     TRG_TYPE_TORRENT_TREE_VIEW,
-                                     G_PARAM_READWRITE |
-                                     G_PARAM_CONSTRUCT_ONLY |
-                                     G_PARAM_STATIC_NAME |
-                                     G_PARAM_STATIC_NICK |
-                                     G_PARAM_STATIC_BLURB));
+    g_object_class_install_property(
+        object_class, PROP_TORRENT_TREE_VIEW,
+        g_param_spec_object("torrent-tree-view", "torrent-tree-view", "torrent-tree-view",
+                            TRG_TYPE_TORRENT_TREE_VIEW,
+                            G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME
+                                | G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
 }
 
-static void trg_menu_bar_init(TrgMenuBar * self)
+static void trg_menu_bar_init(TrgMenuBar *self)
 {
 }
 
-TrgMenuBar *trg_menu_bar_new(TrgMainWindow * win, TrgPrefs * prefs,
-                             TrgTorrentTreeView * ttv,
-                             GtkAccelGroup * accel_group)
+TrgMenuBar *trg_menu_bar_new(TrgMainWindow *win, TrgPrefs *prefs, TrgTorrentTreeView *ttv,
+                             GtkAccelGroup *accel_group)
 {
-    return g_object_new(TRG_TYPE_MENU_BAR,
-                        "torrent-tree-view", ttv, "prefs", prefs,
-                        "mainwin", win, "accel-group", accel_group, NULL);
+    return g_object_new(TRG_TYPE_MENU_BAR, "torrent-tree-view", ttv, "prefs", prefs, "mainwin", win,
+                        "accel-group", accel_group, NULL);
 }

--- a/src/trg-menu-bar.h
+++ b/src/trg-menu-bar.h
@@ -23,23 +23,20 @@
 #include <glib-object.h>
 #include <gtk/gtk.h>
 
+#include "trg-main-window.h"
 #include "trg-prefs.h"
 #include "trg-torrent-tree-view.h"
-#include "trg-main-window.h"
 
 G_BEGIN_DECLS
 #define TRG_TYPE_MENU_BAR trg_menu_bar_get_type()
-#define TRG_MENU_BAR(obj) \
-  (G_TYPE_CHECK_INSTANCE_CAST ((obj), TRG_TYPE_MENU_BAR, TrgMenuBar))
-#define TRG_MENU_BAR_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_CAST ((klass), TRG_TYPE_MENU_BAR, TrgMenuBarClass))
-#define TRG_IS_MENU_BAR(obj) \
-  (G_TYPE_CHECK_INSTANCE_TYPE ((obj), TRG_TYPE_MENU_BAR))
-#define TRG_IS_MENU_BAR_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_TYPE ((klass), TRG_TYPE_MENU_BAR))
-#define TRG_MENU_BAR_GET_CLASS(obj) \
-  (G_TYPE_INSTANCE_GET_CLASS ((obj), TRG_TYPE_MENU_BAR, TrgMenuBarClass))
-    typedef struct {
+#define TRG_MENU_BAR(obj) (G_TYPE_CHECK_INSTANCE_CAST((obj), TRG_TYPE_MENU_BAR, TrgMenuBar))
+#define TRG_MENU_BAR_CLASS(klass)                                                                  \
+    (G_TYPE_CHECK_CLASS_CAST((klass), TRG_TYPE_MENU_BAR, TrgMenuBarClass))
+#define TRG_IS_MENU_BAR(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), TRG_TYPE_MENU_BAR))
+#define TRG_IS_MENU_BAR_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass), TRG_TYPE_MENU_BAR))
+#define TRG_MENU_BAR_GET_CLASS(obj)                                                                \
+    (G_TYPE_INSTANCE_GET_CLASS((obj), TRG_TYPE_MENU_BAR, TrgMenuBarClass))
+typedef struct {
     GtkMenuBar parent;
 } TrgMenuBar;
 
@@ -49,19 +46,14 @@ typedef struct {
 
 GType trg_menu_bar_get_type(void);
 
-TrgMenuBar *trg_menu_bar_new(TrgMainWindow * win, TrgPrefs * prefs,
-                             TrgTorrentTreeView * ttv,
-                             GtkAccelGroup * accel_group);
-GtkWidget *trg_menu_bar_item_new(GtkMenuShell * shell, const gchar * text,
-                                 gboolean sensitive);
+TrgMenuBar *trg_menu_bar_new(TrgMainWindow *win, TrgPrefs *prefs, TrgTorrentTreeView *ttv,
+                             GtkAccelGroup *accel_group);
+GtkWidget *trg_menu_bar_item_new(GtkMenuShell *shell, const gchar *text, gboolean sensitive);
 
 G_END_DECLS
-    void trg_menu_bar_torrent_actions_sensitive(TrgMenuBar * mb,
-                                                gboolean sensitive);
-void trg_menu_bar_connected_change(TrgMenuBar * mb, gboolean connected);
-void trg_menu_bar_set_supports_queues(TrgMenuBar * mb,
-                                      gboolean supportsQueues);
-GtkWidget *trg_menu_bar_file_connect_menu_new(TrgMainWindow * win,
-                                              TrgPrefs * p);
+void trg_menu_bar_torrent_actions_sensitive(TrgMenuBar *mb, gboolean sensitive);
+void trg_menu_bar_connected_change(TrgMenuBar *mb, gboolean connected);
+void trg_menu_bar_set_supports_queues(TrgMenuBar *mb, gboolean supportsQueues);
+GtkWidget *trg_menu_bar_file_connect_menu_new(TrgMainWindow *win, TrgPrefs *p);
 
-#endif                          /* TRG_MENU_BAR_H_ */
+#endif /* TRG_MENU_BAR_H_ */

--- a/src/trg-model.c
+++ b/src/trg-model.c
@@ -19,10 +19,10 @@
 
 #include "config.h"
 
+#include "trg-model.h"
 #include <glib.h>
 #include <gtk/gtk.h>
 #include <json-glib/json-glib.h>
-#include "trg-model.h"
 
 /* An extension of GtkListStore which provides some functions for looking up
  * an entry by ID. Also for removing entries which have an old update serial,
@@ -35,25 +35,21 @@ struct trg_model_remove_removed_foreachfunc_args {
     GList *toRemove;
 };
 
-static gboolean
-trg_model_remove_removed_foreachfunc(GtkTreeModel * model,
-                                     GtkTreePath * path G_GNUC_UNUSED,
-                                     GtkTreeIter * iter, gpointer data)
+static gboolean trg_model_remove_removed_foreachfunc(GtkTreeModel *model,
+                                                     GtkTreePath *path G_GNUC_UNUSED,
+                                                     GtkTreeIter *iter, gpointer data)
 {
-    struct trg_model_remove_removed_foreachfunc_args *args =
-        (struct trg_model_remove_removed_foreachfunc_args *) data;
+    struct trg_model_remove_removed_foreachfunc_args *args
+        = (struct trg_model_remove_removed_foreachfunc_args *)data;
     gint64 rowSerial;
     gtk_tree_model_get(model, iter, args->serial_column, &rowSerial, -1);
     if (rowSerial != args->currentSerial)
-        args->toRemove =
-            g_list_append(args->toRemove, gtk_tree_iter_copy(iter));
+        args->toRemove = g_list_append(args->toRemove, gtk_tree_iter_copy(iter));
 
     return FALSE;
 }
 
-guint
-trg_model_remove_removed(GtkListStore * model, gint serial_column,
-                         gint64 currentSerial)
+guint trg_model_remove_removed(GtkListStore *model, gint serial_column, gint64 currentSerial)
 {
     struct trg_model_remove_removed_foreachfunc_args args;
     GList *li;
@@ -62,13 +58,11 @@ trg_model_remove_removed(GtkListStore * model, gint serial_column,
     args.toRemove = NULL;
     args.currentSerial = currentSerial;
     args.serial_column = serial_column;
-    gtk_tree_model_foreach(GTK_TREE_MODEL(model),
-                           trg_model_remove_removed_foreachfunc, &args);
+    gtk_tree_model_foreach(GTK_TREE_MODEL(model), trg_model_remove_removed_foreachfunc, &args);
     if (args.toRemove != NULL) {
-        for (li = g_list_last(args.toRemove); li != NULL;
-             li = g_list_previous(li)) {
-            gtk_list_store_remove(model, (GtkTreeIter *) li->data);
-            gtk_tree_iter_free((GtkTreeIter *) li->data);
+        for (li = g_list_last(args.toRemove); li != NULL; li = g_list_previous(li)) {
+            gtk_list_store_remove(model, (GtkTreeIter *)li->data);
+            gtk_tree_iter_free((GtkTreeIter *)li->data);
             removed++;
         }
         g_list_free(args.toRemove);
@@ -84,13 +78,10 @@ struct find_existing_item_foreach_args {
     gboolean found;
 };
 
-static gboolean
-find_existing_item_foreachfunc(GtkTreeModel * model,
-                               GtkTreePath * path G_GNUC_UNUSED,
-                               GtkTreeIter * iter, gpointer data)
+static gboolean find_existing_item_foreachfunc(GtkTreeModel *model, GtkTreePath *path G_GNUC_UNUSED,
+                                               GtkTreeIter *iter, gpointer data)
 {
-    struct find_existing_item_foreach_args *args =
-        (struct find_existing_item_foreach_args *) data;
+    struct find_existing_item_foreach_args *args = (struct find_existing_item_foreach_args *)data;
     gint64 currentId;
 
     gtk_tree_model_get(model, iter, args->search_column, &currentId, -1);
@@ -102,9 +93,8 @@ find_existing_item_foreachfunc(GtkTreeModel * model,
     return FALSE;
 }
 
-gboolean
-find_existing_model_item(GtkTreeModel * model, gint search_column,
-                         gint64 id, GtkTreeIter * iter)
+gboolean find_existing_model_item(GtkTreeModel *model, gint search_column, gint64 id,
+                                  GtkTreeIter *iter)
 {
     struct find_existing_item_foreach_args args;
     args.id = id;

--- a/src/trg-model.h
+++ b/src/trg-model.h
@@ -22,11 +22,9 @@
 
 #include <gtk/gtk.h>
 
-guint trg_model_remove_removed(GtkListStore * model, gint serial_column,
-                               gint64 currentSerial);
+guint trg_model_remove_removed(GtkListStore *model, gint serial_column, gint64 currentSerial);
 
-gboolean
-find_existing_model_item(GtkTreeModel * model, gint search_column,
-                         gint64 id, GtkTreeIter * iter);
+gboolean find_existing_model_item(GtkTreeModel *model, gint search_column, gint64 id,
+                                  GtkTreeIter *iter);
 
-#endif                          /* TRG_MODEL_H_ */
+#endif /* TRG_MODEL_H_ */

--- a/src/trg-peers-model.c
+++ b/src/trg-peers-model.c
@@ -19,26 +19,26 @@
 
 #include "config.h"
 
+#include <gio/gio.h>
 #include <glib.h>
+#include <glib/gstdio.h>
 #include <gtk/gtk.h>
 #include <json-glib/json-glib.h>
-#include <gio/gio.h>
-#include <glib/gstdio.h>
 #if HAVE_GEOIP
 #include <GeoIP.h>
 #include <GeoIPCity.h>
 #endif
 
-#include "trg-tree-view.h"
 #include "torrent.h"
 #include "trg-client.h"
-#include "trg-peers-model.h"
 #include "trg-model.h"
+#include "trg-peers-model.h"
+#include "trg-tree-view.h"
 #include "util.h"
 
 G_DEFINE_TYPE(TrgPeersModel, trg_peers_model, GTK_TYPE_LIST_STORE)
-#define TRG_PEERS_MODEL_GET_PRIVATE(o) \
-  (G_TYPE_INSTANCE_GET_PRIVATE ((o), TRG_TYPE_PEERS_MODEL, TrgPeersModelPrivate))
+#define TRG_PEERS_MODEL_GET_PRIVATE(o)                                                             \
+    (G_TYPE_INSTANCE_GET_PRIVATE((o), TRG_TYPE_PEERS_MODEL, TrgPeersModelPrivate))
 #if HAVE_GEOIP
 typedef struct _TrgPeersModelPrivate TrgPeersModelPrivate;
 
@@ -49,21 +49,18 @@ struct _TrgPeersModelPrivate {
 };
 #endif
 
-static void trg_peers_model_class_init(TrgPeersModelClass *
-                                       klass G_GNUC_UNUSED)
+static void trg_peers_model_class_init(TrgPeersModelClass *klass G_GNUC_UNUSED)
 {
 #if HAVE_GEOIP
     g_type_class_add_private(klass, sizeof(TrgPeersModelPrivate));
 #endif
 }
 
-static gboolean
-find_existing_peer_item_foreachfunc(GtkTreeModel * model,
-                                    GtkTreePath *
-                                    path G_GNUC_UNUSED,
-                                    GtkTreeIter * iter, gpointer data)
+static gboolean find_existing_peer_item_foreachfunc(GtkTreeModel *model,
+                                                    GtkTreePath *path G_GNUC_UNUSED,
+                                                    GtkTreeIter *iter, gpointer data)
 {
-    struct peerAndIter *pi = (struct peerAndIter *) data;
+    struct peerAndIter *pi = (struct peerAndIter *)data;
     gchar *ip;
 
     gtk_tree_model_get(model, iter, PEERSCOL_IP, &ip, -1);
@@ -78,16 +75,13 @@ find_existing_peer_item_foreachfunc(GtkTreeModel * model,
     return pi->found;
 }
 
-static gboolean
-find_existing_peer_item(TrgPeersModel * model, JsonObject * p,
-                        GtkTreeIter * iter)
+static gboolean find_existing_peer_item(TrgPeersModel *model, JsonObject *p, GtkTreeIter *iter)
 {
     struct peerAndIter pi;
     pi.ip = peer_get_address(p);
     pi.found = FALSE;
 
-    gtk_tree_model_foreach(GTK_TREE_MODEL(model),
-                           find_existing_peer_item_foreachfunc, &pi);
+    gtk_tree_model_foreach(GTK_TREE_MODEL(model), find_existing_peer_item_foreachfunc, &pi);
 
     if (pi.found == TRUE)
         *iter = pi.iter;
@@ -103,15 +97,13 @@ struct ResolvedDnsIdleData {
 static gboolean resolved_dns_idle_cb(gpointer data)
 {
     struct ResolvedDnsIdleData *idleData = data;
-    GtkTreeModel *model =
-        gtk_tree_row_reference_get_model(idleData->rowRef);
+    GtkTreeModel *model = gtk_tree_row_reference_get_model(idleData->rowRef);
     GtkTreePath *path = gtk_tree_row_reference_get_path(idleData->rowRef);
 
     if (path != NULL) {
         GtkTreeIter iter;
         if (gtk_tree_model_get_iter(model, &iter, path) == TRUE) {
-            gtk_list_store_set(GTK_LIST_STORE(model), &iter, PEERSCOL_HOST,
-                               idleData->rdns, -1);
+            gtk_list_store_set(GTK_LIST_STORE(model), &iter, PEERSCOL_HOST, idleData->rdns, -1);
         }
         gtk_tree_path_free(path);
     }
@@ -123,18 +115,14 @@ static gboolean resolved_dns_idle_cb(gpointer data)
     return FALSE;
 }
 
-static void resolved_dns_cb(GObject * source_object, GAsyncResult * res,
-                            gpointer data)
+static void resolved_dns_cb(GObject *source_object, GAsyncResult *res, gpointer data)
 {
 
-    gchar *rdns =
-        g_resolver_lookup_by_address_finish(G_RESOLVER(source_object),
-                                            res, NULL);
+    gchar *rdns = g_resolver_lookup_by_address_finish(G_RESOLVER(source_object), res, NULL);
     GtkTreeRowReference *rowRef = data;
 
     if (rdns != NULL) {
-        struct ResolvedDnsIdleData *idleData =
-            g_new(struct ResolvedDnsIdleData, 1);
+        struct ResolvedDnsIdleData *idleData = g_new(struct ResolvedDnsIdleData, 1);
         idleData->rdns = rdns;
         idleData->rowRef = rowRef;
         g_idle_add(resolved_dns_idle_cb, idleData);
@@ -145,32 +133,29 @@ static void resolved_dns_cb(GObject * source_object, GAsyncResult * res,
 
 #if HAVE_GEOIP
 /* for handling v4 or v6 addresses. string is owned by GeoIP, should not be freed. */
-static const gchar* lookup_country(TrgPeersModel *model, const gchar *address) {
-	TrgPeersModelPrivate *priv = TRG_PEERS_MODEL_GET_PRIVATE(model);
+static const gchar *lookup_country(TrgPeersModel *model, const gchar *address)
+{
+    TrgPeersModelPrivate *priv = TRG_PEERS_MODEL_GET_PRIVATE(model);
 
-	if (strchr(address, ':') && priv->geoipv6)
-		return GeoIP_country_name_by_addr_v6(priv->geoipv6, address);
-	else if (priv->geoip)
-		return GeoIP_country_name_by_addr(priv->geoip, address);
-	else
-		return NULL;
+    if (strchr(address, ':') && priv->geoipv6)
+        return GeoIP_country_name_by_addr_v6(priv->geoipv6, address);
+    else if (priv->geoip)
+        return GeoIP_country_name_by_addr(priv->geoip, address);
+    else
+        return NULL;
 }
 #endif
 
-void
-trg_peers_model_update(TrgPeersModel * model, TrgTreeView * tv,
-                       gint64 updateSerial, JsonObject * t, gint mode)
+void trg_peers_model_update(TrgPeersModel *model, TrgTreeView *tv, gint64 updateSerial,
+                            JsonObject *t, gint mode)
 {
 #if HAVE_GEOIP
     TrgPeersModelPrivate *priv = TRG_PEERS_MODEL_GET_PRIVATE(model);
-    gboolean doGeoLookup =
-        trg_tree_view_is_column_showing(tv, PEERSCOL_COUNTRY);
-    gboolean doGeoCityLookup =
-        trg_tree_view_is_column_showing(tv, PEERSCOL_CITY);
+    gboolean doGeoLookup = trg_tree_view_is_column_showing(tv, PEERSCOL_COUNTRY);
+    gboolean doGeoCityLookup = trg_tree_view_is_column_showing(tv, PEERSCOL_CITY);
 #endif
 
-    gboolean doHostLookup =
-        trg_tree_view_is_column_showing(tv, PEERSCOL_HOST);
+    gboolean doHostLookup = trg_tree_view_is_column_showing(tv, PEERSCOL_HOST);
     JsonArray *peers;
     GtkTreeIter peerIter;
     GList *li, *peersList;
@@ -183,7 +168,7 @@ trg_peers_model_update(TrgPeersModel * model, TrgTreeView * tv,
 
     peersList = json_array_get_elements(peers);
     for (li = peersList; li; li = g_list_next(li)) {
-        JsonObject *peer = json_node_get_object((JsonNode *) li->data);
+        JsonObject *peer = json_node_get_object((JsonNode *)li->data);
         const gchar *address = NULL, *flagStr;
 #if HAVE_GEOIP
         const gchar *country = NULL;
@@ -196,22 +181,20 @@ trg_peers_model_update(TrgPeersModel * model, TrgTreeView * tv,
 
             address = peer_get_address(peer);
 #if HAVE_GEOIP
-            if (address) {       /* just in case address wasn't set */
-            	if (doGeoLookup)
-            		country = lookup_country(model, address);
-            	if (doGeoCityLookup)
-            		city = GeoIP_record_by_addr(priv->geoipcity, address);
+            if (address) { /* just in case address wasn't set */
+                if (doGeoLookup)
+                    country = lookup_country(model, address);
+                if (doGeoCityLookup)
+                    city = GeoIP_record_by_addr(priv->geoipcity, address);
             }
 #endif
-            gtk_list_store_set(GTK_LIST_STORE(model), &peerIter,
-                               PEERSCOL_ICON, "network-workgroup",
+            gtk_list_store_set(GTK_LIST_STORE(model), &peerIter, PEERSCOL_ICON, "network-workgroup",
                                PEERSCOL_IP, address,
 #if HAVE_GEOIP
-                               PEERSCOL_COUNTRY, country ? country : "",
-                               PEERSCOL_CITY, city ? city->city : "",
+                               PEERSCOL_COUNTRY, country ? country : "", PEERSCOL_CITY,
+                               city ? city->city : "",
 #endif
-                               PEERSCOL_CLIENT, peer_get_client_name(peer),
-                               -1);
+                               PEERSCOL_CLIENT, peer_get_client_name(peer), -1);
 
             isNew = TRUE;
         } else {
@@ -220,23 +203,18 @@ trg_peers_model_update(TrgPeersModel * model, TrgTreeView * tv,
 
 #if HAVE_GEOIP
         if (city)
-        	GeoIPRecord_delete(city);
+            GeoIPRecord_delete(city);
 #endif
 
         flagStr = peer_get_flagstr(peer);
-        gtk_list_store_set(GTK_LIST_STORE(model), &peerIter,
-                           PEERSCOL_FLAGS, flagStr, PEERSCOL_PROGRESS,
-                           peer_get_progress(peer), PEERSCOL_DOWNSPEED,
+        gtk_list_store_set(GTK_LIST_STORE(model), &peerIter, PEERSCOL_FLAGS, flagStr,
+                           PEERSCOL_PROGRESS, peer_get_progress(peer), PEERSCOL_DOWNSPEED,
                            peer_get_rate_to_client(peer), PEERSCOL_UPSPEED,
-                           peer_get_rate_to_peer(peer),
-                           PEERSCOL_UPDATESERIAL, updateSerial, -1);
+                           peer_get_rate_to_peer(peer), PEERSCOL_UPDATESERIAL, updateSerial, -1);
 
         if (doHostLookup && isNew == TRUE) {
-            GtkTreePath *path =
-                gtk_tree_model_get_path(GTK_TREE_MODEL(model),
-                                        &peerIter);
-            GtkTreeRowReference *treeRef =
-                gtk_tree_row_reference_new(GTK_TREE_MODEL(model), path);
+            GtkTreePath *path = gtk_tree_model_get_path(GTK_TREE_MODEL(model), &peerIter);
+            GtkTreeRowReference *treeRef = gtk_tree_row_reference_new(GTK_TREE_MODEL(model), path);
             GInetAddress *inetAddr;
             GResolver *resolver;
 
@@ -244,8 +222,7 @@ trg_peers_model_update(TrgPeersModel * model, TrgTreeView * tv,
 
             inetAddr = g_inet_address_new_from_string(address);
             resolver = g_resolver_get_default();
-            g_resolver_lookup_by_address_async(resolver, inetAddr, NULL,
-                                               resolved_dns_cb, treeRef);
+            g_resolver_lookup_by_address_async(resolver, inetAddr, NULL, resolved_dns_cb, treeRef);
             g_object_unref(resolver);
             g_object_unref(inetAddr);
         }
@@ -254,11 +231,10 @@ trg_peers_model_update(TrgPeersModel * model, TrgTreeView * tv,
     g_list_free(peersList);
 
     if (mode != TORRENT_GET_MODE_FIRST)
-        trg_model_remove_removed(GTK_LIST_STORE(model),
-                                 PEERSCOL_UPDATESERIAL, updateSerial);
+        trg_model_remove_removed(GTK_LIST_STORE(model), PEERSCOL_UPDATESERIAL, updateSerial);
 }
 
-static void trg_peers_model_init(TrgPeersModel * self)
+static void trg_peers_model_init(TrgPeersModel *self)
 {
 #if HAVE_GEOIP
     TrgPeersModelPrivate *priv = TRG_PEERS_MODEL_GET_PRIVATE(self);
@@ -284,8 +260,7 @@ static void trg_peers_model_init(TrgPeersModel * self)
     column_types[PEERSCOL_CLIENT] = G_TYPE_STRING;
     column_types[PEERSCOL_UPDATESERIAL] = G_TYPE_INT64;
 
-    gtk_list_store_set_column_types(GTK_LIST_STORE(self), PEERSCOL_COLUMNS,
-                                    column_types);
+    gtk_list_store_set_column_types(GTK_LIST_STORE(self), PEERSCOL_COLUMNS, column_types);
 
 #if HAVE_GEOIP
 #ifdef G_OS_WIN32
@@ -301,22 +276,18 @@ static void trg_peers_model_init(TrgPeersModel * self)
 #endif
 
     if (g_file_test(geoip_db_path, G_FILE_TEST_EXISTS) == TRUE)
-        priv->geoip = GeoIP_open(geoip_db_path,
-                                 GEOIP_STANDARD | GEOIP_CHECK_CACHE);
+        priv->geoip = GeoIP_open(geoip_db_path, GEOIP_STANDARD | GEOIP_CHECK_CACHE);
 
     if (g_file_test(geoip_v6_db_path, G_FILE_TEST_EXISTS) == TRUE)
-        priv->geoipv6 = GeoIP_open(geoip_v6_db_path,
-                                   GEOIP_STANDARD | GEOIP_CHECK_CACHE);
+        priv->geoipv6 = GeoIP_open(geoip_v6_db_path, GEOIP_STANDARD | GEOIP_CHECK_CACHE);
 
     if (g_file_test(geoip_city_db_path, G_FILE_TEST_EXISTS) == TRUE)
-        priv->geoipcity = GeoIP_open(geoip_city_db_path,
-                                   GEOIP_STANDARD | GEOIP_CHECK_CACHE);
+        priv->geoipcity = GeoIP_open(geoip_city_db_path, GEOIP_STANDARD | GEOIP_CHECK_CACHE);
     else if (g_file_test(geoip_city_alt_db_path, G_FILE_TEST_EXISTS) == TRUE)
-        priv->geoipcity = GeoIP_open(geoip_city_alt_db_path,
-                                   GEOIP_STANDARD | GEOIP_CHECK_CACHE);
+        priv->geoipcity = GeoIP_open(geoip_city_alt_db_path, GEOIP_STANDARD | GEOIP_CHECK_CACHE);
 
     if (priv->geoipcity)
-    	GeoIP_set_charset(priv->geoipcity, GEOIP_CHARSET_UTF8);
+        GeoIP_set_charset(priv->geoipcity, GEOIP_CHARSET_UTF8);
 
     g_free(geoip_city_db_path);
     g_free(geoip_city_alt_db_path);
@@ -326,64 +297,66 @@ static void trg_peers_model_init(TrgPeersModel * self)
 }
 
 #if HAVE_GEOIP
-static gboolean trg_peers_model_add_city_foreach(GtkTreeModel *model,
-        GtkTreePath *path,
-        GtkTreeIter *iter,
-        gpointer data) {
-	TrgPeersModelPrivate *priv = TRG_PEERS_MODEL_GET_PRIVATE(model);
-	gchar *address = NULL;
-	GeoIPRecord *record = NULL;
+static gboolean trg_peers_model_add_city_foreach(GtkTreeModel *model, GtkTreePath *path,
+                                                 GtkTreeIter *iter, gpointer data)
+{
+    TrgPeersModelPrivate *priv = TRG_PEERS_MODEL_GET_PRIVATE(model);
+    gchar *address = NULL;
+    GeoIPRecord *record = NULL;
 
-	gtk_tree_model_get(GTK_TREE_MODEL(model), iter, PEERSCOL_IP, &address, -1);
-	record = GeoIP_record_by_addr(priv->geoipcity, address);
+    gtk_tree_model_get(GTK_TREE_MODEL(model), iter, PEERSCOL_IP, &address, -1);
+    record = GeoIP_record_by_addr(priv->geoipcity, address);
 
-	if (record) {
-		gtk_list_store_set(GTK_LIST_STORE(model), iter, PEERSCOL_CITY, record->city, -1);
-		GeoIPRecord_delete(record);
-	}
+    if (record) {
+        gtk_list_store_set(GTK_LIST_STORE(model), iter, PEERSCOL_CITY, record->city, -1);
+        GeoIPRecord_delete(record);
+    }
 
-	g_free(address);
+    g_free(address);
 
-	return FALSE;
+    return FALSE;
 }
 
-gboolean trg_peers_model_has_city_db(TrgPeersModel *model) {
-	TrgPeersModelPrivate *priv = TRG_PEERS_MODEL_GET_PRIVATE(model);
-	return priv->geoipcity != NULL;
+gboolean trg_peers_model_has_city_db(TrgPeersModel *model)
+{
+    TrgPeersModelPrivate *priv = TRG_PEERS_MODEL_GET_PRIVATE(model);
+    return priv->geoipcity != NULL;
 }
 
-gboolean trg_peers_model_has_country_db(TrgPeersModel *model) {
-	TrgPeersModelPrivate *priv = TRG_PEERS_MODEL_GET_PRIVATE(model);
-	return priv->geoip != NULL;
+gboolean trg_peers_model_has_country_db(TrgPeersModel *model)
+{
+    TrgPeersModelPrivate *priv = TRG_PEERS_MODEL_GET_PRIVATE(model);
+    return priv->geoip != NULL;
 }
 
-void trg_peers_model_add_city_column(TrgPeersModel *model) {
-	TrgPeersModelPrivate *priv = TRG_PEERS_MODEL_GET_PRIVATE(model);
-	if (priv->geoipcity)
-		gtk_tree_model_foreach(GTK_TREE_MODEL(model), trg_peers_model_add_city_foreach, NULL);
+void trg_peers_model_add_city_column(TrgPeersModel *model)
+{
+    TrgPeersModelPrivate *priv = TRG_PEERS_MODEL_GET_PRIVATE(model);
+    if (priv->geoipcity)
+        gtk_tree_model_foreach(GTK_TREE_MODEL(model), trg_peers_model_add_city_foreach, NULL);
 }
 
-static gboolean trg_peers_model_add_country_foreach(GtkTreeModel *model,
-        GtkTreePath *path,
-        GtkTreeIter *iter,
-        gpointer data) {
-	gchar *address = NULL;
+static gboolean trg_peers_model_add_country_foreach(GtkTreeModel *model, GtkTreePath *path,
+                                                    GtkTreeIter *iter, gpointer data)
+{
+    gchar *address = NULL;
 
-	gtk_tree_model_get(GTK_TREE_MODEL(model), iter, PEERSCOL_IP, &address, -1);
-	gtk_list_store_set(GTK_LIST_STORE(model), iter, PEERSCOL_COUNTRY, lookup_country(TRG_PEERS_MODEL(model), address), -1);
+    gtk_tree_model_get(GTK_TREE_MODEL(model), iter, PEERSCOL_IP, &address, -1);
+    gtk_list_store_set(GTK_LIST_STORE(model), iter, PEERSCOL_COUNTRY,
+                       lookup_country(TRG_PEERS_MODEL(model), address), -1);
 
-	g_free(address);
+    g_free(address);
 
-	return FALSE;
+    return FALSE;
 }
 
-void trg_peers_model_add_country_column(TrgPeersModel *model) {
-	TrgPeersModelPrivate *priv = TRG_PEERS_MODEL_GET_PRIVATE(model);
-	if (priv->geoip)
-		gtk_tree_model_foreach(GTK_TREE_MODEL(model), trg_peers_model_add_country_foreach, NULL);
+void trg_peers_model_add_country_column(TrgPeersModel *model)
+{
+    TrgPeersModelPrivate *priv = TRG_PEERS_MODEL_GET_PRIVATE(model);
+    if (priv->geoip)
+        gtk_tree_model_foreach(GTK_TREE_MODEL(model), trg_peers_model_add_country_foreach, NULL);
 }
 #endif
-
 
 TrgPeersModel *trg_peers_model_new()
 {

--- a/src/trg-peers-model.h
+++ b/src/trg-peers-model.h
@@ -17,7 +17,6 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-
 #ifndef TRG_PEERS_MODEL_H_
 #define TRG_PEERS_MODEL_H_
 
@@ -34,17 +33,15 @@
 
 G_BEGIN_DECLS
 #define TRG_TYPE_PEERS_MODEL trg_peers_model_get_type()
-#define TRG_PEERS_MODEL(obj) \
-  (G_TYPE_CHECK_INSTANCE_CAST ((obj), TRG_TYPE_PEERS_MODEL, TrgPeersModel))
-#define TRG_PEERS_MODEL_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_CAST ((klass), TRG_TYPE_PEERS_MODEL, TrgPeersModelClass))
-#define TRG_IS_PEERS_MODEL(obj) \
-  (G_TYPE_CHECK_INSTANCE_TYPE ((obj), TRG_TYPE_PEERS_MODEL))
-#define TRG_IS_PEERS_MODEL_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_TYPE ((klass), TRG_TYPE_PEERS_MODEL))
-#define TRG_PEERS_MODEL_GET_CLASS(obj) \
-  (G_TYPE_INSTANCE_GET_CLASS ((obj), TRG_TYPE_PEERS_MODEL, TrgPeersModelClass))
-    typedef struct {
+#define TRG_PEERS_MODEL(obj)                                                                       \
+    (G_TYPE_CHECK_INSTANCE_CAST((obj), TRG_TYPE_PEERS_MODEL, TrgPeersModel))
+#define TRG_PEERS_MODEL_CLASS(klass)                                                               \
+    (G_TYPE_CHECK_CLASS_CAST((klass), TRG_TYPE_PEERS_MODEL, TrgPeersModelClass))
+#define TRG_IS_PEERS_MODEL(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), TRG_TYPE_PEERS_MODEL))
+#define TRG_IS_PEERS_MODEL_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass), TRG_TYPE_PEERS_MODEL))
+#define TRG_PEERS_MODEL_GET_CLASS(obj)                                                             \
+    (G_TYPE_INSTANCE_GET_CLASS((obj), TRG_TYPE_PEERS_MODEL, TrgPeersModelClass))
+typedef struct {
     GtkListStore parent;
 } TrgPeersModel;
 
@@ -79,9 +76,8 @@ enum {
     PEERSCOL_COLUMNS
 };
 
-void trg_peers_model_update(TrgPeersModel * model, TrgTreeView * tv,
-                            gint64 updateSerial, JsonObject * t,
-                            gboolean first);
+void trg_peers_model_update(TrgPeersModel *model, TrgTreeView *tv, gint64 updateSerial,
+                            JsonObject *t, gboolean first);
 
 #if HAVE_GEOIP
 void trg_peers_model_add_city_column(TrgPeersModel *model);
@@ -90,9 +86,9 @@ gboolean trg_peers_model_has_city_db(TrgPeersModel *model);
 gboolean trg_peers_model_has_country_db(TrgPeersModel *model);
 #endif
 
-#endif                          /* TRG_PEERS_MODEL_H_ */
+#endif /* TRG_PEERS_MODEL_H_ */
 
-#define TRG_GEOIP_DATABASE "/usr/share/GeoIP/GeoIP.dat"
-#define TRG_GEOIPV6_DATABASE "/usr/share/GeoIP/GeoIPv6.dat"
-#define TRG_GEOIP_CITY_DATABASE "/usr/share/GeoIP/GeoLiteCity.dat"
+#define TRG_GEOIP_DATABASE          "/usr/share/GeoIP/GeoIP.dat"
+#define TRG_GEOIPV6_DATABASE        "/usr/share/GeoIP/GeoIPv6.dat"
+#define TRG_GEOIP_CITY_DATABASE     "/usr/share/GeoIP/GeoLiteCity.dat"
 #define TRG_GEOIP_CITY_ALT_DATABASE "/usr/share/GeoIP/GeoIPCity.dat"

--- a/src/trg-peers-tree-view.c
+++ b/src/trg-peers-tree-view.c
@@ -27,75 +27,67 @@
 #include <glib/gi18n.h>
 #include <gtk/gtk.h>
 
-#include "trg-prefs.h"
-#include "trg-tree-view.h"
 #include "trg-peers-model.h"
 #include "trg-peers-tree-view.h"
+#include "trg-prefs.h"
+#include "trg-tree-view.h"
 
 G_DEFINE_TYPE(TrgPeersTreeView, trg_peers_tree_view, TRG_TYPE_TREE_VIEW)
-static void
-trg_peers_tree_view_class_init(TrgPeersTreeViewClass * klass G_GNUC_UNUSED)
+static void trg_peers_tree_view_class_init(TrgPeersTreeViewClass *klass G_GNUC_UNUSED)
 {
 }
 
-static void trg_peers_tree_view_init(TrgPeersTreeView * self) {
-
+static void trg_peers_tree_view_init(TrgPeersTreeView *self)
+{
 }
 
-static void trg_peers_tree_view_setup_columns(TrgPeersTreeView * self, TrgPeersModel *model)
+static void trg_peers_tree_view_setup_columns(TrgPeersTreeView *self, TrgPeersModel *model)
 {
     TrgTreeView *ttv = TRG_TREE_VIEW(self);
     trg_column_description *desc;
 
-    desc =
-        trg_tree_view_reg_column(ttv, TRG_COLTYPE_ICONTEXT,
-                                 PEERSCOL_IP, _("IP"), "ip", 0);
+    desc = trg_tree_view_reg_column(ttv, TRG_COLTYPE_ICONTEXT, PEERSCOL_IP, _("IP"), "ip", 0);
     desc->model_column_extra = PEERSCOL_ICON;
 
-    trg_tree_view_reg_column(ttv, TRG_COLTYPE_TEXT, PEERSCOL_HOST,
-                             _("Host"), "host", 0);
+    trg_tree_view_reg_column(ttv, TRG_COLTYPE_TEXT, PEERSCOL_HOST, _("Host"), "host", 0);
 
 #if HAVE_GEOIP
     if (trg_peers_model_has_country_db(model))
-		trg_tree_view_reg_column(ttv, TRG_COLTYPE_TEXT, PEERSCOL_COUNTRY,
-								 _("Country"), "country", 0);
+        trg_tree_view_reg_column(ttv, TRG_COLTYPE_TEXT, PEERSCOL_COUNTRY, _("Country"), "country",
+                                 0);
 
     if (trg_peers_model_has_city_db(model))
-		trg_tree_view_reg_column(ttv, TRG_COLTYPE_TEXT, PEERSCOL_CITY,
-								 _("City"), "city", 0);
+        trg_tree_view_reg_column(ttv, TRG_COLTYPE_TEXT, PEERSCOL_CITY, _("City"), "city", 0);
 #endif
-    trg_tree_view_reg_column(ttv, TRG_COLTYPE_SPEED, PEERSCOL_DOWNSPEED,
-                             _("Down Speed"), "down-speed", 0);
-    trg_tree_view_reg_column(ttv, TRG_COLTYPE_SPEED, PEERSCOL_UPSPEED,
-                             _("Up Speed"), "up-speed", 0);
-    trg_tree_view_reg_column(ttv, TRG_COLTYPE_PROG, PEERSCOL_PROGRESS,
-                             _("Progress"), "progress", 0);
-    trg_tree_view_reg_column(ttv, TRG_COLTYPE_TEXT, PEERSCOL_FLAGS,
-                             _("Flags"), "flags", 0);
-    trg_tree_view_reg_column(ttv, TRG_COLTYPE_TEXT, PEERSCOL_CLIENT,
-                             _("Client"), "client", 0);
+    trg_tree_view_reg_column(ttv, TRG_COLTYPE_SPEED, PEERSCOL_DOWNSPEED, _("Down Speed"),
+                             "down-speed", 0);
+    trg_tree_view_reg_column(ttv, TRG_COLTYPE_SPEED, PEERSCOL_UPSPEED, _("Up Speed"), "up-speed",
+                             0);
+    trg_tree_view_reg_column(ttv, TRG_COLTYPE_PROG, PEERSCOL_PROGRESS, _("Progress"), "progress",
+                             0);
+    trg_tree_view_reg_column(ttv, TRG_COLTYPE_TEXT, PEERSCOL_FLAGS, _("Flags"), "flags", 0);
+    trg_tree_view_reg_column(ttv, TRG_COLTYPE_TEXT, PEERSCOL_CLIENT, _("Client"), "client", 0);
 
     gtk_tree_view_set_search_column(GTK_TREE_VIEW(self), PEERSCOL_HOST);
 }
 
 #if HAVE_GEOIP
-static void trg_peers_tree_view_column_added(TrgTreeView *tv, const gchar *id) {
-	TrgPeersModel *model = TRG_PEERS_MODEL(gtk_tree_view_get_model(GTK_TREE_VIEW(tv)));
-	if (!g_strcmp0(id, "city")) {
-		trg_peers_model_add_city_column(model);
-	} else if (!g_strcmp0(id, "country")) {
-		trg_peers_model_add_country_column(model);
-	}
+static void trg_peers_tree_view_column_added(TrgTreeView *tv, const gchar *id)
+{
+    TrgPeersModel *model = TRG_PEERS_MODEL(gtk_tree_view_get_model(GTK_TREE_VIEW(tv)));
+    if (!g_strcmp0(id, "city")) {
+        trg_peers_model_add_city_column(model);
+    } else if (!g_strcmp0(id, "country")) {
+        trg_peers_model_add_country_column(model);
+    }
 }
 #endif
 
-TrgPeersTreeView *trg_peers_tree_view_new(TrgPrefs * prefs,
-                                          TrgPeersModel * model,
-                                          const gchar * configId)
+TrgPeersTreeView *trg_peers_tree_view_new(TrgPrefs *prefs, TrgPeersModel *model,
+                                          const gchar *configId)
 {
-    GObject *obj = g_object_new(TRG_TYPE_PEERS_TREE_VIEW,
-                                "config-id", configId,
-                                "prefs", prefs, NULL);
+    GObject *obj
+        = g_object_new(TRG_TYPE_PEERS_TREE_VIEW, "config-id", configId, "prefs", prefs, NULL);
 
     trg_peers_tree_view_setup_columns(TRG_PEERS_TREE_VIEW(obj), model);
 

--- a/src/trg-peers-tree-view.h
+++ b/src/trg-peers-tree-view.h
@@ -23,22 +23,21 @@
 #include <glib-object.h>
 #include <gtk/gtk.h>
 
-#include "trg-prefs.h"
 #include "trg-peers-model.h"
+#include "trg-prefs.h"
 
 G_BEGIN_DECLS
 #define TRG_TYPE_PEERS_TREE_VIEW trg_peers_tree_view_get_type()
-#define TRG_PEERS_TREE_VIEW(obj) \
-  (G_TYPE_CHECK_INSTANCE_CAST ((obj), TRG_TYPE_PEERS_TREE_VIEW, TrgPeersTreeView))
-#define TRG_PEERS_TREE_VIEW_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_CAST ((klass), TRG_TYPE_PEERS_TREE_VIEW, TrgPeersTreeViewClass))
-#define TRG_IS_PEERS_TREE_VIEW(obj) \
-  (G_TYPE_CHECK_INSTANCE_TYPE ((obj), TRG_TYPE_PEERS_TREE_VIEW))
-#define TRG_IS_PEERS_TREE_VIEW_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_TYPE ((klass), TRG_TYPE_PEERS_TREE_VIEW))
-#define TRG_PEERS_TREE_VIEW_GET_CLASS(obj) \
-  (G_TYPE_INSTANCE_GET_CLASS ((obj), TRG_TYPE_PEERS_TREE_VIEW, TrgPeersTreeViewClass))
-    typedef struct {
+#define TRG_PEERS_TREE_VIEW(obj)                                                                   \
+    (G_TYPE_CHECK_INSTANCE_CAST((obj), TRG_TYPE_PEERS_TREE_VIEW, TrgPeersTreeView))
+#define TRG_PEERS_TREE_VIEW_CLASS(klass)                                                           \
+    (G_TYPE_CHECK_CLASS_CAST((klass), TRG_TYPE_PEERS_TREE_VIEW, TrgPeersTreeViewClass))
+#define TRG_IS_PEERS_TREE_VIEW(obj) (G_TYPE_CHECK_INSTANCE_TYPE((obj), TRG_TYPE_PEERS_TREE_VIEW))
+#define TRG_IS_PEERS_TREE_VIEW_CLASS(klass)                                                        \
+    (G_TYPE_CHECK_CLASS_TYPE((klass), TRG_TYPE_PEERS_TREE_VIEW))
+#define TRG_PEERS_TREE_VIEW_GET_CLASS(obj)                                                         \
+    (G_TYPE_INSTANCE_GET_CLASS((obj), TRG_TYPE_PEERS_TREE_VIEW, TrgPeersTreeViewClass))
+typedef struct {
     TrgTreeView parent;
 } TrgPeersTreeView;
 
@@ -48,9 +47,8 @@ typedef struct {
 
 GType trg_peers_tree_view_get_type(void);
 
-TrgPeersTreeView *trg_peers_tree_view_new(TrgPrefs * prefs,
-                                          TrgPeersModel * model,
-                                          const gchar * configId);
+TrgPeersTreeView *trg_peers_tree_view_new(TrgPrefs *prefs, TrgPeersModel *model,
+                                          const gchar *configId);
 
 G_END_DECLS
-#endif                          /* TRG_PEERS_TREE_VIEW_H_ */
+#endif /* TRG_PEERS_TREE_VIEW_H_ */

--- a/src/trg-persistent-tree-view.c
+++ b/src/trg-persistent-tree-view.c
@@ -22,9 +22,9 @@
 #include <glib/gi18n.h>
 #include <gtk/gtk.h>
 
-#include "trg-prefs.h"
 #include "trg-persistent-tree-view.h"
 #include "trg-preferences-dialog.h"
+#include "trg-prefs.h"
 #include "util.h"
 
 /* A config TreeView which can save/restore simple data into the TrgConf backend.
@@ -32,15 +32,17 @@
  * to add/remove entries as well as the TreeView.
  */
 
-G_DEFINE_TYPE(TrgPersistentTreeView, trg_persistent_tree_view,
-              GTK_TYPE_BOX)
-#define GET_PRIVATE(o) \
-  (G_TYPE_INSTANCE_GET_PRIVATE ((o), TRG_TYPE_PERSISTENT_TREE_VIEW, TrgPersistentTreeViewPrivate))
-typedef struct _TrgPersistentTreeViewPrivate
- TrgPersistentTreeViewPrivate;
+G_DEFINE_TYPE(TrgPersistentTreeView, trg_persistent_tree_view, GTK_TYPE_BOX)
+#define GET_PRIVATE(o)                                                                             \
+    (G_TYPE_INSTANCE_GET_PRIVATE((o), TRG_TYPE_PERSISTENT_TREE_VIEW, TrgPersistentTreeViewPrivate))
+typedef struct _TrgPersistentTreeViewPrivate TrgPersistentTreeViewPrivate;
 
 enum {
-    PROP_0, PROP_PREFS, PROP_KEY, PROP_MODEL, PROP_CONF_FLAGS
+    PROP_0,
+    PROP_PREFS,
+    PROP_KEY,
+    PROP_MODEL,
+    PROP_CONF_FLAGS
 };
 
 struct _TrgPersistentTreeViewPrivate {
@@ -58,8 +60,7 @@ struct _TrgPersistentTreeViewPrivate {
     gint conf_flags;
 };
 
-static void selection_changed(TrgPersistentTreeView * ptv,
-                              GtkTreeSelection * selection)
+static void selection_changed(TrgPersistentTreeView *ptv, GtkTreeSelection *selection)
 {
     TrgPersistentTreeViewPrivate *priv = GET_PRIVATE(ptv);
     GtkTreeIter iter;
@@ -68,8 +69,7 @@ static void selection_changed(TrgPersistentTreeView * ptv,
     if (gtk_tree_selection_get_selected(selection, &model, &iter)) {
         GtkTreePath *path = gtk_tree_model_get_path(model, &iter);
         gtk_widget_set_sensitive(priv->upButton, gtk_tree_path_prev(path));
-        gtk_widget_set_sensitive(priv->downButton,
-                                 gtk_tree_model_iter_next(model, &iter));
+        gtk_widget_set_sensitive(priv->downButton, gtk_tree_model_iter_next(model, &iter));
         gtk_tree_path_free(path);
         gtk_widget_set_sensitive(priv->delButton, TRUE);
     } else {
@@ -79,34 +79,28 @@ static void selection_changed(TrgPersistentTreeView * ptv,
     }
 }
 
-static void selection_changed_cb(GtkTreeSelection * selection,
-                                 gpointer data)
+static void selection_changed_cb(GtkTreeSelection *selection, gpointer data)
 {
     selection_changed(TRG_PERSISTENT_TREE_VIEW(data), selection);
 }
 
-static void
-trg_persistent_tree_view_edit(GtkCellRendererText * renderer,
-                              gchar * path, gchar * new_text,
-                              gpointer user_data)
+static void trg_persistent_tree_view_edit(GtkCellRendererText *renderer, gchar *path,
+                                          gchar *new_text, gpointer user_data)
 {
-    trg_persistent_tree_view_column *cd =
-        (trg_persistent_tree_view_column *) user_data;
+    trg_persistent_tree_view_column *cd = (trg_persistent_tree_view_column *)user_data;
     TrgPersistentTreeViewPrivate *priv = GET_PRIVATE(cd->tv);
     GtkTreeModel *model = gtk_tree_view_get_model(priv->tv);
     GtkTreeIter iter;
 
     gtk_tree_model_get_iter_from_string(model, &iter, path);
-    gtk_list_store_set(GTK_LIST_STORE(model), &iter, cd->index, new_text,
-                       -1);
+    gtk_list_store_set(GTK_LIST_STORE(model), &iter, cd->index, new_text, -1);
 }
 
-static void trg_persistent_tree_view_refresh(TrgPrefs * prefs, void *wdp)
+static void trg_persistent_tree_view_refresh(TrgPrefs *prefs, void *wdp)
 {
-    trg_pref_widget_desc *wd = (trg_pref_widget_desc *) wdp;
+    trg_pref_widget_desc *wd = (trg_pref_widget_desc *)wdp;
     TrgPersistentTreeViewPrivate *priv = GET_PRIVATE(wd->widget);
-    GtkListStore *model =
-        GTK_LIST_STORE(gtk_tree_view_get_model(priv->tv));
+    GtkListStore *model = GTK_LIST_STORE(gtk_tree_view_get_model(priv->tv));
     GtkTreeIter iter;
     JsonArray *ja;
     GList *ja_list, *li;
@@ -122,28 +116,21 @@ static void trg_persistent_tree_view_refresh(TrgPrefs * prefs, void *wdp)
     ja_list = json_array_get_elements(ja);
 
     for (li = ja_list; li; li = g_list_next(li)) {
-        JsonNode *ja_node = (JsonNode *) li->data;
+        JsonNode *ja_node = (JsonNode *)li->data;
         JsonObject *jobj = json_node_get_object(ja_node);
         gtk_list_store_append(model, &iter);
         for (sli = priv->columns; sli; sli = g_slist_next(sli)) {
-            trg_persistent_tree_view_column *cd =
-                (trg_persistent_tree_view_column *) sli->data;
+            trg_persistent_tree_view_column *cd = (trg_persistent_tree_view_column *)sli->data;
             gtk_list_store_set(model, &iter, cd->index,
-                               json_object_get_string_member(jobj,
-                                                             cd->key), -1);
+                               json_object_get_string_member(jobj, cd->key), -1);
         }
     }
 
     g_list_free(ja_list);
 }
 
-static gboolean
-trg_persistent_tree_view_save_foreachfunc(GtkTreeModel *
-                                          model,
-                                          GtkTreePath *
-                                          path,
-                                          GtkTreeIter * iter,
-                                          gpointer data)
+static gboolean trg_persistent_tree_view_save_foreachfunc(GtkTreeModel *model, GtkTreePath *path,
+                                                          GtkTreeIter *iter, gpointer data)
 {
     TrgPersistentTreeViewPrivate *priv = GET_PRIVATE(data);
     JsonObject *new = json_object_new();
@@ -151,8 +138,7 @@ trg_persistent_tree_view_save_foreachfunc(GtkTreeModel *
     GSList *li;
 
     for (li = priv->columns; li; li = g_slist_next(li)) {
-        trg_persistent_tree_view_column *cd =
-            (trg_persistent_tree_view_column *) li->data;
+        trg_persistent_tree_view_column *cd = (trg_persistent_tree_view_column *)li->data;
         gtk_tree_model_get(model, iter, cd->index, &value, -1);
         json_object_set_string_member(new, cd->key, value);
         g_free(value);
@@ -163,34 +149,29 @@ trg_persistent_tree_view_save_foreachfunc(GtkTreeModel *
     return FALSE;
 }
 
-static void trg_persistent_tree_view_save(TrgPrefs * prefs, void *wdp)
+static void trg_persistent_tree_view_save(TrgPrefs *prefs, void *wdp)
 {
-    trg_pref_widget_desc *wd = (trg_pref_widget_desc *) wdp;
+    trg_pref_widget_desc *wd = (trg_pref_widget_desc *)wdp;
     TrgPersistentTreeViewPrivate *priv = GET_PRIVATE(wd->widget);
     GtkTreeModel *model = gtk_tree_view_get_model(priv->tv);
 
-    JsonNode *node = trg_prefs_get_value(prefs, wd->key, JSON_NODE_ARRAY,
-                                         wd->flags |
-                                         TRG_PREFS_REPLACENODE);
+    JsonNode *node
+        = trg_prefs_get_value(prefs, wd->key, JSON_NODE_ARRAY, wd->flags | TRG_PREFS_REPLACENODE);
 
     priv->ja = json_array_new();
 
-    gtk_tree_model_foreach(model,
-                           trg_persistent_tree_view_save_foreachfunc,
-                           wd->widget);
+    gtk_tree_model_foreach(model, trg_persistent_tree_view_save_foreachfunc, wd->widget);
     json_node_take_array(node, priv->ja);
 
     trg_prefs_changed_emit_signal(prefs, wd->key);
 }
 
-trg_persistent_tree_view_column
-    * trg_persistent_tree_view_add_column(TrgPersistentTreeView * ptv,
-                                          gint index, const gchar * key,
-                                          const gchar * label)
+trg_persistent_tree_view_column *trg_persistent_tree_view_add_column(TrgPersistentTreeView *ptv,
+                                                                     gint index, const gchar *key,
+                                                                     const gchar *label)
 {
     TrgPersistentTreeViewPrivate *priv = GET_PRIVATE(ptv);
-    trg_persistent_tree_view_column *cd =
-        g_new0(trg_persistent_tree_view_column, 1);
+    trg_persistent_tree_view_column *cd = g_new0(trg_persistent_tree_view_column, 1);
     GtkCellRenderer *renderer;
 
     cd->key = g_strdup(key);
@@ -200,11 +181,9 @@ trg_persistent_tree_view_column
 
     renderer = gtk_cell_renderer_text_new();
     g_object_set(G_OBJECT(renderer), "editable", TRUE, NULL);
-    g_signal_connect(renderer, "edited",
-                     G_CALLBACK(trg_persistent_tree_view_edit), cd);
-    cd->column = gtk_tree_view_column_new_with_attributes(cd->label,
-                                                          renderer, "text",
-                                                          cd->index, NULL);
+    g_signal_connect(renderer, "edited", G_CALLBACK(trg_persistent_tree_view_edit), cd);
+    cd->column
+        = gtk_tree_view_column_new_with_attributes(cd->label, renderer, "text", cd->index, NULL);
     gtk_tree_view_column_set_resizable(cd->column, TRUE);
     gtk_tree_view_append_column(GTK_TREE_VIEW(priv->tv), cd->column);
 
@@ -213,9 +192,8 @@ trg_persistent_tree_view_column
     return cd;
 }
 
-static GtkTreeView
-    * trg_persistent_tree_view_tree_view_new(TrgPersistentTreeView * ptv,
-                                             GtkTreeModel * model)
+static GtkTreeView *trg_persistent_tree_view_tree_view_new(TrgPersistentTreeView *ptv,
+                                                           GtkTreeModel *model)
 {
     GtkTreeView *tv = GTK_TREE_VIEW(gtk_tree_view_new_with_model(model));
     GtkTreeSelection *selection;
@@ -226,13 +204,12 @@ static GtkTreeView
 
     selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(tv));
 
-    g_signal_connect(G_OBJECT(selection), "changed",
-                     G_CALLBACK(selection_changed_cb), ptv);
+    g_signal_connect(G_OBJECT(selection), "changed", G_CALLBACK(selection_changed_cb), ptv);
 
     return tv;
 }
 
-static void trg_persistent_tree_view_add_cb(GtkWidget * w, gpointer data)
+static void trg_persistent_tree_view_add_cb(GtkWidget *w, gpointer data)
 {
     TrgPersistentTreeViewPrivate *priv = GET_PRIVATE(data);
     GtkTreeModel *model = gtk_tree_view_get_model(priv->tv);
@@ -243,13 +220,12 @@ static void trg_persistent_tree_view_add_cb(GtkWidget * w, gpointer data)
     path = gtk_tree_model_get_path(model, &iter);
 
     if (priv->addSelect)
-        gtk_tree_view_set_cursor(priv->tv, path, priv->addSelect->column,
-                                 TRUE);
+        gtk_tree_view_set_cursor(priv->tv, path, priv->addSelect->column, TRUE);
 
     gtk_tree_path_free(path);
 }
 
-static void trg_persistent_tree_view_up_cb(GtkWidget * w, gpointer data)
+static void trg_persistent_tree_view_up_cb(GtkWidget *w, gpointer data)
 {
     TrgPersistentTreeViewPrivate *priv = GET_PRIVATE(data);
     GtkTreeSelection *selection = gtk_tree_view_get_selection(priv->tv);
@@ -259,17 +235,15 @@ static void trg_persistent_tree_view_up_cb(GtkWidget * w, gpointer data)
 
     if (gtk_tree_selection_get_selected(selection, &model, &iter)) {
         path = gtk_tree_model_get_path(model, &iter);
-        if (gtk_tree_path_prev(path) &&
-            gtk_tree_model_get_iter(model, &prevIter, path)) {
-            gtk_list_store_move_before(GTK_LIST_STORE(model), &iter,
-                                       &prevIter);
+        if (gtk_tree_path_prev(path) && gtk_tree_model_get_iter(model, &prevIter, path)) {
+            gtk_list_store_move_before(GTK_LIST_STORE(model), &iter, &prevIter);
             selection_changed(TRG_PERSISTENT_TREE_VIEW(data), selection);
         }
         gtk_tree_path_free(path);
     }
 }
 
-static void trg_persistent_tree_view_down_cb(GtkWidget * w, gpointer data)
+static void trg_persistent_tree_view_down_cb(GtkWidget *w, gpointer data)
 {
     TrgPersistentTreeViewPrivate *priv = GET_PRIVATE(data);
     GtkTreeSelection *selection = gtk_tree_view_get_selection(priv->tv);
@@ -279,14 +253,13 @@ static void trg_persistent_tree_view_down_cb(GtkWidget * w, gpointer data)
     if (gtk_tree_selection_get_selected(selection, &model, &iter)) {
         nextIter = iter;
         if (gtk_tree_model_iter_next(model, &nextIter)) {
-            gtk_list_store_move_after(GTK_LIST_STORE(model), &iter,
-                                      &nextIter);
+            gtk_list_store_move_after(GTK_LIST_STORE(model), &iter, &nextIter);
             selection_changed(TRG_PERSISTENT_TREE_VIEW(data), selection);
         }
     }
 }
 
-static void trg_persistent_tree_view_del_cb(GtkWidget * w, gpointer data)
+static void trg_persistent_tree_view_del_cb(GtkWidget *w, gpointer data)
 {
     TrgPersistentTreeViewPrivate *priv = GET_PRIVATE(data);
     GtkTreeSelection *selection = gtk_tree_view_get_selection(priv->tv);
@@ -297,10 +270,8 @@ static void trg_persistent_tree_view_del_cb(GtkWidget * w, gpointer data)
         gtk_list_store_remove(GTK_LIST_STORE(model), &iter);
 }
 
-static void
-trg_persistent_tree_view_get_property(GObject * object,
-                                      guint property_id,
-                                      GValue * value, GParamSpec * pspec)
+static void trg_persistent_tree_view_get_property(GObject *object, guint property_id, GValue *value,
+                                                  GParamSpec *pspec)
 {
     switch (property_id) {
     default:
@@ -309,11 +280,8 @@ trg_persistent_tree_view_get_property(GObject * object,
     }
 }
 
-static void
-trg_persistent_tree_view_set_property(GObject * object,
-                                      guint property_id,
-                                      const GValue * value,
-                                      GParamSpec * pspec)
+static void trg_persistent_tree_view_set_property(GObject *object, guint property_id,
+                                                  const GValue *value, GParamSpec *pspec)
 {
     TrgPersistentTreeViewPrivate *priv = GET_PRIVATE(object);
     switch (property_id) {
@@ -327,98 +295,80 @@ trg_persistent_tree_view_set_property(GObject * object,
         priv->model = g_value_get_object(value);
         break;
     case PROP_CONF_FLAGS:
-    	priv->conf_flags = g_value_get_int(value);
-    	break;
+        priv->conf_flags = g_value_get_int(value);
+        break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, property_id, pspec);
         break;
     }
 }
 
-static void trg_persistent_tree_view_finalize(GObject * object)
+static void trg_persistent_tree_view_finalize(GObject *object)
 {
     TrgPersistentTreeViewPrivate *priv = GET_PRIVATE(object);
     GSList *li;
     for (li = priv->columns; li; li = g_slist_next(li)) {
-        trg_persistent_tree_view_column *cd =
-            (trg_persistent_tree_view_column *) li->data;
+        trg_persistent_tree_view_column *cd = (trg_persistent_tree_view_column *)li->data;
         g_free(cd->key);
         g_free(cd->label);
         g_free(cd);
     }
     g_slist_free(priv->columns);
     g_free(priv->key);
-    G_OBJECT_CLASS(trg_persistent_tree_view_parent_class)->finalize
-        (object);
+    G_OBJECT_CLASS(trg_persistent_tree_view_parent_class)->finalize(object);
 }
 
-trg_pref_widget_desc
-    * trg_persistent_tree_view_get_widget_desc(TrgPersistentTreeView * ptv)
+trg_pref_widget_desc *trg_persistent_tree_view_get_widget_desc(TrgPersistentTreeView *ptv)
 {
     TrgPersistentTreeViewPrivate *priv = GET_PRIVATE(ptv);
     return priv->wd;
 }
 
-void
-trg_persistent_tree_view_set_add_select(TrgPersistentTreeView * ptv,
-                                        trg_persistent_tree_view_column *
-                                        cd)
+void trg_persistent_tree_view_set_add_select(TrgPersistentTreeView *ptv,
+                                             trg_persistent_tree_view_column *cd)
 {
     TrgPersistentTreeViewPrivate *priv = GET_PRIVATE(ptv);
     priv->addSelect = cd;
 }
 
-static GObject *trg_persistent_tree_view_constructor(GType type,
-                                                     guint
-                                                     n_construct_properties,
-                                                     GObjectConstructParam
-                                                     * construct_params)
+static GObject *trg_persistent_tree_view_constructor(GType type, guint n_construct_properties,
+                                                     GObjectConstructParam *construct_params)
 {
     GObject *object;
     TrgPersistentTreeViewPrivate *priv;
     GtkWidget *hbox, *w;
 
-    object = G_OBJECT_CLASS
-        (trg_persistent_tree_view_parent_class)->constructor(type,
-                                                             n_construct_properties,
-                                                             construct_params);
+    object = G_OBJECT_CLASS(trg_persistent_tree_view_parent_class)
+                 ->constructor(type, n_construct_properties, construct_params);
     priv = GET_PRIVATE(object);
 
     hbox = trg_hbox_new(FALSE, 0);
 
     w = gtk_button_new_with_label(_("Add"));
-    g_signal_connect(w, "clicked",
-                     G_CALLBACK(trg_persistent_tree_view_add_cb), object);
+    g_signal_connect(w, "clicked", G_CALLBACK(trg_persistent_tree_view_add_cb), object);
     gtk_box_pack_start(GTK_BOX(hbox), w, FALSE, FALSE, 4);
 
     w = priv->delButton = gtk_button_new_with_label(_("Delete"));
     gtk_widget_set_sensitive(w, FALSE);
-    g_signal_connect(w, "clicked",
-                     G_CALLBACK(trg_persistent_tree_view_del_cb), object);
+    g_signal_connect(w, "clicked", G_CALLBACK(trg_persistent_tree_view_del_cb), object);
     gtk_box_pack_start(GTK_BOX(hbox), w, FALSE, FALSE, 4);
 
     w = priv->upButton = gtk_button_new_with_label(_("Up"));
     gtk_widget_set_sensitive(w, FALSE);
-    g_signal_connect(w, "clicked",
-                     G_CALLBACK(trg_persistent_tree_view_up_cb), object);
+    g_signal_connect(w, "clicked", G_CALLBACK(trg_persistent_tree_view_up_cb), object);
     gtk_box_pack_start(GTK_BOX(hbox), w, FALSE, FALSE, 4);
 
     w = priv->downButton = gtk_button_new_with_label(_("Down"));
     gtk_widget_set_sensitive(w, FALSE);
-    g_signal_connect(w, "clicked",
-                     G_CALLBACK(trg_persistent_tree_view_down_cb), object);
+    g_signal_connect(w, "clicked", G_CALLBACK(trg_persistent_tree_view_down_cb), object);
     gtk_box_pack_start(GTK_BOX(hbox), w, FALSE, FALSE, 4);
 
-    priv->tv =
-        trg_persistent_tree_view_tree_view_new(TRG_PERSISTENT_TREE_VIEW
-                                               (object), priv->model);
-    gtk_box_pack_start(GTK_BOX(object),
-                       my_scrolledwin_new(GTK_WIDGET(priv->tv)), TRUE,
-                       TRUE, 4);
+    priv->tv
+        = trg_persistent_tree_view_tree_view_new(TRG_PERSISTENT_TREE_VIEW(object), priv->model);
+    gtk_box_pack_start(GTK_BOX(object), my_scrolledwin_new(GTK_WIDGET(priv->tv)), TRUE, TRUE, 4);
     gtk_box_pack_start(GTK_BOX(object), hbox, FALSE, FALSE, 4);
 
-    priv->wd = trg_pref_widget_desc_new(GTK_WIDGET(priv->tv), priv->key,
-                                        priv->conf_flags);
+    priv->wd = trg_pref_widget_desc_new(GTK_WIDGET(priv->tv), priv->key, priv->conf_flags);
     priv->wd->widget = GTK_WIDGET(object);
     priv->wd->saveFunc = &trg_persistent_tree_view_save;
     priv->wd->refreshFunc = &trg_persistent_tree_view_refresh;
@@ -426,8 +376,7 @@ static GObject *trg_persistent_tree_view_constructor(GType type,
     return object;
 }
 
-static void
-trg_persistent_tree_view_class_init(TrgPersistentTreeViewClass * klass)
+static void trg_persistent_tree_view_class_init(TrgPersistentTreeViewClass *klass)
 {
     GObjectClass *object_class = G_OBJECT_CLASS(klass);
 
@@ -438,80 +387,43 @@ trg_persistent_tree_view_class_init(TrgPersistentTreeViewClass * klass)
     object_class->finalize = trg_persistent_tree_view_finalize;
     object_class->constructor = trg_persistent_tree_view_constructor;
 
-    g_object_class_install_property(object_class,
-                                    PROP_KEY,
-                                    g_param_spec_pointer("conf-key",
-                                                         "Conf Key",
-                                                         "Conf Key",
-                                                         G_PARAM_READWRITE
-                                                         |
-                                                         G_PARAM_CONSTRUCT_ONLY
-                                                         |
-                                                         G_PARAM_STATIC_NAME
-                                                         |
-                                                         G_PARAM_STATIC_NICK
-                                                         |
-                                                         G_PARAM_STATIC_BLURB));
+    g_object_class_install_property(
+        object_class, PROP_KEY,
+        g_param_spec_pointer("conf-key", "Conf Key", "Conf Key",
+                             G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME
+                                 | G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
 
-    g_object_class_install_property(object_class,
-                                    PROP_PREFS,
-                                    g_param_spec_object("prefs",
-                                                        "Prefs",
-                                                        "Prefs",
-                                                        TRG_TYPE_PREFS,
-                                                        G_PARAM_READWRITE |
-                                                        G_PARAM_CONSTRUCT_ONLY
-                                                        |
-                                                        G_PARAM_STATIC_NAME
-                                                        |
-                                                        G_PARAM_STATIC_NICK
-                                                        |
-                                                        G_PARAM_STATIC_BLURB));
+    g_object_class_install_property(
+        object_class, PROP_PREFS,
+        g_param_spec_object("prefs", "Prefs", "Prefs", TRG_TYPE_PREFS,
+                            G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME
+                                | G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
 
-    g_object_class_install_property(object_class,
-                                    PROP_CONF_FLAGS,
-                                    g_param_spec_int("conf-flags",
-                                                     "Conf Flags",
-                                                     "Conf Flags",
-                                                     INT_MIN,
-                                                     INT_MAX,
-                                                     TRG_PREFS_PROFILE,
-                                                     G_PARAM_READWRITE |
-                                                     G_PARAM_CONSTRUCT_ONLY |
-                                                     G_PARAM_STATIC_NAME |
-                                                     G_PARAM_STATIC_NICK |
-                                                     G_PARAM_STATIC_BLURB));
+    g_object_class_install_property(object_class, PROP_CONF_FLAGS,
+                                    g_param_spec_int("conf-flags", "Conf Flags", "Conf Flags",
+                                                     INT_MIN, INT_MAX, TRG_PREFS_PROFILE,
+                                                     G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY
+                                                         | G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK
+                                                         | G_PARAM_STATIC_BLURB));
 
-    g_object_class_install_property(object_class,
-                                    PROP_MODEL,
-                                    g_param_spec_object("persistent-model",
-                                                        "Persistent Model",
-                                                        "Persistent Model",
-                                                        GTK_TYPE_LIST_STORE,
-                                                        G_PARAM_READWRITE |
-                                                        G_PARAM_CONSTRUCT_ONLY
-                                                        |
-                                                        G_PARAM_STATIC_NAME
-                                                        |
-                                                        G_PARAM_STATIC_NICK
-                                                        |
-                                                        G_PARAM_STATIC_BLURB));
+    g_object_class_install_property(
+        object_class, PROP_MODEL,
+        g_param_spec_object("persistent-model", "Persistent Model", "Persistent Model",
+                            GTK_TYPE_LIST_STORE,
+                            G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME
+                                | G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
 }
 
-static void trg_persistent_tree_view_init(TrgPersistentTreeView * self)
+static void trg_persistent_tree_view_init(TrgPersistentTreeView *self)
 {
 }
 
-TrgPersistentTreeView *trg_persistent_tree_view_new(TrgPrefs * prefs,
-                                                    GtkListStore * model,
-                                                    const gchar * key, gint conf_flags)
+TrgPersistentTreeView *trg_persistent_tree_view_new(TrgPrefs *prefs, GtkListStore *model,
+                                                    const gchar *key, gint conf_flags)
 {
-    GObject *obj =
-        g_object_new(TRG_TYPE_PERSISTENT_TREE_VIEW, "prefs", prefs,
-                     "conf-key", key, "persistent-model",
-                     model, "conf-flags", conf_flags,
-                     "orientation", GTK_ORIENTATION_VERTICAL,
-                     NULL);
+    GObject *obj = g_object_new(TRG_TYPE_PERSISTENT_TREE_VIEW, "prefs", prefs, "conf-key", key,
+                                "persistent-model", model, "conf-flags", conf_flags, "orientation",
+                                GTK_ORIENTATION_VERTICAL, NULL);
 
     return TRG_PERSISTENT_TREE_VIEW(obj);
 }

--- a/src/trg-persistent-tree-view.h
+++ b/src/trg-persistent-tree-view.h
@@ -20,24 +20,24 @@
 #ifndef _TRG_PERSISTENT_TREE_VIEW
 #define _TRG_PERSISTENT_TREE_VIEW
 
-#include <gtk/gtk.h>
 #include <glib-object.h>
+#include <gtk/gtk.h>
 
 #include "trg-preferences-dialog.h"
 
 G_BEGIN_DECLS
 #define TRG_TYPE_PERSISTENT_TREE_VIEW trg_persistent_tree_view_get_type()
-#define TRG_PERSISTENT_TREE_VIEW(obj) \
-  (G_TYPE_CHECK_INSTANCE_CAST ((obj), TRG_TYPE_PERSISTENT_TREE_VIEW, TrgPersistentTreeView))
-#define TRG_PERSISTENT_TREE_VIEW_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_CAST ((klass), TRG_TYPE_PERSISTENT_TREE_VIEW, TrgPersistentTreeViewClass))
-#define TRG_IS_PERSISTENT_TREE_VIEW(obj) \
-  (G_TYPE_CHECK_INSTANCE_TYPE ((obj), TRG_TYPE_PERSISTENT_TREE_VIEW))
-#define TRG_IS_PERSISTENT_TREE_VIEW_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_TYPE ((klass), TRG_TYPE_PERSISTENT_TREE_VIEW))
-#define TRG_PERSISTENT_TREE_VIEW_GET_CLASS(obj) \
-  (G_TYPE_INSTANCE_GET_CLASS ((obj), TRG_TYPE_PERSISTENT_TREE_VIEW, TrgPersistentTreeViewClass))
-    typedef struct {
+#define TRG_PERSISTENT_TREE_VIEW(obj)                                                              \
+    (G_TYPE_CHECK_INSTANCE_CAST((obj), TRG_TYPE_PERSISTENT_TREE_VIEW, TrgPersistentTreeView))
+#define TRG_PERSISTENT_TREE_VIEW_CLASS(klass)                                                      \
+    (G_TYPE_CHECK_CLASS_CAST((klass), TRG_TYPE_PERSISTENT_TREE_VIEW, TrgPersistentTreeViewClass))
+#define TRG_IS_PERSISTENT_TREE_VIEW(obj)                                                           \
+    (G_TYPE_CHECK_INSTANCE_TYPE((obj), TRG_TYPE_PERSISTENT_TREE_VIEW))
+#define TRG_IS_PERSISTENT_TREE_VIEW_CLASS(klass)                                                   \
+    (G_TYPE_CHECK_CLASS_TYPE((klass), TRG_TYPE_PERSISTENT_TREE_VIEW))
+#define TRG_PERSISTENT_TREE_VIEW_GET_CLASS(obj)                                                    \
+    (G_TYPE_INSTANCE_GET_CLASS((obj), TRG_TYPE_PERSISTENT_TREE_VIEW, TrgPersistentTreeViewClass))
+typedef struct {
     GtkVBox parent;
 } TrgPersistentTreeView;
 
@@ -55,22 +55,17 @@ typedef struct {
     gint index;
 } trg_persistent_tree_view_column;
 
-TrgPersistentTreeView *trg_persistent_tree_view_new(TrgPrefs * prefs,
-                                                    GtkListStore * model,
-                                                    const gchar * key, gint conf_flags);
+TrgPersistentTreeView *trg_persistent_tree_view_new(TrgPrefs *prefs, GtkListStore *model,
+                                                    const gchar *key, gint conf_flags);
 
-trg_pref_widget_desc
-    * trg_persistent_tree_view_get_widget_desc(TrgPersistentTreeView *
-                                               ptv);
+trg_pref_widget_desc *trg_persistent_tree_view_get_widget_desc(TrgPersistentTreeView *ptv);
 
-void trg_persistent_tree_view_set_add_select(TrgPersistentTreeView * ptv,
-                                             trg_persistent_tree_view_column
-                                             * cd);
+void trg_persistent_tree_view_set_add_select(TrgPersistentTreeView *ptv,
+                                             trg_persistent_tree_view_column *cd);
 
-trg_persistent_tree_view_column
-    * trg_persistent_tree_view_add_column(TrgPersistentTreeView * ptv,
-                                          gint index, const gchar * key,
-                                          const gchar * label);
+trg_persistent_tree_view_column *trg_persistent_tree_view_add_column(TrgPersistentTreeView *ptv,
+                                                                     gint index, const gchar *key,
+                                                                     const gchar *label);
 
 G_END_DECLS
-#endif                          /* _TRG_PERSISTENT_TREE_VIEW */
+#endif /* _TRG_PERSISTENT_TREE_VIEW */

--- a/src/trg-preferences-dialog.c
+++ b/src/trg-preferences-dialog.c
@@ -19,17 +19,17 @@
 
 #include "config.h"
 
+#include <glib-object.h>
 #include <glib.h>
 #include <glib/gi18n.h>
-#include <glib-object.h>
 #include <glib/gprintf.h>
 #include <gtk/gtk.h>
 
 #include "hig.h"
 #include "trg-json-widgets.h"
-#include "trg-preferences-dialog.h"
-#include "trg-persistent-tree-view.h"
 #include "trg-main-window.h"
+#include "trg-persistent-tree-view.h"
+#include "trg-preferences-dialog.h"
 #include "trg-prefs.h"
 #include "util.h"
 
@@ -40,13 +40,15 @@
  * pointer for a save/display function. These are all called on save/load.
  */
 
-#define TRG_PREFERENCES_DIALOG_GET_PRIVATE(object) \
-        (G_TYPE_INSTANCE_GET_PRIVATE ((object), TRG_TYPE_PREFERENCES_DIALOG, TrgPreferencesDialogPrivate))
+#define TRG_PREFERENCES_DIALOG_GET_PRIVATE(object)                                                 \
+    (G_TYPE_INSTANCE_GET_PRIVATE((object), TRG_TYPE_PREFERENCES_DIALOG,                            \
+                                 TrgPreferencesDialogPrivate))
 
-G_DEFINE_TYPE(TrgPreferencesDialog, trg_preferences_dialog,
-              GTK_TYPE_DIALOG)
+G_DEFINE_TYPE(TrgPreferencesDialog, trg_preferences_dialog, GTK_TYPE_DIALOG)
 enum {
-    PROP_0, PROP_TRG_CLIENT, PROP_MAIN_WINDOW
+    PROP_0,
+    PROP_TRG_CLIENT,
+    PROP_MAIN_WINDOW
 };
 
 struct _TrgPreferencesDialogPrivate {
@@ -63,14 +65,13 @@ struct _TrgPreferencesDialogPrivate {
 
 static GObject *instance = NULL;
 
-static void trg_pref_widget_desc_free(trg_pref_widget_desc * wd)
+static void trg_pref_widget_desc_free(trg_pref_widget_desc *wd)
 {
     g_free(wd->key);
     g_free(wd);
 }
 
-trg_pref_widget_desc *trg_pref_widget_desc_new(GtkWidget * w, gchar * key,
-                                               int flags)
+trg_pref_widget_desc *trg_pref_widget_desc_new(GtkWidget *w, gchar *key, int flags)
 {
     trg_pref_widget_desc *desc = g_new0(trg_pref_widget_desc, 1);
     desc->widget = w;
@@ -79,39 +80,32 @@ trg_pref_widget_desc *trg_pref_widget_desc_new(GtkWidget * w, gchar * key,
     return desc;
 }
 
-static void
-trg_pref_widget_refresh(TrgPreferencesDialog * dlg,
-                        trg_pref_widget_desc * wd)
+static void trg_pref_widget_refresh(TrgPreferencesDialog *dlg, trg_pref_widget_desc *wd)
 {
-    TrgPreferencesDialogPrivate *priv =
-        TRG_PREFERENCES_DIALOG_GET_PRIVATE(dlg);
+    TrgPreferencesDialogPrivate *priv = TRG_PREFERENCES_DIALOG_GET_PRIVATE(dlg);
 
     wd->refreshFunc(priv->prefs, wd);
 }
 
-static void trg_pref_widget_refresh_all(TrgPreferencesDialog * dlg)
+static void trg_pref_widget_refresh_all(TrgPreferencesDialog *dlg)
 {
-    TrgPreferencesDialogPrivate *priv =
-        TRG_PREFERENCES_DIALOG_GET_PRIVATE(dlg);
+    TrgPreferencesDialogPrivate *priv = TRG_PREFERENCES_DIALOG_GET_PRIVATE(dlg);
 
     GList *li;
     for (li = priv->widgets; li; li = g_list_next(li))
-        trg_pref_widget_refresh(dlg, (trg_pref_widget_desc *) li->data);
+        trg_pref_widget_refresh(dlg, (trg_pref_widget_desc *)li->data);
 }
 
-static void
-trg_pref_widget_save(TrgPreferencesDialog * dlg, trg_pref_widget_desc * wd)
+static void trg_pref_widget_save(TrgPreferencesDialog *dlg, trg_pref_widget_desc *wd)
 {
-    TrgPreferencesDialogPrivate *priv =
-        TRG_PREFERENCES_DIALOG_GET_PRIVATE(dlg);
+    TrgPreferencesDialogPrivate *priv = TRG_PREFERENCES_DIALOG_GET_PRIVATE(dlg);
 
     wd->saveFunc(priv->prefs, wd);
 }
 
-static void trg_pref_widget_save_all(TrgPreferencesDialog * dlg)
+static void trg_pref_widget_save_all(TrgPreferencesDialog *dlg)
 {
-    TrgPreferencesDialogPrivate *priv =
-        TRG_PREFERENCES_DIALOG_GET_PRIVATE(dlg);
+    TrgPreferencesDialogPrivate *priv = TRG_PREFERENCES_DIALOG_GET_PRIVATE(dlg);
     GList *li;
 
     if (trg_prefs_get_profile(priv->prefs) == NULL)
@@ -119,20 +113,16 @@ static void trg_pref_widget_save_all(TrgPreferencesDialog * dlg)
 
     trg_client_configlock(priv->client);
     for (li = priv->widgets; li; li = g_list_next(li)) {
-        trg_pref_widget_desc *wd = (trg_pref_widget_desc *) li->data;
+        trg_pref_widget_desc *wd = (trg_pref_widget_desc *)li->data;
         trg_pref_widget_save(dlg, wd);
     }
     trg_client_configunlock(priv->client);
 }
 
-static void
-trg_preferences_dialog_set_property(GObject * object,
-                                    guint prop_id,
-                                    const GValue * value,
-                                    GParamSpec * pspec G_GNUC_UNUSED)
+static void trg_preferences_dialog_set_property(GObject *object, guint prop_id, const GValue *value,
+                                                GParamSpec *pspec G_GNUC_UNUSED)
 {
-    TrgPreferencesDialogPrivate *priv =
-        TRG_PREFERENCES_DIALOG_GET_PRIVATE(object);
+    TrgPreferencesDialogPrivate *priv = TRG_PREFERENCES_DIALOG_GET_PRIVATE(object);
 
     switch (prop_id) {
     case PROP_MAIN_WINDOW:
@@ -145,12 +135,9 @@ trg_preferences_dialog_set_property(GObject * object,
     }
 }
 
-static void
-trg_preferences_response_cb(GtkDialog * dlg, gint res_id,
-                            gpointer data G_GNUC_UNUSED)
+static void trg_preferences_response_cb(GtkDialog *dlg, gint res_id, gpointer data G_GNUC_UNUSED)
 {
-    TrgPreferencesDialogPrivate *priv =
-        TRG_PREFERENCES_DIALOG_GET_PRIVATE(dlg);
+    TrgPreferencesDialogPrivate *priv = TRG_PREFERENCES_DIALOG_GET_PRIVATE(dlg);
     GList *li;
 
     if (res_id == GTK_RESPONSE_OK) {
@@ -161,21 +148,17 @@ trg_preferences_response_cb(GtkDialog * dlg, gint res_id,
     trg_main_window_reload_dir_aliases(priv->win);
 
     for (li = priv->widgets; li; li = g_list_next(li))
-        trg_pref_widget_desc_free((trg_pref_widget_desc *) li->data);
+        trg_pref_widget_desc_free((trg_pref_widget_desc *)li->data);
     g_list_free(priv->widgets);
 
     gtk_widget_destroy(GTK_WIDGET(dlg));
     instance = NULL;
 }
 
-static void
-trg_preferences_dialog_get_property(GObject * object,
-                                    guint prop_id,
-                                    GValue * value,
-                                    GParamSpec * pspec G_GNUC_UNUSED)
+static void trg_preferences_dialog_get_property(GObject *object, guint prop_id, GValue *value,
+                                                GParamSpec *pspec G_GNUC_UNUSED)
 {
-    TrgPreferencesDialogPrivate *priv =
-        TRG_PREFERENCES_DIALOG_GET_PRIVATE(object);
+    TrgPreferencesDialogPrivate *priv = TRG_PREFERENCES_DIALOG_GET_PRIVATE(object);
 
     switch (prop_id) {
     case PROP_MAIN_WINDOW:
@@ -187,9 +170,9 @@ trg_preferences_dialog_get_property(GObject * object,
     }
 }
 
-static void entry_refresh(TrgPrefs * prefs, void *wdp)
+static void entry_refresh(TrgPrefs *prefs, void *wdp)
 {
-    trg_pref_widget_desc *wd = (trg_pref_widget_desc *) wdp;
+    trg_pref_widget_desc *wd = (trg_pref_widget_desc *)wdp;
     gchar *value = trg_prefs_get_string(prefs, wd->key, wd->flags);
 
     if (value) {
@@ -200,20 +183,16 @@ static void entry_refresh(TrgPrefs * prefs, void *wdp)
     }
 }
 
-static void entry_save(TrgPrefs * prefs, void *wdp)
+static void entry_save(TrgPrefs *prefs, void *wdp)
 {
-    trg_pref_widget_desc *wd = (trg_pref_widget_desc *) wdp;
+    trg_pref_widget_desc *wd = (trg_pref_widget_desc *)wdp;
 
-    trg_prefs_set_string(prefs, wd->key,
-                         gtk_entry_get_text(GTK_ENTRY(wd->widget)),
-                         wd->flags);
+    trg_prefs_set_string(prefs, wd->key, gtk_entry_get_text(GTK_ENTRY(wd->widget)), wd->flags);
 }
 
-static GtkWidget *trgp_entry_new(TrgPreferencesDialog * dlg, gchar * key,
-                                 int flags)
+static GtkWidget *trgp_entry_new(TrgPreferencesDialog *dlg, gchar *key, int flags)
 {
-    TrgPreferencesDialogPrivate *priv =
-        TRG_PREFERENCES_DIALOG_GET_PRIVATE(dlg);
+    TrgPreferencesDialogPrivate *priv = TRG_PREFERENCES_DIALOG_GET_PRIVATE(dlg);
     GtkWidget *w = gtk_entry_new();
     trg_pref_widget_desc *wd = trg_pref_widget_desc_new(w, key, flags);
 
@@ -226,35 +205,30 @@ static GtkWidget *trgp_entry_new(TrgPreferencesDialog * dlg, gchar * key,
     return w;
 }
 
-static void check_refresh(TrgPrefs * prefs, void *wdp)
+static void check_refresh(TrgPrefs *prefs, void *wdp)
 {
-    trg_pref_widget_desc *wd = (trg_pref_widget_desc *) wdp;
+    trg_pref_widget_desc *wd = (trg_pref_widget_desc *)wdp;
     gboolean value = trg_prefs_get_bool(prefs, wd->key, wd->flags);
 
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(wd->widget), value);
 }
 
-static void check_save(TrgPrefs * prefs, void *wdp)
+static void check_save(TrgPrefs *prefs, void *wdp)
 {
-    trg_pref_widget_desc *wd = (trg_pref_widget_desc *) wdp;
-    trg_prefs_set_bool(prefs, wd->key,
-                       gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON
-                                                    (wd->widget)),
+    trg_pref_widget_desc *wd = (trg_pref_widget_desc *)wdp;
+    trg_prefs_set_bool(prefs, wd->key, gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(wd->widget)),
                        wd->flags);
 }
 
-static void trgp_toggle_dependent(GtkToggleButton * b, gpointer data)
+static void trgp_toggle_dependent(GtkToggleButton *b, gpointer data)
 {
-    gtk_widget_set_sensitive(GTK_WIDGET(data),
-                             gtk_toggle_button_get_active(b));
+    gtk_widget_set_sensitive(GTK_WIDGET(data), gtk_toggle_button_get_active(b));
 }
 
-static GtkWidget *trgp_check_new(TrgPreferencesDialog * dlg,
-                                 const char *mnemonic, gchar * key,
-                                 int flags, GtkToggleButton * dependency)
+static GtkWidget *trgp_check_new(TrgPreferencesDialog *dlg, const char *mnemonic, gchar *key,
+                                 int flags, GtkToggleButton *dependency)
 {
-    TrgPreferencesDialogPrivate *priv =
-        TRG_PREFERENCES_DIALOG_GET_PRIVATE(dlg);
+    TrgPreferencesDialogPrivate *priv = TRG_PREFERENCES_DIALOG_GET_PRIVATE(dlg);
 
     GtkWidget *w = gtk_check_button_new_with_mnemonic(mnemonic);
 
@@ -264,10 +238,8 @@ static GtkWidget *trgp_check_new(TrgPreferencesDialog * dlg,
     check_refresh(priv->prefs, wd);
 
     if (dependency) {
-        g_signal_connect(dependency, "toggled",
-                         G_CALLBACK(trgp_toggle_dependent), w);
-        gtk_widget_set_sensitive(w,
-                                 gtk_toggle_button_get_active(dependency));
+        g_signal_connect(dependency, "toggled", G_CALLBACK(trgp_toggle_dependent), w);
+        gtk_widget_set_sensitive(w, gtk_toggle_button_get_active(dependency));
     }
 
     priv->widgets = g_list_append(priv->widgets, wd);
@@ -275,30 +247,26 @@ static GtkWidget *trgp_check_new(TrgPreferencesDialog * dlg,
     return w;
 }
 
-static void spin_refresh(TrgPrefs * prefs, void *wdp)
+static void spin_refresh(TrgPrefs *prefs, void *wdp)
 {
-    trg_pref_widget_desc *wd = (trg_pref_widget_desc *) wdp;
+    trg_pref_widget_desc *wd = (trg_pref_widget_desc *)wdp;
     GtkWidget *widget = wd->widget;
 
     gint value = trg_prefs_get_int(prefs, wd->key, wd->flags);
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(widget), value);
 }
 
-static void spin_save(TrgPrefs * prefs, void *wdp)
+static void spin_save(TrgPrefs *prefs, void *wdp)
 {
-    trg_pref_widget_desc *wd = (trg_pref_widget_desc *) wdp;
-    trg_prefs_set_int(prefs, wd->key,
-                      gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON
-                                                       (wd->widget)),
+    trg_pref_widget_desc *wd = (trg_pref_widget_desc *)wdp;
+    trg_prefs_set_int(prefs, wd->key, gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON(wd->widget)),
                       wd->flags);
 }
 
-static GtkWidget *trgp_spin_new(TrgPreferencesDialog * dlg, gchar * key,
-                                int low, int high, int step, int flags,
-                                GtkToggleButton * dependency)
+static GtkWidget *trgp_spin_new(TrgPreferencesDialog *dlg, gchar *key, int low, int high, int step,
+                                int flags, GtkToggleButton *dependency)
 {
-    TrgPreferencesDialogPrivate *priv =
-        TRG_PREFERENCES_DIALOG_GET_PRIVATE(dlg);
+    TrgPreferencesDialogPrivate *priv = TRG_PREFERENCES_DIALOG_GET_PRIVATE(dlg);
     GtkWidget *w = gtk_spin_button_new_with_range(low, high, step);
     trg_pref_widget_desc *wd = trg_pref_widget_desc_new(w, key, flags);
 
@@ -308,10 +276,8 @@ static GtkWidget *trgp_spin_new(TrgPreferencesDialog * dlg, gchar * key,
     wd->refreshFunc = &spin_refresh;
 
     if (dependency) {
-        g_signal_connect(dependency, "toggled",
-                         G_CALLBACK(trgp_toggle_dependent), w);
-        gtk_widget_set_sensitive(w,
-                                 gtk_toggle_button_get_active(dependency));
+        g_signal_connect(dependency, "toggled", G_CALLBACK(trgp_toggle_dependent), w);
+        gtk_widget_set_sensitive(w, gtk_toggle_button_get_active(dependency));
     }
 
     spin_refresh(priv->prefs, wd);
@@ -320,23 +286,20 @@ static GtkWidget *trgp_spin_new(TrgPreferencesDialog * dlg, gchar * key,
     return w;
 }
 
-static void toggle_filter_trackers(GtkToggleButton * w, gpointer win)
+static void toggle_filter_trackers(GtkToggleButton *w, gpointer win)
 {
-    TrgStateSelector *selector =
-        trg_main_window_get_state_selector(TRG_MAIN_WINDOW(win));
-    trg_state_selector_set_show_trackers(selector,
-                                         gtk_toggle_button_get_active(w));
+    TrgStateSelector *selector = trg_main_window_get_state_selector(TRG_MAIN_WINDOW(win));
+    trg_state_selector_set_show_trackers(selector, gtk_toggle_button_get_active(w));
 }
 
-static void toggle_directories_first(GtkToggleButton * w, gpointer win){
-	TrgStateSelector *selector =
-		trg_main_window_get_state_selector(TRG_MAIN_WINDOW(win));
-	trg_state_selector_set_directories_first(selector,
-											gtk_toggle_button_get_active(w));
+static void toggle_directories_first(GtkToggleButton *w, gpointer win)
+{
+    TrgStateSelector *selector = trg_main_window_get_state_selector(TRG_MAIN_WINDOW(win));
+    trg_state_selector_set_directories_first(selector, gtk_toggle_button_get_active(w));
 }
 
 #if TRG_WITH_GRAPH
-static void toggle_graph(GtkToggleButton * w, gpointer win)
+static void toggle_graph(GtkToggleButton *w, gpointer win)
 {
     if (gtk_toggle_button_get_active(w))
         trg_main_window_add_graph(TRG_MAIN_WINDOW(win), TRUE);
@@ -345,8 +308,7 @@ static void toggle_graph(GtkToggleButton * w, gpointer win)
 }
 #endif
 
-
-static void toggle_tray_icon(GtkToggleButton * w, gpointer win)
+static void toggle_tray_icon(GtkToggleButton *w, gpointer win)
 {
     if (gtk_toggle_button_get_active(w))
         trg_main_window_add_tray(TRG_MAIN_WINDOW(win));
@@ -354,51 +316,38 @@ static void toggle_tray_icon(GtkToggleButton * w, gpointer win)
         trg_main_window_remove_tray(TRG_MAIN_WINDOW(win));
 }
 
-static void menu_bar_toggle_filter_dirs(GtkToggleButton * w, gpointer win)
+static void menu_bar_toggle_filter_dirs(GtkToggleButton *w, gpointer win)
 {
-    TrgStateSelector *selector =
-        trg_main_window_get_state_selector(TRG_MAIN_WINDOW(win));
-    trg_state_selector_set_show_dirs(selector,
-                                     gtk_toggle_button_get_active(w));
+    TrgStateSelector *selector = trg_main_window_get_state_selector(TRG_MAIN_WINDOW(win));
+    trg_state_selector_set_show_dirs(selector, gtk_toggle_button_get_active(w));
 }
 
-static void view_states_toggled_cb(GtkToggleButton * w, gpointer data)
+static void view_states_toggled_cb(GtkToggleButton *w, gpointer data)
 {
-    GtkWidget *scroll =
-        gtk_widget_get_parent(GTK_WIDGET
-                              (trg_main_window_get_state_selector
-                               (TRG_MAIN_WINDOW(data))));
+    GtkWidget *scroll = gtk_widget_get_parent(
+        GTK_WIDGET(trg_main_window_get_state_selector(TRG_MAIN_WINDOW(data))));
     trg_widget_set_visible(scroll, gtk_toggle_button_get_active(w));
 }
 
-static void notebook_toggled_cb(GtkToggleButton * b, gpointer data)
+static void notebook_toggled_cb(GtkToggleButton *b, gpointer data)
 {
-    trg_main_window_notebook_set_visible(TRG_MAIN_WINDOW(data),
-                                         gtk_toggle_button_get_active(b));
+    trg_main_window_notebook_set_visible(TRG_MAIN_WINDOW(data), gtk_toggle_button_get_active(b));
 }
 
-static void
-trgp_double_special_dependent(GtkWidget * widget, gpointer data)
+static void trgp_double_special_dependent(GtkWidget *widget, gpointer data)
 {
-    TrgPreferencesDialogPrivate *priv =
-        TRG_PREFERENCES_DIALOG_GET_PRIVATE(gtk_widget_get_toplevel
-                                           (widget));
-    gtk_widget_set_sensitive(GTK_WIDGET(data),
-                             gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON
-                                                          (widget))
-                             &&
-                             gtk_widget_get_sensitive
-                             (priv->fullUpdateCheck)
-                             &&
-                             gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON
-                                                          (priv->
-                                                           fullUpdateCheck)));
+    TrgPreferencesDialogPrivate *priv
+        = TRG_PREFERENCES_DIALOG_GET_PRIVATE(gtk_widget_get_toplevel(widget));
+    gtk_widget_set_sensitive(
+        GTK_WIDGET(data),
+        gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget))
+            && gtk_widget_get_sensitive(priv->fullUpdateCheck)
+            && gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(priv->fullUpdateCheck)));
 }
 
-static GtkWidget *trg_prefs_generalPage(TrgPreferencesDialog * dlg)
+static GtkWidget *trg_prefs_generalPage(TrgPreferencesDialog *dlg)
 {
-    TrgPreferencesDialogPrivate *priv =
-        TRG_PREFERENCES_DIALOG_GET_PRIVATE(dlg);
+    TrgPreferencesDialogPrivate *priv = TRG_PREFERENCES_DIALOG_GET_PRIVATE(dlg);
 
     GtkWidget *w, *activeOnly, *t;
     guint row = 0;
@@ -408,61 +357,48 @@ static GtkWidget *trg_prefs_generalPage(TrgPreferencesDialog * dlg)
     hig_workarea_add_section_title(t, &row, _("Updates"));
 
     activeOnly = w = trgp_check_new(dlg, _("Update active torrents only"),
-                                    TRG_PREFS_KEY_UPDATE_ACTIVE_ONLY,
-                                    TRG_PREFS_PROFILE, NULL);
+                                    TRG_PREFS_KEY_UPDATE_ACTIVE_ONLY, TRG_PREFS_PROFILE, NULL);
     hig_workarea_add_wide_control(t, &row, w);
 
-    priv->fullUpdateCheck = trgp_check_new(dlg,
-                                           _
-                                           ("Full update every (?) updates"),
-                                           TRG_PREFS_ACTIVEONLY_FULLSYNC_ENABLED,
-                                           TRG_PREFS_PROFILE,
+    priv->fullUpdateCheck = trgp_check_new(dlg, _("Full update every (?) updates"),
+                                           TRG_PREFS_ACTIVEONLY_FULLSYNC_ENABLED, TRG_PREFS_PROFILE,
                                            GTK_TOGGLE_BUTTON(activeOnly));
-    w = trgp_spin_new(dlg, TRG_PREFS_ACTIVEONLY_FULLSYNC_EVERY, 2, INT_MAX,
-                      1, TRG_PREFS_PROFILE,
+    w = trgp_spin_new(dlg, TRG_PREFS_ACTIVEONLY_FULLSYNC_EVERY, 2, INT_MAX, 1, TRG_PREFS_PROFILE,
                       GTK_TOGGLE_BUTTON(priv->fullUpdateCheck));
-    g_signal_connect(activeOnly, "toggled",
-                     G_CALLBACK(trgp_double_special_dependent), w);
+    g_signal_connect(activeOnly, "toggled", G_CALLBACK(trgp_double_special_dependent), w);
 
     hig_workarea_add_row_w(t, &row, priv->fullUpdateCheck, w, NULL);
 
-    w = trgp_spin_new(dlg, TRG_PREFS_KEY_UPDATE_INTERVAL, 1, INT_MAX, 1,
-                      TRG_PREFS_PROFILE, NULL);
+    w = trgp_spin_new(dlg, TRG_PREFS_KEY_UPDATE_INTERVAL, 1, INT_MAX, 1, TRG_PREFS_PROFILE, NULL);
     hig_workarea_add_row(t, &row, _("Update interval:"), w, NULL);
 
-    w = trgp_spin_new(dlg, TRG_PREFS_KEY_MINUPDATE_INTERVAL, 1, INT_MAX, 1,
-                      TRG_PREFS_PROFILE, NULL);
-    hig_workarea_add_row(t, &row, _("Minimised update interval:"), w,
-                         NULL);
+    w = trgp_spin_new(dlg, TRG_PREFS_KEY_MINUPDATE_INTERVAL, 1, INT_MAX, 1, TRG_PREFS_PROFILE,
+                      NULL);
+    hig_workarea_add_row(t, &row, _("Minimised update interval:"), w, NULL);
 
-    w = trgp_spin_new(dlg, TRG_PREFS_KEY_SESSION_UPDATE_INTERVAL, 1,
-                      INT_MAX, 1, TRG_PREFS_PROFILE, NULL);
+    w = trgp_spin_new(dlg, TRG_PREFS_KEY_SESSION_UPDATE_INTERVAL, 1, INT_MAX, 1, TRG_PREFS_PROFILE,
+                      NULL);
     hig_workarea_add_row(t, &row, _("Session update interval:"), w, NULL);
 
     hig_workarea_add_section_title(t, &row, _("Torrents"));
 
-    w = trgp_check_new(dlg, _("Start paused"), TRG_PREFS_KEY_START_PAUSED,
-                       TRG_PREFS_GLOBAL, NULL);
+    w = trgp_check_new(dlg, _("Start paused"), TRG_PREFS_KEY_START_PAUSED, TRG_PREFS_GLOBAL, NULL);
     hig_workarea_add_wide_control(t, &row, w);
 
-    w = trgp_check_new(dlg, _("Options dialog on add"),
-                       TRG_PREFS_KEY_ADD_OPTIONS_DIALOG, TRG_PREFS_GLOBAL,
-                       NULL);
+    w = trgp_check_new(dlg, _("Options dialog on add"), TRG_PREFS_KEY_ADD_OPTIONS_DIALOG,
+                       TRG_PREFS_GLOBAL, NULL);
     hig_workarea_add_wide_control(t, &row, w);
 
     w = trgp_check_new(dlg, _("Delete local .torrent file after adding"),
-                       TRG_PREFS_KEY_DELETE_LOCAL_TORRENT,
-                       TRG_PREFS_GLOBAL, NULL);
+                       TRG_PREFS_KEY_DELETE_LOCAL_TORRENT, TRG_PREFS_GLOBAL, NULL);
     hig_workarea_add_wide_control(t, &row, w);
-
 
     return t;
 }
 
-static void profile_changed_cb(GtkWidget * w, gpointer data)
+static void profile_changed_cb(GtkWidget *w, gpointer data)
 {
-    TrgPreferencesDialogPrivate *priv =
-        TRG_PREFERENCES_DIALOG_GET_PRIVATE(data);
+    TrgPreferencesDialogPrivate *priv = TRG_PREFERENCES_DIALOG_GET_PRIVATE(data);
     GtkTreeModel *model = gtk_combo_box_get_model(GTK_COMBO_BOX(w));
     gint n_children = gtk_tree_model_iter_n_children(model, NULL);
 
@@ -482,53 +418,45 @@ static void profile_changed_cb(GtkWidget * w, gpointer data)
     }
 }
 
-static void
-trg_prefs_profile_combo_populate(TrgPreferencesDialog * dialog,
-                                 GtkComboBox * combo, TrgPrefs * prefs)
+static void trg_prefs_profile_combo_populate(TrgPreferencesDialog *dialog, GtkComboBox *combo,
+                                             TrgPrefs *prefs)
 {
-    TrgPreferencesDialogPrivate *priv =
-        TRG_PREFERENCES_DIALOG_GET_PRIVATE(dialog);
+    TrgPreferencesDialogPrivate *priv = TRG_PREFERENCES_DIALOG_GET_PRIVATE(dialog);
 
-    gint profile_id = trg_prefs_get_int(prefs, TRG_PREFS_KEY_PROFILE_ID,
-                                        TRG_PREFS_GLOBAL);
+    gint profile_id = trg_prefs_get_int(prefs, TRG_PREFS_KEY_PROFILE_ID, TRG_PREFS_GLOBAL);
     GtkListStore *store = GTK_LIST_STORE(gtk_combo_box_get_model(combo));
-    GList *profiles =
-        json_array_get_elements(trg_prefs_get_profiles(prefs));
+    GList *profiles = json_array_get_elements(trg_prefs_get_profiles(prefs));
     GList *li;
 
     int i = 0;
     for (li = profiles; li; li = g_list_next(li)) {
-        JsonObject *profile = json_node_get_object((JsonNode *) li->data);
+        JsonObject *profile = json_node_get_object((JsonNode *)li->data);
         const gchar *name_value;
         GtkTreeIter iter;
 
         if (json_object_has_member(profile, TRG_PREFS_KEY_PROFILE_NAME)) {
-            name_value = json_object_get_string_member(profile,
-                                                       TRG_PREFS_KEY_PROFILE_NAME);
+            name_value = json_object_get_string_member(profile, TRG_PREFS_KEY_PROFILE_NAME);
         } else {
             name_value = _(TRG_PROFILE_NAME_DEFAULT);
         }
 
-        gtk_list_store_insert_with_values(store, &iter, INT_MAX, 0,
-                                          profile, 1, name_value, -1);
+        gtk_list_store_insert_with_values(store, &iter, INT_MAX, 0, profile, 1, name_value, -1);
         if (i == profile_id)
             gtk_combo_box_set_active_iter(combo, &iter);
 
         i++;
     }
 
-    gtk_widget_set_sensitive(priv->profileDelButton,
-                             g_list_length(profiles) > 1);
+    gtk_widget_set_sensitive(priv->profileDelButton, g_list_length(profiles) > 1);
 
     g_list_free(profiles);
 }
 
-static GtkWidget *trg_prefs_profile_combo_new(TrgClient * tc)
+static GtkWidget *trg_prefs_profile_combo_new(TrgClient *tc)
 {
     GtkWidget *w;
     GtkCellRenderer *r;
-    GtkListStore *store =
-        gtk_list_store_new(2, G_TYPE_POINTER, G_TYPE_STRING);
+    GtkListStore *store = gtk_list_store_new(2, G_TYPE_POINTER, G_TYPE_STRING);
 
     w = gtk_combo_box_new_with_model(GTK_TREE_MODEL(store));
     r = gtk_cell_renderer_text_new();
@@ -538,10 +466,9 @@ static GtkWidget *trg_prefs_profile_combo_new(TrgClient * tc)
     return w;
 }
 
-static void name_changed_cb(GtkWidget * w, gpointer data)
+static void name_changed_cb(GtkWidget *w, gpointer data)
 {
-    TrgPreferencesDialogPrivate *priv =
-        TRG_PREFERENCES_DIALOG_GET_PRIVATE(data);
+    TrgPreferencesDialogPrivate *priv = TRG_PREFERENCES_DIALOG_GET_PRIVATE(data);
     GtkTreeIter iter;
     GtkTreeModel *model;
     GtkComboBox *combo;
@@ -550,16 +477,14 @@ static void name_changed_cb(GtkWidget * w, gpointer data)
     model = gtk_combo_box_get_model(combo);
 
     if (gtk_combo_box_get_active_iter(combo, &iter)) {
-        gtk_list_store_set(GTK_LIST_STORE(model), &iter, 1,
-                           gtk_entry_get_text(GTK_ENTRY(w)), -1);
+        gtk_list_store_set(GTK_LIST_STORE(model), &iter, 1, gtk_entry_get_text(GTK_ENTRY(w)), -1);
     }
 }
 
-static void del_profile_cb(GtkWidget * w, gpointer data)
+static void del_profile_cb(GtkWidget *w, gpointer data)
 {
     GtkWidget *win = gtk_widget_get_toplevel(w);
-    TrgPreferencesDialogPrivate *priv =
-        TRG_PREFERENCES_DIALOG_GET_PRIVATE(win);
+    TrgPreferencesDialogPrivate *priv = TRG_PREFERENCES_DIALOG_GET_PRIVATE(win);
     TrgPrefs *prefs = priv->prefs;
     GtkComboBox *combo = GTK_COMBO_BOX(data);
     GtkTreeModel *profileModel = gtk_combo_box_get_model(combo);
@@ -575,26 +500,23 @@ static void del_profile_cb(GtkWidget * w, gpointer data)
     }
 }
 
-static void add_profile_cb(GtkWidget * w, gpointer data)
+static void add_profile_cb(GtkWidget *w, gpointer data)
 {
     GtkWidget *win = gtk_widget_get_toplevel(w);
-    TrgPreferencesDialogPrivate *priv =
-        TRG_PREFERENCES_DIALOG_GET_PRIVATE(win);
+    TrgPreferencesDialogPrivate *priv = TRG_PREFERENCES_DIALOG_GET_PRIVATE(win);
     GtkComboBox *combo = GTK_COMBO_BOX(data);
     GtkTreeModel *profileModel = gtk_combo_box_get_model(combo);
     GtkTreeIter iter;
 
     JsonObject *profile = trg_prefs_new_profile(priv->prefs);
-    gtk_list_store_insert_with_values(GTK_LIST_STORE(profileModel), &iter,
-                                      INT_MAX, 0, profile, 1,
+    gtk_list_store_insert_with_values(GTK_LIST_STORE(profileModel), &iter, INT_MAX, 0, profile, 1,
                                       _(TRG_PROFILE_NAME_DEFAULT), -1);
     gtk_combo_box_set_active_iter(combo, &iter);
 }
 
-static GtkWidget *trg_prefs_openExecPage(TrgPreferencesDialog * dlg)
+static GtkWidget *trg_prefs_openExecPage(TrgPreferencesDialog *dlg)
 {
-    TrgPreferencesDialogPrivate *priv =
-        TRG_PREFERENCES_DIALOG_GET_PRIVATE(dlg);
+    TrgPreferencesDialogPrivate *priv = TRG_PREFERENCES_DIALOG_GET_PRIVATE(dlg);
     GtkWidget *t, *l;
     TrgPersistentTreeView *ptv;
     GtkListStore *model;
@@ -607,15 +529,11 @@ static GtkWidget *trg_prefs_openExecPage(TrgPreferencesDialog * dlg)
 
     model = gtk_list_store_new(2, G_TYPE_STRING, G_TYPE_STRING);
 
-    ptv = trg_persistent_tree_view_new(priv->prefs, model,
-                                       TRG_PREFS_KEY_EXEC_COMMANDS, TRG_PREFS_CONNECTION);
-    trg_persistent_tree_view_set_add_select(ptv,
-                                            trg_persistent_tree_view_add_column
-                                            (ptv, 0,
-                                             TRG_PREFS_SUBKEY_LABEL,
-                                             _("Label")));
-    trg_persistent_tree_view_add_column(ptv, 1,
-                                        TRG_PREFS_KEY_EXEC_COMMANDS_SUBKEY_CMD,
+    ptv = trg_persistent_tree_view_new(priv->prefs, model, TRG_PREFS_KEY_EXEC_COMMANDS,
+                                       TRG_PREFS_CONNECTION);
+    trg_persistent_tree_view_set_add_select(
+        ptv, trg_persistent_tree_view_add_column(ptv, 0, TRG_PREFS_SUBKEY_LABEL, _("Label")));
+    trg_persistent_tree_view_add_column(ptv, 1, TRG_PREFS_KEY_EXEC_COMMANDS_SUBKEY_CMD,
                                         _("Command"));
     wd = trg_persistent_tree_view_get_widget_desc(ptv);
     trg_pref_widget_refresh(dlg, wd);
@@ -625,10 +543,10 @@ static GtkWidget *trg_prefs_openExecPage(TrgPreferencesDialog * dlg)
 
     l = gtk_label_new(NULL);
     gtk_label_set_markup(GTK_LABEL(l),
-            _("Documentation for commands can be found "
-              "<a href=\"https://github.com/transmission-remote-gtk/"
-              "transmission-remote-gtk/wiki/Local-Command-usage\">"
-              "here</a>"));
+                         _("Documentation for commands can be found "
+                           "<a href=\"https://github.com/transmission-remote-gtk/"
+                           "transmission-remote-gtk/wiki/Local-Command-usage\">"
+                           "here</a>"));
 
     hig_workarea_add_label_w(t, row, l);
 
@@ -636,9 +554,9 @@ static GtkWidget *trg_prefs_openExecPage(TrgPreferencesDialog * dlg)
 }
 
 #if HAVE_RSS
-static GtkWidget *trg_prefs_rss_page(TrgPreferencesDialog * dlg) {
-    TrgPreferencesDialogPrivate *priv =
-        TRG_PREFERENCES_DIALOG_GET_PRIVATE(dlg);
+static GtkWidget *trg_prefs_rss_page(TrgPreferencesDialog *dlg)
+{
+    TrgPreferencesDialogPrivate *priv = TRG_PREFERENCES_DIALOG_GET_PRIVATE(dlg);
     GtkWidget *t;
     guint row = 0;
     TrgPersistentTreeView *ptv;
@@ -647,21 +565,14 @@ static GtkWidget *trg_prefs_rss_page(TrgPreferencesDialog * dlg) {
 
     t = hig_workarea_create();
 
-    hig_workarea_add_section_title(t, &row,
-                                   _("RSS Feeds"));
+    hig_workarea_add_section_title(t, &row, _("RSS Feeds"));
 
     model = gtk_list_store_new(2, G_TYPE_STRING, G_TYPE_STRING);
 
-    ptv = trg_persistent_tree_view_new(priv->prefs, model,
-                                       TRG_PREFS_KEY_RSS, TRG_PREFS_GLOBAL);
-    trg_persistent_tree_view_set_add_select(ptv,
-                                            trg_persistent_tree_view_add_column
-                                            (ptv, 0,
-                                             TRG_PREFS_RSS_SUBKEY_ID,
-                                             _("Name")));
-    trg_persistent_tree_view_add_column(ptv, 1,
-                                        TRG_PREFS_RSS_SUBKEY_URL,
-                                        _("URL"));
+    ptv = trg_persistent_tree_view_new(priv->prefs, model, TRG_PREFS_KEY_RSS, TRG_PREFS_GLOBAL);
+    trg_persistent_tree_view_set_add_select(
+        ptv, trg_persistent_tree_view_add_column(ptv, 0, TRG_PREFS_RSS_SUBKEY_ID, _("Name")));
+    trg_persistent_tree_view_add_column(ptv, 1, TRG_PREFS_RSS_SUBKEY_URL, _("URL"));
 
     wd = trg_persistent_tree_view_get_widget_desc(ptv);
     trg_pref_widget_refresh(dlg, wd);
@@ -673,10 +584,9 @@ static GtkWidget *trg_prefs_rss_page(TrgPreferencesDialog * dlg) {
 }
 #endif
 
-static GtkWidget *trg_prefs_dirsPage(TrgPreferencesDialog * dlg)
+static GtkWidget *trg_prefs_dirsPage(TrgPreferencesDialog *dlg)
 {
-    TrgPreferencesDialogPrivate *priv =
-        TRG_PREFERENCES_DIALOG_GET_PRIVATE(dlg);
+    TrgPreferencesDialogPrivate *priv = TRG_PREFERENCES_DIALOG_GET_PRIVATE(dlg);
     GtkWidget *t;
     TrgPersistentTreeView *ptv;
     GtkListStore *model;
@@ -685,20 +595,15 @@ static GtkWidget *trg_prefs_dirsPage(TrgPreferencesDialog * dlg)
 
     t = hig_workarea_create();
 
-    hig_workarea_add_section_title(t, &row,
-                                   _("Remote Download Directories"));
+    hig_workarea_add_section_title(t, &row, _("Remote Download Directories"));
 
     model = gtk_list_store_new(2, G_TYPE_STRING, G_TYPE_STRING);
 
-    ptv = trg_persistent_tree_view_new(priv->prefs, model,
-                                       TRG_PREFS_KEY_DESTINATIONS, TRG_PREFS_CONNECTION);
-    trg_persistent_tree_view_set_add_select(ptv,
-                                            trg_persistent_tree_view_add_column
-                                            (ptv, 0,
-                                             TRG_PREFS_SUBKEY_LABEL,
-                                             _("Label")));
-    trg_persistent_tree_view_add_column(ptv, 1,
-                                        TRG_PREFS_KEY_DESTINATIONS_SUBKEY_DIR,
+    ptv = trg_persistent_tree_view_new(priv->prefs, model, TRG_PREFS_KEY_DESTINATIONS,
+                                       TRG_PREFS_CONNECTION);
+    trg_persistent_tree_view_set_add_select(
+        ptv, trg_persistent_tree_view_add_column(ptv, 0, TRG_PREFS_SUBKEY_LABEL, _("Label")));
+    trg_persistent_tree_view_add_column(ptv, 1, TRG_PREFS_KEY_DESTINATIONS_SUBKEY_DIR,
                                         _("Directory"));
     wd = trg_persistent_tree_view_get_widget_desc(ptv);
     trg_pref_widget_refresh(dlg, wd);
@@ -709,10 +614,9 @@ static GtkWidget *trg_prefs_dirsPage(TrgPreferencesDialog * dlg)
     return t;
 }
 
-static GtkWidget *trg_prefs_viewPage(TrgPreferencesDialog * dlg)
+static GtkWidget *trg_prefs_viewPage(TrgPreferencesDialog *dlg)
 {
-    TrgPreferencesDialogPrivate *priv =
-        TRG_PREFERENCES_DIALOG_GET_PRIVATE(dlg);
+    TrgPreferencesDialogPrivate *priv = TRG_PREFERENCES_DIALOG_GET_PRIVATE(dlg);
 
     GtkWidget *w, *dep, *t, *tray;
     guint row = 0;
@@ -721,56 +625,43 @@ static GtkWidget *trg_prefs_viewPage(TrgPreferencesDialog * dlg)
 
     hig_workarea_add_section_title(t, &row, _("View"));
 
-    dep = w = trgp_check_new(dlg, _("State selector"),
-                             TRG_PREFS_KEY_SHOW_STATE_SELECTOR,
+    dep = w = trgp_check_new(dlg, _("State selector"), TRG_PREFS_KEY_SHOW_STATE_SELECTOR,
                              TRG_PREFS_GLOBAL, NULL);
-    g_signal_connect(G_OBJECT(w), "toggled",
-                     G_CALLBACK(view_states_toggled_cb), priv->win);
+    g_signal_connect(G_OBJECT(w), "toggled", G_CALLBACK(view_states_toggled_cb), priv->win);
     hig_workarea_add_wide_control(t, &row, w);
 
-    w = trgp_check_new(dlg, _("Directory filters"),
-                       TRG_PREFS_KEY_FILTER_DIRS, TRG_PREFS_GLOBAL,
+    w = trgp_check_new(dlg, _("Directory filters"), TRG_PREFS_KEY_FILTER_DIRS, TRG_PREFS_GLOBAL,
                        GTK_TOGGLE_BUTTON(dep));
-    g_signal_connect(G_OBJECT(w), "toggled",
-                     G_CALLBACK(menu_bar_toggle_filter_dirs), priv->win);
+    g_signal_connect(G_OBJECT(w), "toggled", G_CALLBACK(menu_bar_toggle_filter_dirs), priv->win);
     hig_workarea_add_wide_control(t, &row, w);
 
-    w = trgp_check_new(dlg, _("Tracker filters"),
-                       TRG_PREFS_KEY_FILTER_TRACKERS, TRG_PREFS_GLOBAL,
+    w = trgp_check_new(dlg, _("Tracker filters"), TRG_PREFS_KEY_FILTER_TRACKERS, TRG_PREFS_GLOBAL,
                        GTK_TOGGLE_BUTTON(dep));
-    g_signal_connect(G_OBJECT(w), "toggled",
-                     G_CALLBACK(toggle_filter_trackers), priv->win);
+    g_signal_connect(G_OBJECT(w), "toggled", G_CALLBACK(toggle_filter_trackers), priv->win);
     hig_workarea_add_wide_control(t, &row, w);
 
-	w = trgp_check_new(dlg, _("Directories first"),
-						TRG_PREFS_KEY_DIRECTORIES_FIRST, TRG_PREFS_GLOBAL,
-						GTK_TOGGLE_BUTTON(dep));
-	g_signal_connect(G_OBJECT(w), "toggled",
-					 G_CALLBACK(toggle_directories_first), priv->win);
-	hig_workarea_add_wide_control(t, &row, w);
+    w = trgp_check_new(dlg, _("Directories first"), TRG_PREFS_KEY_DIRECTORIES_FIRST,
+                       TRG_PREFS_GLOBAL, GTK_TOGGLE_BUTTON(dep));
+    g_signal_connect(G_OBJECT(w), "toggled", G_CALLBACK(toggle_directories_first), priv->win);
+    hig_workarea_add_wide_control(t, &row, w);
 
-    w = trgp_check_new(dlg, _("Torrent Details"),
-                       TRG_PREFS_KEY_SHOW_NOTEBOOK, TRG_PREFS_GLOBAL,
+    w = trgp_check_new(dlg, _("Torrent Details"), TRG_PREFS_KEY_SHOW_NOTEBOOK, TRG_PREFS_GLOBAL,
                        NULL);
-    g_signal_connect(G_OBJECT(w), "toggled",
-                     G_CALLBACK(notebook_toggled_cb), priv->win);
+    g_signal_connect(G_OBJECT(w), "toggled", G_CALLBACK(notebook_toggled_cb), priv->win);
     hig_workarea_add_wide_control(t, &row, w);
 
 #if TRG_WITH_GRAPH
-    w = trgp_check_new(dlg, _("Show graph"), TRG_PREFS_KEY_SHOW_GRAPH,
-                       TRG_PREFS_GLOBAL, GTK_TOGGLE_BUTTON(w));
-    g_signal_connect(G_OBJECT(w), "toggled", G_CALLBACK(toggle_graph),
-                     priv->win);
+    w = trgp_check_new(dlg, _("Show graph"), TRG_PREFS_KEY_SHOW_GRAPH, TRG_PREFS_GLOBAL,
+                       GTK_TOGGLE_BUTTON(w));
+    g_signal_connect(G_OBJECT(w), "toggled", G_CALLBACK(toggle_graph), priv->win);
     hig_workarea_add_wide_control(t, &row, w);
 #endif
 
-
     hig_workarea_add_section_title(t, &row, _("System Tray"));
 
-    tray = trgp_check_new(dlg, _("Show in system tray"),
-    TRG_PREFS_KEY_SYSTEM_TRAY, TRG_PREFS_GLOBAL, NULL);
-    g_signal_connect(G_OBJECT(tray), "toggled", G_CALLBACK(toggle_tray_icon),
-                     priv->win);
+    tray = trgp_check_new(dlg, _("Show in system tray"), TRG_PREFS_KEY_SYSTEM_TRAY,
+                          TRG_PREFS_GLOBAL, NULL);
+    g_signal_connect(G_OBJECT(tray), "toggled", G_CALLBACK(toggle_tray_icon), priv->win);
 
     if (!HAVE_LIBAPPINDICATOR) {
         gtk_widget_set_sensitive(tray, FALSE);
@@ -779,33 +670,28 @@ static GtkWidget *trg_prefs_viewPage(TrgPreferencesDialog * dlg)
 
     hig_workarea_add_wide_control(t, &row, tray);
 
-    w = trgp_check_new(dlg, _("Minimise to system tray"),
-    TRG_PREFS_KEY_SYSTEM_TRAY_MINIMISE,
-    TRG_PREFS_GLOBAL, NULL);
+    w = trgp_check_new(dlg, _("Minimise to system tray"), TRG_PREFS_KEY_SYSTEM_TRAY_MINIMISE,
+                       TRG_PREFS_GLOBAL, NULL);
     gtk_widget_set_sensitive(w, gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(tray)));
-    g_signal_connect(G_OBJECT(tray), "toggled",
-                     G_CALLBACK(toggle_active_arg_is_sensitive), w);
+    g_signal_connect(G_OBJECT(tray), "toggled", G_CALLBACK(toggle_active_arg_is_sensitive), w);
     hig_workarea_add_wide_control(t, &row, w);
-
 
     hig_workarea_add_section_title(t, &row, _("Notifications"));
 
-    w = trgp_check_new(dlg, _("Torrent added notifications"),
-                       TRG_PREFS_KEY_ADD_NOTIFY, TRG_PREFS_GLOBAL, NULL);
+    w = trgp_check_new(dlg, _("Torrent added notifications"), TRG_PREFS_KEY_ADD_NOTIFY,
+                       TRG_PREFS_GLOBAL, NULL);
     hig_workarea_add_wide_control(t, &row, w);
 
-    w = trgp_check_new(dlg, _("Torrent complete notifications"),
-                       TRG_PREFS_KEY_COMPLETE_NOTIFY, TRG_PREFS_GLOBAL,
-                       NULL);
+    w = trgp_check_new(dlg, _("Torrent complete notifications"), TRG_PREFS_KEY_COMPLETE_NOTIFY,
+                       TRG_PREFS_GLOBAL, NULL);
     hig_workarea_add_wide_control(t, &row, w);
 
     return t;
 }
 
-static GtkWidget *trg_prefs_serverPage(TrgPreferencesDialog * dlg)
+static GtkWidget *trg_prefs_serverPage(TrgPreferencesDialog *dlg)
 {
-    TrgPreferencesDialogPrivate *priv =
-        TRG_PREFERENCES_DIALOG_GET_PRIVATE(dlg);
+    TrgPreferencesDialogPrivate *priv = TRG_PREFERENCES_DIALOG_GET_PRIVATE(dlg);
     TrgPrefs *prefs = priv->prefs;
 
     GtkWidget *w, *t, *frame, *frameHbox, *profileLabel;
@@ -819,38 +705,31 @@ static GtkWidget *trg_prefs_serverPage(TrgPreferencesDialog * dlg)
 
     /* Profile */
 
-    priv->profileNameEntry =
-        trgp_entry_new(dlg, TRG_PREFS_KEY_PROFILE_NAME, TRG_PREFS_PROFILE);
+    priv->profileNameEntry = trgp_entry_new(dlg, TRG_PREFS_KEY_PROFILE_NAME, TRG_PREFS_PROFILE);
 
     priv->profileComboBox = trg_prefs_profile_combo_new(priv->client);
     profileLabel = gtk_label_new(_("Profile: "));
 
     profileButtonsHbox = trg_hbox_new(FALSE, 0);
     w = gtk_button_new_with_label(_("New"));
-    g_signal_connect(w, "clicked", G_CALLBACK(add_profile_cb),
-                     priv->profileComboBox);
+    g_signal_connect(w, "clicked", G_CALLBACK(add_profile_cb), priv->profileComboBox);
     gtk_box_pack_start(GTK_BOX(profileButtonsHbox), w, FALSE, FALSE, 4);
 
     priv->profileDelButton = gtk_button_new_with_label(_("Delete"));
-    g_signal_connect(priv->profileDelButton, "clicked",
-                     G_CALLBACK(del_profile_cb), priv->profileComboBox);
+    g_signal_connect(priv->profileDelButton, "clicked", G_CALLBACK(del_profile_cb),
+                     priv->profileComboBox);
     gtk_widget_set_sensitive(priv->profileDelButton, FALSE);
-    gtk_box_pack_start(GTK_BOX(profileButtonsHbox), priv->profileDelButton,
-                       FALSE, FALSE, 4);
+    gtk_box_pack_start(GTK_BOX(profileButtonsHbox), priv->profileDelButton, FALSE, FALSE, 4);
 
-    trg_prefs_profile_combo_populate(dlg,
-                                     GTK_COMBO_BOX(priv->profileComboBox),
-                                     prefs);
-    g_signal_connect(G_OBJECT(priv->profileComboBox), "changed",
-                     G_CALLBACK(profile_changed_cb), dlg);
+    trg_prefs_profile_combo_populate(dlg, GTK_COMBO_BOX(priv->profileComboBox), prefs);
+    g_signal_connect(G_OBJECT(priv->profileComboBox), "changed", G_CALLBACK(profile_changed_cb),
+                     dlg);
 
     /* Name */
 
-    g_signal_connect(priv->profileNameEntry, "changed",
-                     G_CALLBACK(name_changed_cb), dlg);
+    g_signal_connect(priv->profileNameEntry, "changed", G_CALLBACK(name_changed_cb), dlg);
 
-    hig_workarea_add_row(t, &row, _("Name:"), priv->profileNameEntry,
-                         NULL);
+    hig_workarea_add_row(t, &row, _("Name:"), priv->profileNameEntry, NULL);
 
     hig_workarea_add_wide_control(t, &row, profileButtonsHbox);
 
@@ -859,8 +738,7 @@ static GtkWidget *trg_prefs_serverPage(TrgPreferencesDialog * dlg)
     w = trgp_entry_new(dlg, TRG_PREFS_KEY_HOSTNAME, TRG_PREFS_PROFILE);
     hig_workarea_add_row(t, &row, _("Host:"), w, NULL);
 
-    w = trgp_spin_new(dlg, TRG_PREFS_KEY_PORT, 1, 65535, 1,
-                      TRG_PREFS_PROFILE, NULL);
+    w = trgp_spin_new(dlg, TRG_PREFS_KEY_PORT, 1, 65535, 1, TRG_PREFS_PROFILE, NULL);
     hig_workarea_add_row(t, &row, _("Port:"), w, NULL);
     w = trgp_entry_new(dlg, TRG_PREFS_KEY_RPC_URL_PATH, TRG_PREFS_PROFILE);
     hig_workarea_add_row(t, &row, _("RPC URL Path:"), w, NULL);
@@ -872,40 +750,34 @@ static GtkWidget *trg_prefs_serverPage(TrgPreferencesDialog * dlg)
     gtk_entry_set_visibility(GTK_ENTRY(w), FALSE);
     hig_workarea_add_row(t, &row, _("Password:"), w, NULL);
 
-    w = trgp_check_new(dlg, _("Automatically connect"),
-                       TRG_PREFS_KEY_AUTO_CONNECT, TRG_PREFS_PROFILE,
-                       NULL);
+    w = trgp_check_new(dlg, _("Automatically connect"), TRG_PREFS_KEY_AUTO_CONNECT,
+                       TRG_PREFS_PROFILE, NULL);
     hig_workarea_add_wide_control(t, &row, w);
 
 #ifndef CURL_NO_SSL
-    w = trgp_check_new(dlg, _("SSL"), TRG_PREFS_KEY_SSL, TRG_PREFS_PROFILE,
-                       NULL);
+    w = trgp_check_new(dlg, _("SSL"), TRG_PREFS_KEY_SSL, TRG_PREFS_PROFILE, NULL);
     hig_workarea_add_wide_control(t, &row, w);
-    w = trgp_check_new(dlg, _("Validate SSL Certificate"), TRG_PREFS_KEY_SSL_VALIDATE, TRG_PREFS_PROFILE,
-                       GTK_TOGGLE_BUTTON(w));
+    w = trgp_check_new(dlg, _("Validate SSL Certificate"), TRG_PREFS_KEY_SSL_VALIDATE,
+                       TRG_PREFS_PROFILE, GTK_TOGGLE_BUTTON(w));
     hig_workarea_add_wide_control(t, &row, w);
 
 #endif
 
-    w = trgp_spin_new(dlg, TRG_PREFS_KEY_TIMEOUT, 1, 3600, 1,
-                      TRG_PREFS_PROFILE, NULL);
+    w = trgp_spin_new(dlg, TRG_PREFS_KEY_TIMEOUT, 1, 3600, 1, TRG_PREFS_PROFILE, NULL);
     hig_workarea_add_row(t, &row, _("Timeout:"), w, NULL);
 
-    w = trgp_spin_new(dlg, TRG_PREFS_KEY_RETRIES, 0, 3600, 1,
-                      TRG_PREFS_PROFILE, NULL);
+    w = trgp_spin_new(dlg, TRG_PREFS_KEY_RETRIES, 0, 3600, 1, TRG_PREFS_PROFILE, NULL);
     hig_workarea_add_row(t, &row, _("Retries:"), w, NULL);
 
     hig_workarea_add_section_title(t, &row, _("Headers"));
 
     model = gtk_list_store_new(2, G_TYPE_STRING, G_TYPE_STRING);
-    ptv = trg_persistent_tree_view_new(
-        priv->prefs, model, TRG_PREFS_KEY_CUSTOM_HEADERS, TRG_PREFS_PROFILE);
-    trg_persistent_tree_view_set_add_select(ptv,
-                                             trg_persistent_tree_view_add_column (ptv, 0, TRG_PREFS_KEY_CUSTOM_HEADER_NAME,
-                                                                                  _("Name")));
-    trg_persistent_tree_view_add_column (ptv, 1,
-                                         TRG_PREFS_KEY_CUSTOM_HEADER_VALUE,
-                                         _("Value"));
+    ptv = trg_persistent_tree_view_new(priv->prefs, model, TRG_PREFS_KEY_CUSTOM_HEADERS,
+                                       TRG_PREFS_PROFILE);
+    trg_persistent_tree_view_set_add_select(
+        ptv,
+        trg_persistent_tree_view_add_column(ptv, 0, TRG_PREFS_KEY_CUSTOM_HEADER_NAME, _("Name")));
+    trg_persistent_tree_view_add_column(ptv, 1, TRG_PREFS_KEY_CUSTOM_HEADER_VALUE, _("Value"));
     wd = trg_persistent_tree_view_get_widget_desc(ptv);
     trg_pref_widget_refresh(dlg, wd);
     priv->widgets = g_list_append(priv->widgets, wd);
@@ -914,8 +786,7 @@ static GtkWidget *trg_prefs_serverPage(TrgPreferencesDialog * dlg)
     frame = gtk_frame_new(NULL);
     frameHbox = trg_hbox_new(FALSE, 2);
     gtk_box_pack_start(GTK_BOX(frameHbox), profileLabel, FALSE, FALSE, 2);
-    gtk_box_pack_start(GTK_BOX(frameHbox), priv->profileComboBox, FALSE,
-                       FALSE, 4);
+    gtk_box_pack_start(GTK_BOX(frameHbox), priv->profileComboBox, FALSE, FALSE, 4);
     gtk_frame_set_label_widget(GTK_FRAME(frame), frameHbox);
     gtk_container_set_border_width(GTK_CONTAINER(frame), 5);
     gtk_container_add(GTK_CONTAINER(frame), t);
@@ -923,71 +794,56 @@ static GtkWidget *trg_prefs_serverPage(TrgPreferencesDialog * dlg)
     return frame;
 }
 
-static GObject *trg_preferences_dialog_constructor(GType type,
-                                                   guint
-                                                   n_construct_properties,
-                                                   GObjectConstructParam *
-                                                   construct_params)
+static GObject *trg_preferences_dialog_constructor(GType type, guint n_construct_properties,
+                                                   GObjectConstructParam *construct_params)
 {
     GObject *object;
     TrgPreferencesDialogPrivate *priv;
     GtkWidget *notebook, *contentvbox;
 
-    object = G_OBJECT_CLASS
-        (trg_preferences_dialog_parent_class)->constructor(type,
-                                                           n_construct_properties,
-                                                           construct_params);
+    object = G_OBJECT_CLASS(trg_preferences_dialog_parent_class)
+                 ->constructor(type, n_construct_properties, construct_params);
     priv = TRG_PREFERENCES_DIALOG_GET_PRIVATE(object);
 
     contentvbox = gtk_dialog_get_content_area(GTK_DIALOG(object));
 
-    gtk_window_set_transient_for(GTK_WINDOW(object),
-                                 GTK_WINDOW(priv->win));
+    gtk_window_set_transient_for(GTK_WINDOW(object), GTK_WINDOW(priv->win));
     gtk_window_set_destroy_with_parent(GTK_WINDOW(object), TRUE);
-    gtk_dialog_add_button(GTK_DIALOG(object), _("_Close"),
-                          GTK_RESPONSE_CLOSE);
-    gtk_dialog_add_button(GTK_DIALOG(object), _("_OK"),
-                          GTK_RESPONSE_OK);
+    gtk_dialog_add_button(GTK_DIALOG(object), _("_Close"), GTK_RESPONSE_CLOSE);
+    gtk_dialog_add_button(GTK_DIALOG(object), _("_OK"), GTK_RESPONSE_OK);
 
     gtk_dialog_set_default_response(GTK_DIALOG(object), GTK_RESPONSE_OK);
 
     gtk_window_set_title(GTK_WINDOW(object), _("Local Preferences"));
     gtk_container_set_border_width(GTK_CONTAINER(object), GUI_PAD);
 
-    g_signal_connect(G_OBJECT(object), "response",
-                     G_CALLBACK(trg_preferences_response_cb), NULL);
+    g_signal_connect(G_OBJECT(object), "response", G_CALLBACK(trg_preferences_response_cb), NULL);
 
     notebook = priv->notebook = gtk_notebook_new();
 
     gtk_notebook_append_page(GTK_NOTEBOOK(notebook),
-                             trg_prefs_serverPage(TRG_PREFERENCES_DIALOG
-                                                  (object)),
+                             trg_prefs_serverPage(TRG_PREFERENCES_DIALOG(object)),
                              gtk_label_new(_("Connection")));
 
     gtk_notebook_append_page(GTK_NOTEBOOK(notebook),
-                             trg_prefs_generalPage(TRG_PREFERENCES_DIALOG
-                                                   (object)),
+                             trg_prefs_generalPage(TRG_PREFERENCES_DIALOG(object)),
                              gtk_label_new(_("General")));
 
     gtk_notebook_append_page(GTK_NOTEBOOK(notebook),
-                             trg_prefs_viewPage(TRG_PREFERENCES_DIALOG
-                                                (object)),
+                             trg_prefs_viewPage(TRG_PREFERENCES_DIALOG(object)),
                              gtk_label_new(_("View")));
 
     gtk_notebook_append_page(GTK_NOTEBOOK(notebook),
-                             trg_prefs_openExecPage(TRG_PREFERENCES_DIALOG
-                                                    (object)),
+                             trg_prefs_openExecPage(TRG_PREFERENCES_DIALOG(object)),
                              gtk_label_new(_("Actions")));
 
     gtk_notebook_append_page(GTK_NOTEBOOK(notebook),
-                             trg_prefs_dirsPage(TRG_PREFERENCES_DIALOG
-                                                (object)),
+                             trg_prefs_dirsPage(TRG_PREFERENCES_DIALOG(object)),
                              gtk_label_new(_("Directories")));
 
 #if HAVE_RSS
     gtk_notebook_append_page(GTK_NOTEBOOK(notebook),
-                             trg_prefs_rss_page(TRG_PREFERENCES_DIALOG
-                                                (object)),
+                             trg_prefs_rss_page(TRG_PREFERENCES_DIALOG(object)),
                              gtk_label_new(_("RSS Feeds")));
 #endif
 
@@ -998,65 +854,44 @@ static GObject *trg_preferences_dialog_constructor(GType type,
     return object;
 }
 
-void trg_preferences_dialog_set_page(TrgPreferencesDialog *pref_dlg, guint page) {
-	TrgPreferencesDialogPrivate *priv = TRG_PREFERENCES_DIALOG_GET_PRIVATE(pref_dlg);
-	gtk_notebook_set_current_page(GTK_NOTEBOOK(priv->notebook), page);
+void trg_preferences_dialog_set_page(TrgPreferencesDialog *pref_dlg, guint page)
+{
+    TrgPreferencesDialogPrivate *priv = TRG_PREFERENCES_DIALOG_GET_PRIVATE(pref_dlg);
+    gtk_notebook_set_current_page(GTK_NOTEBOOK(priv->notebook), page);
 }
 
-static void trg_preferences_dialog_init(TrgPreferencesDialog * pref_dlg)
+static void trg_preferences_dialog_init(TrgPreferencesDialog *pref_dlg)
 {
 }
 
-static void
-trg_preferences_dialog_class_init(TrgPreferencesDialogClass * class)
+static void trg_preferences_dialog_class_init(TrgPreferencesDialogClass *class)
 {
-    GObjectClass *g_object_class = (GObjectClass *) class;
+    GObjectClass *g_object_class = (GObjectClass *)class;
 
     g_object_class->constructor = trg_preferences_dialog_constructor;
     g_object_class->set_property = trg_preferences_dialog_set_property;
     g_object_class->get_property = trg_preferences_dialog_get_property;
 
-    g_object_class_install_property(g_object_class,
-                                    PROP_TRG_CLIENT,
-                                    g_param_spec_pointer("trg-client",
-                                                         "TClient",
-                                                         "Client",
-                                                         G_PARAM_READWRITE
-                                                         |
-                                                         G_PARAM_CONSTRUCT_ONLY
-                                                         |
-                                                         G_PARAM_STATIC_NAME
-                                                         |
-                                                         G_PARAM_STATIC_NICK
-                                                         |
-                                                         G_PARAM_STATIC_BLURB));
+    g_object_class_install_property(
+        g_object_class, PROP_TRG_CLIENT,
+        g_param_spec_pointer("trg-client", "TClient", "Client",
+                             G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME
+                                 | G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
 
-    g_object_class_install_property(g_object_class,
-                                    PROP_MAIN_WINDOW,
-                                    g_param_spec_object("main-window",
-                                                        "Main Window",
-                                                        "Main Window",
-                                                        TRG_TYPE_MAIN_WINDOW,
-                                                        G_PARAM_READWRITE |
-                                                        G_PARAM_CONSTRUCT_ONLY
-                                                        |
-                                                        G_PARAM_STATIC_NAME
-                                                        |
-                                                        G_PARAM_STATIC_NICK
-                                                        |
-                                                        G_PARAM_STATIC_BLURB));
+    g_object_class_install_property(
+        g_object_class, PROP_MAIN_WINDOW,
+        g_param_spec_object("main-window", "Main Window", "Main Window", TRG_TYPE_MAIN_WINDOW,
+                            G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME
+                                | G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
 
-    g_type_class_add_private(g_object_class,
-                             sizeof(TrgPreferencesDialogPrivate));
+    g_type_class_add_private(g_object_class, sizeof(TrgPreferencesDialogPrivate));
 }
 
-GtkWidget *trg_preferences_dialog_get_instance(TrgMainWindow * win,
-                                               TrgClient * client)
+GtkWidget *trg_preferences_dialog_get_instance(TrgMainWindow *win, TrgClient *client)
 {
     if (!instance)
-        instance =
-            g_object_new(TRG_TYPE_PREFERENCES_DIALOG, "main-window", win,
-                         "trg-client", client, NULL);
+        instance = g_object_new(TRG_TYPE_PREFERENCES_DIALOG, "main-window", win, "trg-client",
+                                client, NULL);
 
     return GTK_WIDGET(instance);
 }

--- a/src/trg-preferences-dialog.h
+++ b/src/trg-preferences-dialog.h
@@ -20,8 +20,8 @@
 #ifndef TRG_PREFERENCES_WINDOW_H_
 #define TRG_PREFERENCES_WINDOW_H_
 
-#include <glib.h>
 #include <glib-object.h>
+#include <glib.h>
 #include <gtk/gtk.h>
 
 #include "trg-main-window.h"
@@ -30,19 +30,24 @@ G_BEGIN_DECLS typedef struct _TrgPreferencesDialog TrgPreferencesDialog;
 typedef struct _TrgPreferencesDialogClass TrgPreferencesDialogClass;
 typedef struct _TrgPreferencesDialogPrivate TrgPreferencesDialogPrivate;
 
-#define TRG_TYPE_PREFERENCES_DIALOG            (trg_preferences_dialog_get_type ())
-#define TRG_PREFERENCES_DIALOG(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), TRG_TYPE_PREFERENCES_DIALOG, TrgPreferencesDialog))
-#define TRG_PREFERENCES_DIALOG_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass),  TRG_TYPE_PREFERENCES_DIALOG, TrgPreferencesDialogClass))
-#define TRG_IS_PREFERENCES_DIALOG(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), TRG_TYPE_PREFERENCES_DIALOG))
-#define TRG_IS_PREFERENCES_DIALOG_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass),  TRG_TYPE_PREFERENCES_DIALOG))
-#define TRG_PREFERENCES_DIALOG_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj),  TRG_TYPE_PREFERENCES_DIALOG, TrgPreferencesDialogClass))
+#define TRG_TYPE_PREFERENCES_DIALOG (trg_preferences_dialog_get_type())
+#define TRG_PREFERENCES_DIALOG(obj)                                                                \
+    (G_TYPE_CHECK_INSTANCE_CAST((obj), TRG_TYPE_PREFERENCES_DIALOG, TrgPreferencesDialog))
+#define TRG_PREFERENCES_DIALOG_CLASS(klass)                                                        \
+    (G_TYPE_CHECK_CLASS_CAST((klass), TRG_TYPE_PREFERENCES_DIALOG, TrgPreferencesDialogClass))
+#define TRG_IS_PREFERENCES_DIALOG(obj)                                                             \
+    (G_TYPE_CHECK_INSTANCE_TYPE((obj), TRG_TYPE_PREFERENCES_DIALOG))
+#define TRG_IS_PREFERENCES_DIALOG_CLASS(klass)                                                     \
+    (G_TYPE_CHECK_CLASS_TYPE((klass), TRG_TYPE_PREFERENCES_DIALOG))
+#define TRG_PREFERENCES_DIALOG_GET_CLASS(obj)                                                      \
+    (G_TYPE_INSTANCE_GET_CLASS((obj), TRG_TYPE_PREFERENCES_DIALOG, TrgPreferencesDialogClass))
 
 typedef struct {
     GtkWidget *widget;
     int flags;
     gchar *key;
-    void (*saveFunc) (TrgPrefs *, void *);
-    void (*refreshFunc) (TrgPrefs *, void *);
+    void (*saveFunc)(TrgPrefs *, void *);
+    void (*refreshFunc)(TrgPrefs *, void *);
 } trg_pref_widget_desc;
 
 struct _TrgPreferencesDialog {
@@ -56,11 +61,9 @@ struct _TrgPreferencesDialogClass {
 
 GType trg_preferences_dialog_get_type(void);
 
-GtkWidget *trg_preferences_dialog_get_instance(TrgMainWindow * win,
-                                               TrgClient * client);
-trg_pref_widget_desc *trg_pref_widget_desc_new(GtkWidget * w, gchar * key,
-                                               int flags);
+GtkWidget *trg_preferences_dialog_get_instance(TrgMainWindow *win, TrgClient *client);
+trg_pref_widget_desc *trg_pref_widget_desc_new(GtkWidget *w, gchar *key, int flags);
 void trg_preferences_dialog_set_page(TrgPreferencesDialog *pref_dlg, guint page);
 
 G_END_DECLS
-#endif                          /* TRG_PREFERENCES_WINDOW_H_ */
+#endif /* TRG_PREFERENCES_WINDOW_H_ */

--- a/src/trg-prefs.c
+++ b/src/trg-prefs.c
@@ -20,15 +20,15 @@
 #include "config.h"
 
 #include <glib.h>
-#include <glib/gstdio.h>
-#include <json-glib/json-glib.h>
 #include <glib/gi18n.h>
 #include <glib/gprintf.h>
+#include <glib/gstdio.h>
+#include <json-glib/json-glib.h>
 
-#include "util.h"
 #include "torrent.h"
 #include "trg-client.h"
 #include "trg-prefs.h"
+#include "util.h"
 
 /* I replaced GConf with this custom configuration backend for a few reasons.
  * 1) Better windows support. No dependency on DBus.
@@ -57,50 +57,45 @@ enum {
 
 static guint signals[PREFS_SIGNAL_COUNT] = { 0 };
 
-void trg_prefs_profile_change_emit_signal(TrgPrefs * p)
+void trg_prefs_profile_change_emit_signal(TrgPrefs *p)
 {
     g_signal_emit(p, signals[PREF_PROFILE_CHANGE], 0);
 }
 
-void trg_prefs_changed_emit_signal(TrgPrefs * p, const gchar * key)
+void trg_prefs_changed_emit_signal(TrgPrefs *p, const gchar *key)
 {
     g_signal_emit(p, signals[PREF_CHANGE], 0, key);
 }
 
-static void
-trg_prefs_get_property(GObject * object, guint property_id,
-                       GValue * value, GParamSpec * pspec)
+static void trg_prefs_get_property(GObject *object, guint property_id, GValue *value,
+                                   GParamSpec *pspec)
 {
     G_OBJECT_WARN_INVALID_PROPERTY_ID(object, property_id, pspec);
 }
 
-static void
-trg_prefs_set_property(GObject * object, guint property_id,
-                       const GValue * value, GParamSpec * pspec)
+static void trg_prefs_set_property(GObject *object, guint property_id, const GValue *value,
+                                   GParamSpec *pspec)
 {
     G_OBJECT_WARN_INVALID_PROPERTY_ID(object, property_id, pspec);
 }
 
-static void trg_prefs_dispose(GObject * object)
+static void trg_prefs_dispose(GObject *object)
 {
     G_OBJECT_CLASS(trg_prefs_parent_class)->dispose(object);
 }
 
-static void trg_prefs_create_defaults(TrgPrefs * p)
+static void trg_prefs_create_defaults(TrgPrefs *p)
 {
     TrgPrefsPrivate *priv = p->priv;
     priv->defaultsObj = json_object_new();
 
-    trg_prefs_add_default_string(p, TRG_PREFS_KEY_PROFILE_NAME,
-                                 _(TRG_PROFILE_NAME_DEFAULT));
+    trg_prefs_add_default_string(p, TRG_PREFS_KEY_PROFILE_NAME, _(TRG_PROFILE_NAME_DEFAULT));
     trg_prefs_add_default_string(p, TRG_PREFS_KEY_RPC_URL_PATH, "/transmission/rpc");
     trg_prefs_add_default_int(p, TRG_PREFS_KEY_PORT, 9091);
-    trg_prefs_add_default_int(p, TRG_PREFS_KEY_UPDATE_INTERVAL,
-                              TRG_INTERVAL_DEFAULT);
+    trg_prefs_add_default_int(p, TRG_PREFS_KEY_UPDATE_INTERVAL, TRG_INTERVAL_DEFAULT);
     trg_prefs_add_default_int(p, TRG_PREFS_KEY_SESSION_UPDATE_INTERVAL,
                               TRG_SESSION_INTERVAL_DEFAULT);
-    trg_prefs_add_default_int(p, TRG_PREFS_KEY_MINUPDATE_INTERVAL,
-                              TRG_INTERVAL_DEFAULT);
+    trg_prefs_add_default_int(p, TRG_PREFS_KEY_MINUPDATE_INTERVAL, TRG_INTERVAL_DEFAULT);
     trg_prefs_add_default_int(p, TRG_PREFS_ACTIVEONLY_FULLSYNC_EVERY, 2);
     trg_prefs_add_default_int(p, TRG_PREFS_KEY_STATES_PANED_POS, 120);
     trg_prefs_add_default_int(p, TRG_PREFS_KEY_TIMEOUT, 40);
@@ -112,30 +107,26 @@ static void trg_prefs_create_defaults(TrgPrefs * p)
     trg_prefs_add_default_bool_true(p, TRG_PREFS_KEY_SHOW_GRAPH);
     trg_prefs_add_default_bool_true(p, TRG_PREFS_KEY_ADD_OPTIONS_DIALOG);
     trg_prefs_add_default_bool_true(p, TRG_PREFS_KEY_SHOW_STATE_SELECTOR);
-    //trg_prefs_add_default_bool_true(p, TRG_PREFS_KEY_SHOW_NOTEBOOK);
+    // trg_prefs_add_default_bool_true(p, TRG_PREFS_KEY_SHOW_NOTEBOOK);
 }
 
-static GObject *trg_prefs_constructor(GType type,
-                                      guint n_construct_properties,
-                                      GObjectConstructParam *
-                                      construct_params)
+static GObject *trg_prefs_constructor(GType type, guint n_construct_properties,
+                                      GObjectConstructParam *construct_params)
 {
-    GObject *object = G_OBJECT_CLASS
-        (trg_prefs_parent_class)->constructor(type, n_construct_properties,
-                                              construct_params);
+    GObject *object = G_OBJECT_CLASS(trg_prefs_parent_class)
+                          ->constructor(type, n_construct_properties, construct_params);
     TrgPrefs *prefs = TRG_PREFS(object);
     TrgPrefsPrivate *priv = prefs->priv;
 
     trg_prefs_create_defaults(prefs);
 
-    priv->file = g_build_filename(g_get_user_config_dir(),
-                                  g_get_application_name(),
+    priv->file = g_build_filename(g_get_user_config_dir(), g_get_application_name(),
                                   TRG_PREFS_FILENAME, NULL);
 
     return object;
 }
 
-static void trg_prefs_class_init(TrgPrefsClass * klass)
+static void trg_prefs_class_init(TrgPrefsClass *klass)
 {
     GObjectClass *object_class = G_OBJECT_CLASS(klass);
 
@@ -146,28 +137,20 @@ static void trg_prefs_class_init(TrgPrefsClass * klass)
     object_class->dispose = trg_prefs_dispose;
     object_class->constructor = trg_prefs_constructor;
 
-    signals[PREF_CHANGE] =
-        g_signal_new("pref-changed",
-                     G_TYPE_FROM_CLASS(object_class),
-                     G_SIGNAL_RUN_LAST | G_SIGNAL_ACTION,
-                     G_STRUCT_OFFSET(TrgPrefsClass,
-                                     pref_changed), NULL,
-                     NULL, g_cclosure_marshal_VOID__POINTER,
-                     G_TYPE_NONE, 1, G_TYPE_POINTER);
+    signals[PREF_CHANGE] = g_signal_new(
+        "pref-changed", G_TYPE_FROM_CLASS(object_class), G_SIGNAL_RUN_LAST | G_SIGNAL_ACTION,
+        G_STRUCT_OFFSET(TrgPrefsClass, pref_changed), NULL, NULL, g_cclosure_marshal_VOID__POINTER,
+        G_TYPE_NONE, 1, G_TYPE_POINTER);
 
-    signals[PREF_PROFILE_CHANGE] =
-        g_signal_new("pref-profile-changed",
-                     G_TYPE_FROM_CLASS(object_class),
-                     G_SIGNAL_RUN_LAST | G_SIGNAL_ACTION,
-                     G_STRUCT_OFFSET(TrgPrefsClass,
-                                     pref_changed), NULL,
-                     NULL, g_cclosure_marshal_VOID__VOID, G_TYPE_NONE, 0);
+    signals[PREF_PROFILE_CHANGE] = g_signal_new(
+        "pref-profile-changed", G_TYPE_FROM_CLASS(object_class),
+        G_SIGNAL_RUN_LAST | G_SIGNAL_ACTION, G_STRUCT_OFFSET(TrgPrefsClass, pref_changed), NULL,
+        NULL, g_cclosure_marshal_VOID__VOID, G_TYPE_NONE, 0);
 }
 
-static void trg_prefs_init(TrgPrefs * self)
+static void trg_prefs_init(TrgPrefs *self)
 {
-    self->priv =
-        G_TYPE_INSTANCE_GET_PRIVATE(self, TRG_TYPE_PREFS, TrgPrefsPrivate);
+    self->priv = G_TYPE_INSTANCE_GET_PRIVATE(self, TRG_TYPE_PREFS, TrgPrefsPrivate);
 }
 
 TrgPrefs *trg_prefs_new(void)
@@ -180,24 +163,21 @@ static JsonObject *trg_prefs_new_profile_object(void)
     return json_object_new();
 }
 
-void trg_prefs_add_default_int(TrgPrefs * p, const gchar * key, int value)
+void trg_prefs_add_default_int(TrgPrefs *p, const gchar *key, int value)
 {
     TrgPrefsPrivate *priv = p->priv;
 
     json_object_set_int_member(priv->defaultsObj, key, value);
 }
 
-void
-trg_prefs_add_default_string(TrgPrefs * p, const gchar * key,
-                             gchar * value)
+void trg_prefs_add_default_string(TrgPrefs *p, const gchar *key, gchar *value)
 {
     TrgPrefsPrivate *priv = p->priv;
 
     json_object_set_string_member(priv->defaultsObj, key, value);
 }
 
-void
-trg_prefs_add_default_double(TrgPrefs * p, const gchar * key, double value)
+void trg_prefs_add_default_double(TrgPrefs *p, const gchar *key, double value)
 {
     TrgPrefsPrivate *priv = p->priv;
 
@@ -205,22 +185,19 @@ trg_prefs_add_default_double(TrgPrefs * p, const gchar * key, double value)
 }
 
 /* Not much point adding a default of FALSE, as that's the fallback */
-void trg_prefs_add_default_bool_true(TrgPrefs * p, const gchar * key)
+void trg_prefs_add_default_bool_true(TrgPrefs *p, const gchar *key)
 {
     TrgPrefsPrivate *priv = p->priv;
     json_object_set_boolean_member(priv->defaultsObj, key, TRUE);
 }
 
-gint trg_prefs_get_profile_id(TrgPrefs * p)
+gint trg_prefs_get_profile_id(TrgPrefs *p)
 {
     TrgPrefsPrivate *priv = p->priv;
-    return (gint) json_object_get_int_member(priv->userObj,
-                                             TRG_PREFS_KEY_PROFILE_ID);
+    return (gint)json_object_get_int_member(priv->userObj, TRG_PREFS_KEY_PROFILE_ID);
 }
 
-static JsonNode *trg_prefs_get_value_inner(JsonObject * obj,
-                                           const gchar * key, int type,
-                                           int flags)
+static JsonNode *trg_prefs_get_value_inner(JsonObject *obj, const gchar *key, int type, int flags)
 {
     if (json_object_has_member(obj, key)) {
         if ((flags & TRG_PREFS_REPLACENODE))
@@ -238,35 +215,29 @@ static JsonNode *trg_prefs_get_value_inner(JsonObject * obj,
     return NULL;
 }
 
-JsonNode *trg_prefs_get_value(TrgPrefs * p, const gchar * key, int type,
-                              int flags)
+JsonNode *trg_prefs_get_value(TrgPrefs *p, const gchar *key, int type, int flags)
 {
     TrgPrefsPrivate *priv = p->priv;
     JsonNode *res;
 
     if (priv->profile && (flags & TRG_PREFS_PROFILE)) {
-        if ((res =
-             trg_prefs_get_value_inner(priv->profile, key, type, flags)))
+        if ((res = trg_prefs_get_value_inner(priv->profile, key, type, flags)))
             return res;
     } else if (priv->connectionObj && (flags & TRG_PREFS_CONNECTION)) {
-        if ((res =
-             trg_prefs_get_value_inner(priv->connectionObj, key, type,
-                                       flags)))
+        if ((res = trg_prefs_get_value_inner(priv->connectionObj, key, type, flags)))
             return res;
     } else {
-        if ((res =
-             trg_prefs_get_value_inner(priv->userObj, key, type, flags)))
+        if ((res = trg_prefs_get_value_inner(priv->userObj, key, type, flags)))
             return res;
     }
 
-    if (priv->defaultsObj
-        && json_object_has_member(priv->defaultsObj, key))
+    if (priv->defaultsObj && json_object_has_member(priv->defaultsObj, key))
         return json_object_get_member(priv->defaultsObj, key);
 
     return NULL;
 }
 
-void trg_prefs_set_connection(TrgPrefs * p, JsonObject * profile)
+void trg_prefs_set_connection(TrgPrefs *p, JsonObject *profile)
 {
     TrgPrefsPrivate *priv = p->priv;
 
@@ -278,7 +249,7 @@ void trg_prefs_set_connection(TrgPrefs * p, JsonObject * profile)
     priv->connectionObj = profile;
 }
 
-gchar *trg_prefs_get_string(TrgPrefs * p, const gchar * key, int flags)
+gchar *trg_prefs_get_string(TrgPrefs *p, const gchar *key, int flags)
 {
     JsonNode *node = trg_prefs_get_value(p, key, JSON_NODE_VALUE, flags);
 
@@ -288,7 +259,7 @@ gchar *trg_prefs_get_string(TrgPrefs * p, const gchar * key, int flags)
         return NULL;
 }
 
-JsonArray *trg_prefs_get_array(TrgPrefs * p, const gchar * key, int flags)
+JsonArray *trg_prefs_get_array(TrgPrefs *p, const gchar *key, int flags)
 {
     JsonNode *node = trg_prefs_get_value(p, key, JSON_NODE_ARRAY, flags);
 
@@ -298,7 +269,7 @@ JsonArray *trg_prefs_get_array(TrgPrefs * p, const gchar * key, int flags)
         return NULL;
 }
 
-gint64 trg_prefs_get_int(TrgPrefs * p, const gchar * key, int flags)
+gint64 trg_prefs_get_int(TrgPrefs *p, const gchar *key, int flags)
 {
     JsonNode *node = trg_prefs_get_value(p, key, JSON_NODE_VALUE, flags);
 
@@ -308,7 +279,7 @@ gint64 trg_prefs_get_int(TrgPrefs * p, const gchar * key, int flags)
         return 0;
 }
 
-gdouble trg_prefs_get_double(TrgPrefs * p, const gchar * key, int flags)
+gdouble trg_prefs_get_double(TrgPrefs *p, const gchar *key, int flags)
 {
     JsonNode *node = trg_prefs_get_value(p, key, JSON_NODE_VALUE, flags);
     if (node)
@@ -317,7 +288,7 @@ gdouble trg_prefs_get_double(TrgPrefs * p, const gchar * key, int flags)
         return 0.0;
 }
 
-gboolean trg_prefs_get_bool(TrgPrefs * p, const gchar * key, int flags)
+gboolean trg_prefs_get_bool(TrgPrefs *p, const gchar *key, int flags)
 {
     JsonNode *node = trg_prefs_get_value(p, key, JSON_NODE_VALUE, flags);
 
@@ -327,27 +298,22 @@ gboolean trg_prefs_get_bool(TrgPrefs * p, const gchar * key, int flags)
         return FALSE;
 }
 
-void
-trg_prefs_set_int(TrgPrefs * p, const gchar * key, int value, int flags)
+void trg_prefs_set_int(TrgPrefs *p, const gchar *key, int value, int flags)
 {
-    JsonNode *node = trg_prefs_get_value(p, key, JSON_NODE_VALUE,
-                                         flags | TRG_PREFS_NEWNODE);
+    JsonNode *node = trg_prefs_get_value(p, key, JSON_NODE_VALUE, flags | TRG_PREFS_NEWNODE);
 
-    json_node_set_int(node, (gint64) value);
+    json_node_set_int(node, (gint64)value);
     trg_prefs_changed_emit_signal(p, key);
 }
 
-void
-trg_prefs_set_string(TrgPrefs * p, const gchar * key,
-                     const gchar * value, int flags)
+void trg_prefs_set_string(TrgPrefs *p, const gchar *key, const gchar *value, int flags)
 {
-    JsonNode *node = trg_prefs_get_value(p, key, JSON_NODE_VALUE,
-                                         flags | TRG_PREFS_NEWNODE);
+    JsonNode *node = trg_prefs_get_value(p, key, JSON_NODE_VALUE, flags | TRG_PREFS_NEWNODE);
     json_node_set_string(node, value);
     trg_prefs_changed_emit_signal(p, key);
 }
 
-void trg_prefs_set_profile(TrgPrefs * p, JsonObject * profile)
+void trg_prefs_set_profile(TrgPrefs *p, JsonObject *profile)
 {
     TrgPrefsPrivate *priv = p->priv;
     GList *profiles = json_array_get_elements(trg_prefs_get_profiles(p));
@@ -357,9 +323,8 @@ void trg_prefs_set_profile(TrgPrefs * p, JsonObject * profile)
     priv->profile = profile;
 
     for (li = profiles; li; li = g_list_next(li)) {
-        if (json_node_get_object((JsonNode *) li->data) == profile) {
-            trg_prefs_set_int(p, TRG_PREFS_KEY_PROFILE_ID, i,
-                              TRG_PREFS_GLOBAL);
+        if (json_node_get_object((JsonNode *)li->data) == profile) {
+            trg_prefs_set_int(p, TRG_PREFS_KEY_PROFILE_ID, i, TRG_PREFS_GLOBAL);
             break;
         }
         i++;
@@ -371,7 +336,7 @@ void trg_prefs_set_profile(TrgPrefs * p, JsonObject * profile)
     trg_prefs_profile_change_emit_signal(p);
 }
 
-JsonObject *trg_prefs_new_profile(TrgPrefs * p)
+JsonObject *trg_prefs_new_profile(TrgPrefs *p)
 {
     JsonArray *profiles = trg_prefs_get_profiles(p);
     JsonObject *newp = trg_prefs_new_profile_object();
@@ -381,7 +346,7 @@ JsonObject *trg_prefs_new_profile(TrgPrefs * p)
     return newp;
 }
 
-void trg_prefs_del_profile(TrgPrefs * p, JsonObject * profile)
+void trg_prefs_del_profile(TrgPrefs *p, JsonObject *profile)
 {
     JsonArray *profiles = trg_prefs_get_profiles(p);
     GList *profilesList = json_array_get_elements(profiles);
@@ -391,7 +356,7 @@ void trg_prefs_del_profile(TrgPrefs * p, JsonObject * profile)
     int i = 0;
 
     for (li = profilesList; li; li = g_list_next(li)) {
-        node = (JsonNode *) li->data;
+        node = (JsonNode *)li->data;
         if (profile == json_node_get_object(node)) {
             json_array_remove_element(profiles, i);
             break;
@@ -404,52 +369,44 @@ void trg_prefs_del_profile(TrgPrefs * p, JsonObject * profile)
     trg_prefs_profile_change_emit_signal(p);
 }
 
-JsonObject *trg_prefs_get_profile(TrgPrefs * p)
+JsonObject *trg_prefs_get_profile(TrgPrefs *p)
 {
     TrgPrefsPrivate *priv = p->priv;
     return priv->profile;
 }
 
-JsonObject *trg_prefs_get_connection(TrgPrefs * p)
+JsonObject *trg_prefs_get_connection(TrgPrefs *p)
 {
     TrgPrefsPrivate *priv = p->priv;
     return priv->connectionObj;
 }
 
-JsonArray *trg_prefs_get_profiles(TrgPrefs * p)
+JsonArray *trg_prefs_get_profiles(TrgPrefs *p)
 {
     TrgPrefsPrivate *priv = p->priv;
-    return json_object_get_array_member(priv->userObj,
-                                        TRG_PREFS_KEY_PROFILES);
+    return json_object_get_array_member(priv->userObj, TRG_PREFS_KEY_PROFILES);
 }
 
 JsonArray *trg_prefs_get_rss(TrgPrefs *p)
 {
-    return trg_prefs_get_array(p, TRG_PREFS_KEY_RSS,
-                               TRG_PREFS_GLOBAL);
+    return trg_prefs_get_array(p, TRG_PREFS_KEY_RSS, TRG_PREFS_GLOBAL);
 }
 
-void
-trg_prefs_set_double(TrgPrefs * p, const gchar * key, gdouble value,
-                     int flags)
+void trg_prefs_set_double(TrgPrefs *p, const gchar *key, gdouble value, int flags)
 {
-    JsonNode *node = trg_prefs_get_value(p, key, JSON_NODE_VALUE,
-                                         flags | TRG_PREFS_NEWNODE);
+    JsonNode *node = trg_prefs_get_value(p, key, JSON_NODE_VALUE, flags | TRG_PREFS_NEWNODE);
     json_node_set_double(node, value);
     trg_prefs_changed_emit_signal(p, key);
 }
 
-void
-trg_prefs_set_bool(TrgPrefs * p, const gchar * key, gboolean value,
-                   int flags)
+void trg_prefs_set_bool(TrgPrefs *p, const gchar *key, gboolean value, int flags)
 {
-    JsonNode *node = trg_prefs_get_value(p, key, JSON_NODE_VALUE,
-                                         flags | TRG_PREFS_NEWNODE);
+    JsonNode *node = trg_prefs_get_value(p, key, JSON_NODE_VALUE, flags | TRG_PREFS_NEWNODE);
     json_node_set_boolean(node, value);
     trg_prefs_changed_emit_signal(p, key);
 }
 
-gboolean trg_prefs_save(TrgPrefs * p)
+gboolean trg_prefs_save(TrgPrefs *p)
 {
     TrgPrefsPrivate *priv = p->priv;
     JsonGenerator *gen = json_generator_new();
@@ -459,35 +416,32 @@ gboolean trg_prefs_save(TrgPrefs * p)
 
     dirName = g_path_get_dirname(priv->file);
     if (!g_file_test(dirName, G_FILE_TEST_IS_DIR)) {
-        success = g_mkdir_with_parents(dirName, TRG_PREFS_DEFAULT_DIR_MODE)
-            == 0;
+        success = g_mkdir_with_parents(dirName, TRG_PREFS_DEFAULT_DIR_MODE) == 0;
     } else if (g_file_test(priv->file, G_FILE_TEST_IS_REGULAR)) {
         isNew = FALSE;
     }
     g_free(dirName);
 
     if (!success) {
-        g_error
-            ("Problem creating parent directory (permissions?) for: %s\n",
-             priv->file);
+        g_error("Problem creating parent directory (permissions?) for: %s\n", priv->file);
         return success;
     }
 
     g_object_set(G_OBJECT(gen), "pretty", TRUE, NULL);
     json_generator_set_root(gen, priv->user);
 
-    if(g_file_test(priv->file, G_FILE_TEST_IS_SYMLINK)) {
-	    gsize len;
-	    gchar *realFile;
-	    gchar *fileData;
+    if (g_file_test(priv->file, G_FILE_TEST_IS_SYMLINK)) {
+        gsize len;
+        gchar *realFile;
+        gchar *fileData;
         gchar *linkPath = realFile = g_file_read_link(priv->file, NULL);
-        if (!g_path_is_absolute (linkPath)) {
-            dirName = g_path_get_dirname (priv->file);
-            realFile = g_build_filename (dirName, linkPath, NULL);
+        if (!g_path_is_absolute(linkPath)) {
+            dirName = g_path_get_dirname(priv->file);
+            realFile = g_build_filename(dirName, linkPath, NULL);
             g_free(dirName);
             g_free(linkPath);
         }
-        fileData = json_generator_to_data (gen, &len);
+        fileData = json_generator_to_data(gen, &len);
         success = g_file_set_contents(realFile, fileData, len, NULL);
         g_free(realFile);
         g_free(fileData);
@@ -496,8 +450,7 @@ gboolean trg_prefs_save(TrgPrefs * p)
     }
 
     if (!success)
-        g_error("Problem writing configuration file (permissions?) to: %s",
-                priv->file);
+        g_error("Problem writing configuration file (permissions?) to: %s", priv->file);
     else if (isNew)
         g_chmod(priv->file, 384);
 
@@ -506,13 +459,13 @@ gboolean trg_prefs_save(TrgPrefs * p)
     return success;
 }
 
-JsonObject *trg_prefs_get_root(TrgPrefs * p)
+JsonObject *trg_prefs_get_root(TrgPrefs *p)
 {
     TrgPrefsPrivate *priv = p->priv;
     return priv->userObj;
 }
 
-static void trg_prefs_empty_init(TrgPrefs * p)
+static void trg_prefs_empty_init(TrgPrefs *p)
 {
     TrgPrefsPrivate *priv = p->priv;
     JsonArray *profiles = json_array_new();
@@ -524,13 +477,12 @@ static void trg_prefs_empty_init(TrgPrefs * p)
     priv->profile = trg_prefs_new_profile_object();
 
     json_array_add_object_element(profiles, priv->profile);
-    json_object_set_array_member(priv->userObj, TRG_PREFS_KEY_PROFILES,
-                                 profiles);
+    json_object_set_array_member(priv->userObj, TRG_PREFS_KEY_PROFILES, profiles);
 
     json_object_set_int_member(priv->userObj, TRG_PREFS_KEY_PROFILE_ID, 0);
 }
 
-void trg_prefs_load(TrgPrefs * p)
+void trg_prefs_load(TrgPrefs *p)
 {
     TrgPrefsPrivate *priv = p->priv;
     JsonParser *parser = json_parser_new();
@@ -561,11 +513,9 @@ void trg_prefs_load(TrgPrefs * p)
 
     if (!json_object_has_member(priv->userObj, TRG_PREFS_KEY_PROFILES)) {
         profiles = json_array_new();
-        json_object_set_array_member(priv->userObj, TRG_PREFS_KEY_PROFILES,
-                                     profiles);
+        json_object_set_array_member(priv->userObj, TRG_PREFS_KEY_PROFILES, profiles);
     } else {
-        profiles = json_object_get_array_member(priv->userObj,
-                                                TRG_PREFS_KEY_PROFILES);
+        profiles = json_object_get_array_member(priv->userObj, TRG_PREFS_KEY_PROFILES);
     }
 
     n_profiles = json_array_get_length(profiles);
@@ -573,31 +523,25 @@ void trg_prefs_load(TrgPrefs * p)
     if (n_profiles < 1) {
         priv->profile = trg_prefs_new_profile_object();
         json_array_add_object_element(profiles, priv->profile);
-        trg_prefs_set_int(p, TRG_PREFS_KEY_PROFILE_ID, 0,
-                          TRG_PREFS_GLOBAL);
+        trg_prefs_set_int(p, TRG_PREFS_KEY_PROFILE_ID, 0, TRG_PREFS_GLOBAL);
     } else {
         // Note: profile IDs are strictly positive
-        guint profile_id = (guint) trg_prefs_get_int(p, TRG_PREFS_KEY_PROFILE_ID,
-                                                     TRG_PREFS_GLOBAL);
+        guint profile_id = (guint)trg_prefs_get_int(p, TRG_PREFS_KEY_PROFILE_ID, TRG_PREFS_GLOBAL);
         if (profile_id >= n_profiles)
-            trg_prefs_set_int(p, TRG_PREFS_KEY_PROFILE_ID, profile_id = 0,
-                              TRG_PREFS_GLOBAL);
+            trg_prefs_set_int(p, TRG_PREFS_KEY_PROFILE_ID, profile_id = 0, TRG_PREFS_GLOBAL);
 
-        priv->profile =
-            json_array_get_object_element(profiles, profile_id);
+        priv->profile = json_array_get_object_element(profiles, profile_id);
     }
 }
 
-guint trg_prefs_get_add_flags(TrgPrefs * p)
+guint trg_prefs_get_add_flags(TrgPrefs *p)
 {
     guint flags = 0x00;
 
-    if (trg_prefs_get_bool
-        (p, TRG_PREFS_KEY_START_PAUSED, TRG_PREFS_GLOBAL))
+    if (trg_prefs_get_bool(p, TRG_PREFS_KEY_START_PAUSED, TRG_PREFS_GLOBAL))
         flags |= TORRENT_ADD_FLAG_PAUSED;
 
-    if (trg_prefs_get_bool
-        (p, TRG_PREFS_KEY_DELETE_LOCAL_TORRENT, TRG_PREFS_GLOBAL))
+    if (trg_prefs_get_bool(p, TRG_PREFS_KEY_DELETE_LOCAL_TORRENT, TRG_PREFS_GLOBAL))
         flags |= TORRENT_ADD_FLAG_DELETE;
 
     return flags;

--- a/src/trg-prefs.h
+++ b/src/trg-prefs.h
@@ -23,79 +23,79 @@
 #include <glib-object.h>
 #include <json-glib/json-glib.h>
 
-#define TRG_PREFS_FILENAME          "config.json"
-#define TRG_PREFS_DEFAULT_DIR_MODE  448
-#define TRG_PORT_DEFAULT            9091
-#define TRG_INTERVAL_DEFAULT        3
+#define TRG_PREFS_FILENAME           "config.json"
+#define TRG_PREFS_DEFAULT_DIR_MODE   448
+#define TRG_PORT_DEFAULT             9091
+#define TRG_INTERVAL_DEFAULT         3
 #define TRG_SESSION_INTERVAL_DEFAULT 60
-#define TRG_PROFILE_NAME_DEFAULT   "Default"
+#define TRG_PROFILE_NAME_DEFAULT     "Default"
 
-#define TRG_PREFS_KEY_RPC_URL_PATH "rpc-url-path"
-#define TRG_PREFS_KEY_PROFILE_ID    "profile-id"
-#define TRG_PREFS_KEY_PROFILES    "profiles"
-#define TRG_PREFS_KEY_RSS    "rss"
-#define TRG_PREFS_KEY_PROFILE_NAME   "profile-name"
-#define TRG_PREFS_KEY_HOSTNAME      "hostname"
-#define TRG_PREFS_KEY_PORT          "port"
-#define TRG_PREFS_KEY_MINUPDATE_INTERVAL "min-update-interval"
-#define TRG_PREFS_KEY_USERNAME      "username"
-#define TRG_PREFS_KEY_PASSWORD      "password"
-#define TRG_PREFS_KEY_CUSTOM_HEADERS "custom-headers"
-#define TRG_PREFS_KEY_CUSTOM_HEADER_NAME "custom-header-name"
-#define TRG_PREFS_KEY_CUSTOM_HEADER_VALUE "custom-header-value"
-#define TRG_PREFS_KEY_AUTO_CONNECT  "auto-connect"
-#define TRG_PREFS_KEY_SSL            "ssl"
-#define TRG_PREFS_KEY_SSL_VALIDATE   "ssl-validate"
-#define TRG_PREFS_KEY_TIMEOUT            "timeout"
-#define TRG_PREFS_KEY_RETRIES            "retries"
-#define TRG_PREFS_KEY_UPDATE_INTERVAL "update-interval"
-#define TRG_PREFS_KEY_SESSION_UPDATE_INTERVAL "session-update-interval"
-#define TRG_PREFS_KEY_COMPLETE_NOTIFY "complete-notify"
-#define TRG_PREFS_KEY_ADD_NOTIFY    "add-notify"
-#define TRG_PREFS_KEY_WINDOW_WIDTH  "window-width"
-#define TRG_PREFS_KEY_WINDOW_HEIGHT "window-height"
-#define TRG_PREFS_KEY_GRAPH_SPAN  "graph-span"
-#define TRG_PREFS_KEY_SYSTEM_TRAY   "system-tray"
-#define TRG_PREFS_KEY_SHOW_GRAPH    "show-graph"
-#define TRG_PREFS_KEY_SYSTEM_TRAY_MINIMISE  "system-tray-minimise"
-#define TRG_PREFS_KEY_FILTER_TRACKERS  "filter-trackers"
-#define TRG_PREFS_KEY_DIRECTORIES_FIRST  "directories-first"
-#define TRG_PREFS_KEY_FILTER_DIRS  "filter-dirs"
-#define TRG_PREFS_KEY_SHOW_STATE_SELECTOR "show-state-selector"
-#define TRG_PREFS_KEY_SHOW_NOTEBOOK "show-notebook"
-#define TRG_PREFS_KEY_LAST_TORRENT_DIR "last-torrent-dir"
-#define TRG_PREFS_KEY_ADD_OPTIONS_DIALOG "add-options-dialog"
-#define TRG_PREFS_KEY_START_PAUSED "start-paused"
-#define TRG_PREFS_KEY_UPDATE_ACTIVE_ONLY "update-active-only"
-#define TRG_PREFS_KEY_DELETE_LOCAL_TORRENT "delete-local-torrent"
-#define TRG_PREFS_STATE_SELECTOR_LAST "state-selector-last"
-#define TRG_PREFS_ACTIVEONLY_FULLSYNC_ENABLED   "activeonly-fullsync-enabled"
-#define TRG_PREFS_ACTIVEONLY_FULLSYNC_EVERY     "activeonly-fullsync-every"
-#define TRG_PREFS_KEY_STYLE	"style"
-#define TRG_PREFS_KEY_TREE_VIEWS "tree-views"
-#define TRG_PREFS_KEY_TV_SORT_TYPE "sort-type"
-#define TRG_PREFS_KEY_TV_SORT_COL "sort-col"
-#define TRG_PREFS_KEY_TV_COLUMNS "columns"
-#define TRG_PREFS_KEY_TV_WIDTHS "widths"
-#define TRG_PREFS_KEY_NOTEBOOK_PANED_POS "notebook-paned-pos"
-#define TRG_PREFS_KEY_STATES_PANED_POS "states-paned-pos"
-#define TRG_PREFS_SUBKEY_LABEL "label"
-#define TRG_PREFS_KEY_EXEC_COMMANDS "exec-commands"
+#define TRG_PREFS_KEY_RPC_URL_PATH             "rpc-url-path"
+#define TRG_PREFS_KEY_PROFILE_ID               "profile-id"
+#define TRG_PREFS_KEY_PROFILES                 "profiles"
+#define TRG_PREFS_KEY_RSS                      "rss"
+#define TRG_PREFS_KEY_PROFILE_NAME             "profile-name"
+#define TRG_PREFS_KEY_HOSTNAME                 "hostname"
+#define TRG_PREFS_KEY_PORT                     "port"
+#define TRG_PREFS_KEY_MINUPDATE_INTERVAL       "min-update-interval"
+#define TRG_PREFS_KEY_USERNAME                 "username"
+#define TRG_PREFS_KEY_PASSWORD                 "password"
+#define TRG_PREFS_KEY_CUSTOM_HEADERS           "custom-headers"
+#define TRG_PREFS_KEY_CUSTOM_HEADER_NAME       "custom-header-name"
+#define TRG_PREFS_KEY_CUSTOM_HEADER_VALUE      "custom-header-value"
+#define TRG_PREFS_KEY_AUTO_CONNECT             "auto-connect"
+#define TRG_PREFS_KEY_SSL                      "ssl"
+#define TRG_PREFS_KEY_SSL_VALIDATE             "ssl-validate"
+#define TRG_PREFS_KEY_TIMEOUT                  "timeout"
+#define TRG_PREFS_KEY_RETRIES                  "retries"
+#define TRG_PREFS_KEY_UPDATE_INTERVAL          "update-interval"
+#define TRG_PREFS_KEY_SESSION_UPDATE_INTERVAL  "session-update-interval"
+#define TRG_PREFS_KEY_COMPLETE_NOTIFY          "complete-notify"
+#define TRG_PREFS_KEY_ADD_NOTIFY               "add-notify"
+#define TRG_PREFS_KEY_WINDOW_WIDTH             "window-width"
+#define TRG_PREFS_KEY_WINDOW_HEIGHT            "window-height"
+#define TRG_PREFS_KEY_GRAPH_SPAN               "graph-span"
+#define TRG_PREFS_KEY_SYSTEM_TRAY              "system-tray"
+#define TRG_PREFS_KEY_SHOW_GRAPH               "show-graph"
+#define TRG_PREFS_KEY_SYSTEM_TRAY_MINIMISE     "system-tray-minimise"
+#define TRG_PREFS_KEY_FILTER_TRACKERS          "filter-trackers"
+#define TRG_PREFS_KEY_DIRECTORIES_FIRST        "directories-first"
+#define TRG_PREFS_KEY_FILTER_DIRS              "filter-dirs"
+#define TRG_PREFS_KEY_SHOW_STATE_SELECTOR      "show-state-selector"
+#define TRG_PREFS_KEY_SHOW_NOTEBOOK            "show-notebook"
+#define TRG_PREFS_KEY_LAST_TORRENT_DIR         "last-torrent-dir"
+#define TRG_PREFS_KEY_ADD_OPTIONS_DIALOG       "add-options-dialog"
+#define TRG_PREFS_KEY_START_PAUSED             "start-paused"
+#define TRG_PREFS_KEY_UPDATE_ACTIVE_ONLY       "update-active-only"
+#define TRG_PREFS_KEY_DELETE_LOCAL_TORRENT     "delete-local-torrent"
+#define TRG_PREFS_STATE_SELECTOR_LAST          "state-selector-last"
+#define TRG_PREFS_ACTIVEONLY_FULLSYNC_ENABLED  "activeonly-fullsync-enabled"
+#define TRG_PREFS_ACTIVEONLY_FULLSYNC_EVERY    "activeonly-fullsync-every"
+#define TRG_PREFS_KEY_STYLE                    "style"
+#define TRG_PREFS_KEY_TREE_VIEWS               "tree-views"
+#define TRG_PREFS_KEY_TV_SORT_TYPE             "sort-type"
+#define TRG_PREFS_KEY_TV_SORT_COL              "sort-col"
+#define TRG_PREFS_KEY_TV_COLUMNS               "columns"
+#define TRG_PREFS_KEY_TV_WIDTHS                "widths"
+#define TRG_PREFS_KEY_NOTEBOOK_PANED_POS       "notebook-paned-pos"
+#define TRG_PREFS_KEY_STATES_PANED_POS         "states-paned-pos"
+#define TRG_PREFS_SUBKEY_LABEL                 "label"
+#define TRG_PREFS_KEY_EXEC_COMMANDS            "exec-commands"
 #define TRG_PREFS_KEY_EXEC_COMMANDS_SUBKEY_CMD "cmd"
-#define TRG_PREFS_KEY_DESTINATIONS "destinations"
-#define TRG_PREFS_KEY_RSS "rss"
-#define TRG_PREFS_RSS_SUBKEY_ID "id"
-#define TRG_PREFS_RSS_SUBKEY_URL "url"
-#define TRG_PREFS_KEY_LAST_MOVE_DESTINATION "last-move-destination"
-#define TRG_PREFS_KEY_LAST_ADD_DESTINATION "last-add-destination"
-#define TRG_PREFS_KEY_DESTINATIONS_SUBKEY_DIR "dir"
+#define TRG_PREFS_KEY_DESTINATIONS             "destinations"
+#define TRG_PREFS_KEY_RSS                      "rss"
+#define TRG_PREFS_RSS_SUBKEY_ID                "id"
+#define TRG_PREFS_RSS_SUBKEY_URL               "url"
+#define TRG_PREFS_KEY_LAST_MOVE_DESTINATION    "last-move-destination"
+#define TRG_PREFS_KEY_LAST_ADD_DESTINATION     "last-add-destination"
+#define TRG_PREFS_KEY_DESTINATIONS_SUBKEY_DIR  "dir"
 
-#define TRG_PREFS_NOFLAGS    (1 << 0)   /* 0x00 */
-#define TRG_PREFS_GLOBAL     (1 << 1)   /* 0x01 */
-#define TRG_PREFS_PROFILE    (1 << 2)   /* 0x02 */
-#define TRG_PREFS_CONNECTION (1 << 3)   /* 0x04 */
-#define TRG_PREFS_NEWNODE    (1 << 4)   /* 0x08 */
-#define TRG_PREFS_REPLACENODE (1 << 5)  /* 0x16 */
+#define TRG_PREFS_NOFLAGS     (1 << 0) /* 0x00 */
+#define TRG_PREFS_GLOBAL      (1 << 1) /* 0x01 */
+#define TRG_PREFS_PROFILE     (1 << 2) /* 0x02 */
+#define TRG_PREFS_CONNECTION  (1 << 3) /* 0x04 */
+#define TRG_PREFS_NEWNODE     (1 << 4) /* 0x08 */
+#define TRG_PREFS_REPLACENODE (1 << 5) /* 0x16 */
 
 enum {
     TRG_STYLE_TR = 0,
@@ -106,71 +106,59 @@ enum {
 typedef struct _TrgPrefsPrivate TrgPrefsPrivate;
 
 G_BEGIN_DECLS
-#define TRG_TYPE_PREFS trg_prefs_get_type()
-#define TRG_PREFS(obj) \
-  (G_TYPE_CHECK_INSTANCE_CAST ((obj), TRG_TYPE_PREFS, TrgPrefs))
-#define TRG_PREFS_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_CAST ((klass), TRG_TYPE_PREFS, TrgPrefsClass))
-#define TRG_IS_PREFS(obj) \
-  (G_TYPE_CHECK_INSTANCE_TYPE ((obj), TRG_TYPE_PREFS))
-#define TRG_IS_PREFS_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_TYPE ((klass), TRG_TYPE_PREFS))
-#define TRG_PREFS_GET_CLASS(obj) \
-  (G_TYPE_INSTANCE_GET_CLASS ((obj), TRG_TYPE_PREFS, TrgPrefsClass))
-    typedef struct {
+#define TRG_TYPE_PREFS            trg_prefs_get_type()
+#define TRG_PREFS(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), TRG_TYPE_PREFS, TrgPrefs))
+#define TRG_PREFS_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass), TRG_TYPE_PREFS, TrgPrefsClass))
+#define TRG_IS_PREFS(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), TRG_TYPE_PREFS))
+#define TRG_IS_PREFS_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass), TRG_TYPE_PREFS))
+#define TRG_PREFS_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj), TRG_TYPE_PREFS, TrgPrefsClass))
+typedef struct {
     GObject parent;
     TrgPrefsPrivate *priv;
 } TrgPrefs;
 
 typedef struct {
     GObjectClass parent_class;
-    void (*pref_changed) (TrgPrefs * tc, const gchar * key, gpointer data);
+    void (*pref_changed)(TrgPrefs *tc, const gchar *key, gpointer data);
 } TrgPrefsClass;
 
 GType trg_prefs_get_type(void);
 
 TrgPrefs *trg_prefs_new(void);
 
-void trg_prefs_add_default_int(TrgPrefs * p, const gchar * key, int value);
-void trg_prefs_add_default_string(TrgPrefs * p, const gchar * key,
-                                  gchar * value);
-void trg_prefs_add_default_double(TrgPrefs * p, const gchar * key,
-                                  double value);
-void trg_prefs_add_default_bool_true(TrgPrefs * p, const gchar * key);
+void trg_prefs_add_default_int(TrgPrefs *p, const gchar *key, int value);
+void trg_prefs_add_default_string(TrgPrefs *p, const gchar *key, gchar *value);
+void trg_prefs_add_default_double(TrgPrefs *p, const gchar *key, double value);
+void trg_prefs_add_default_bool_true(TrgPrefs *p, const gchar *key);
 
-JsonNode *trg_prefs_get_value(TrgPrefs * p, const gchar * key, int type,
-                              int flags);
-gchar *trg_prefs_get_string(TrgPrefs * p, const gchar * key, int flags);
-gint64 trg_prefs_get_int(TrgPrefs * p, const gchar * key, int flags);
-gdouble trg_prefs_get_double(TrgPrefs * p, const gchar * key, int flags);
-gboolean trg_prefs_get_bool(TrgPrefs * p, const gchar * key, int flags);
-JsonObject *trg_prefs_get_profile(TrgPrefs * p);
-JsonObject *trg_prefs_get_connection(TrgPrefs * p);
-JsonArray *trg_prefs_get_profiles(TrgPrefs * p);
+JsonNode *trg_prefs_get_value(TrgPrefs *p, const gchar *key, int type, int flags);
+gchar *trg_prefs_get_string(TrgPrefs *p, const gchar *key, int flags);
+gint64 trg_prefs_get_int(TrgPrefs *p, const gchar *key, int flags);
+gdouble trg_prefs_get_double(TrgPrefs *p, const gchar *key, int flags);
+gboolean trg_prefs_get_bool(TrgPrefs *p, const gchar *key, int flags);
+JsonObject *trg_prefs_get_profile(TrgPrefs *p);
+JsonObject *trg_prefs_get_connection(TrgPrefs *p);
+JsonArray *trg_prefs_get_profiles(TrgPrefs *p);
 JsonArray *trg_prefs_get_rss(TrgPrefs *p);
-void trg_prefs_set_connection(TrgPrefs * p, JsonObject * profile);
-gint trg_prefs_get_profile_id(TrgPrefs * p);
-void trg_prefs_del_profile(TrgPrefs * p, JsonObject * profile);
-void trg_prefs_set_profile(TrgPrefs * p, JsonObject * profile);
-JsonObject *trg_prefs_new_profile(TrgPrefs * p);
-JsonObject *trg_get_current_profile(TrgPrefs * p);
-JsonObject *trg_prefs_get_root(TrgPrefs * p);
-JsonArray *trg_prefs_get_array(TrgPrefs * p, const gchar * key, int flags);
+void trg_prefs_set_connection(TrgPrefs *p, JsonObject *profile);
+gint trg_prefs_get_profile_id(TrgPrefs *p);
+void trg_prefs_del_profile(TrgPrefs *p, JsonObject *profile);
+void trg_prefs_set_profile(TrgPrefs *p, JsonObject *profile);
+JsonObject *trg_prefs_new_profile(TrgPrefs *p);
+JsonObject *trg_get_current_profile(TrgPrefs *p);
+JsonObject *trg_prefs_get_root(TrgPrefs *p);
+JsonArray *trg_prefs_get_array(TrgPrefs *p, const gchar *key, int flags);
 
-void trg_prefs_set_int(TrgPrefs * p, const gchar * key, int value,
-                       int flags);
-void trg_prefs_set_string(TrgPrefs * p, const gchar * key,
-                          const gchar * value, int flags);
-void trg_prefs_set_double(TrgPrefs * p, const gchar * key, double value,
-                          int flags);
-void trg_prefs_set_bool(TrgPrefs * p, const gchar * key, gboolean value,
-                        int flags);
+void trg_prefs_set_int(TrgPrefs *p, const gchar *key, int value, int flags);
+void trg_prefs_set_string(TrgPrefs *p, const gchar *key, const gchar *value, int flags);
+void trg_prefs_set_double(TrgPrefs *p, const gchar *key, double value, int flags);
+void trg_prefs_set_bool(TrgPrefs *p, const gchar *key, gboolean value, int flags);
 
-gboolean trg_prefs_save(TrgPrefs * p);
-void trg_prefs_load(TrgPrefs * p);
-void trg_prefs_changed_emit_signal(TrgPrefs * p, const gchar * key);
-void trg_prefs_profile_change_emit_signal(TrgPrefs * p);
-guint trg_prefs_get_add_flags(TrgPrefs * p);
+gboolean trg_prefs_save(TrgPrefs *p);
+void trg_prefs_load(TrgPrefs *p);
+void trg_prefs_changed_emit_signal(TrgPrefs *p, const gchar *key);
+void trg_prefs_profile_change_emit_signal(TrgPrefs *p);
+guint trg_prefs_get_add_flags(TrgPrefs *p);
 
 G_END_DECLS
-#endif                          /* _TRG_PREFS_H_ */
+#endif /* _TRG_PREFS_H_ */

--- a/src/trg-remote-prefs-dialog.c
+++ b/src/trg-remote-prefs-dialog.c
@@ -19,23 +19,23 @@
 
 #include "config.h"
 
-#include <math.h>
-#include <stdint.h>
 #include <glib/gi18n.h>
 #include <gtk/gtk.h>
 #include <json-glib/json-glib.h>
+#include <math.h>
+#include <stdint.h>
 #if ENABLE_NL_LANGINFO
 #include <langinfo.h>
 #endif
 
+#include "hig.h"
+#include "json.h"
+#include "requests.h"
+#include "session-get.h"
+#include "trg-json-widgets.h"
 #include "trg-main-window.h"
 #include "trg-remote-prefs-dialog.h"
-#include "hig.h"
 #include "util.h"
-#include "requests.h"
-#include "json.h"
-#include "trg-json-widgets.h"
-#include "session-get.h"
 
 /* Using the widget creation functions in trg-json-widgets.c, load remote
  * preferences from the latest session object held by TrgClient.
@@ -46,12 +46,13 @@
  * as soon as the set is complete.
  */
 
-G_DEFINE_TYPE(TrgRemotePrefsDialog, trg_remote_prefs_dialog,
-              GTK_TYPE_DIALOG)
-#define TRG_REMOTE_PREFS_DIALOG_GET_PRIVATE(o) \
-(G_TYPE_INSTANCE_GET_PRIVATE ((o), TRG_TYPE_REMOTE_PREFS_DIALOG, TrgRemotePrefsDialogPrivate))
+G_DEFINE_TYPE(TrgRemotePrefsDialog, trg_remote_prefs_dialog, GTK_TYPE_DIALOG)
+#define TRG_REMOTE_PREFS_DIALOG_GET_PRIVATE(o)                                                     \
+    (G_TYPE_INSTANCE_GET_PRIVATE((o), TRG_TYPE_REMOTE_PREFS_DIALOG, TrgRemotePrefsDialogPrivate))
 enum {
-    PROP_0, PROP_PARENT, PROP_CLIENT
+    PROP_0,
+    PROP_PARENT,
+    PROP_CLIENT
 };
 
 typedef struct _TrgRemotePrefsDialogPrivate TrgRemotePrefsDialogPrivate;
@@ -69,10 +70,9 @@ struct _TrgRemotePrefsDialogPrivate {
 
 static GObject *instance = NULL;
 
-static void update_session(GtkDialog * dlg)
+static void update_session(GtkDialog *dlg)
 {
-    TrgRemotePrefsDialogPrivate *priv =
-        TRG_REMOTE_PREFS_DIALOG_GET_PRIVATE(dlg);
+    TrgRemotePrefsDialogPrivate *priv = TRG_REMOTE_PREFS_DIALOG_GET_PRIVATE(dlg);
 
     JsonNode *request = session_set();
     JsonObject *args = node_get_arguments(request);
@@ -80,8 +80,7 @@ static void update_session(GtkDialog * dlg)
 
     /* Connection */
 
-    switch (gtk_combo_box_get_active
-            (GTK_COMBO_BOX(priv->encryption_combo))) {
+    switch (gtk_combo_box_get_active(GTK_COMBO_BOX(priv->encryption_combo))) {
     case 0:
         encryption = "required";
         break;
@@ -100,12 +99,9 @@ static void update_session(GtkDialog * dlg)
     dispatch_async(priv->client, request, on_session_set, priv->parent);
 }
 
-static void
-trg_remote_prefs_response_cb(GtkDialog * dlg, gint res_id,
-                             gpointer data G_GNUC_UNUSED)
+static void trg_remote_prefs_response_cb(GtkDialog *dlg, gint res_id, gpointer data G_GNUC_UNUSED)
 {
-    TrgRemotePrefsDialogPrivate *priv =
-        TRG_REMOTE_PREFS_DIALOG_GET_PRIVATE(dlg);
+    TrgRemotePrefsDialogPrivate *priv = TRG_REMOTE_PREFS_DIALOG_GET_PRIVATE(dlg);
 
     if (res_id == GTK_RESPONSE_OK)
         update_session(dlg);
@@ -116,13 +112,10 @@ trg_remote_prefs_response_cb(GtkDialog * dlg, gint res_id,
     instance = NULL;
 }
 
-static void
-trg_remote_prefs_dialog_get_property(GObject * object,
-                                     guint property_id,
-                                     GValue * value, GParamSpec * pspec)
+static void trg_remote_prefs_dialog_get_property(GObject *object, guint property_id, GValue *value,
+                                                 GParamSpec *pspec)
 {
-    TrgRemotePrefsDialogPrivate *priv =
-        TRG_REMOTE_PREFS_DIALOG_GET_PRIVATE(object);
+    TrgRemotePrefsDialogPrivate *priv = TRG_REMOTE_PREFS_DIALOG_GET_PRIVATE(object);
     switch (property_id) {
     case PROP_PARENT:
         g_value_set_object(value, priv->parent);
@@ -136,14 +129,10 @@ trg_remote_prefs_dialog_get_property(GObject * object,
     }
 }
 
-static void
-trg_remote_prefs_dialog_set_property(GObject * object,
-                                     guint property_id,
-                                     const GValue * value,
-                                     GParamSpec * pspec)
+static void trg_remote_prefs_dialog_set_property(GObject *object, guint property_id,
+                                                 const GValue *value, GParamSpec *pspec)
 {
-    TrgRemotePrefsDialogPrivate *priv =
-        TRG_REMOTE_PREFS_DIALOG_GET_PRIVATE(object);
+    TrgRemotePrefsDialogPrivate *priv = TRG_REMOTE_PREFS_DIALOG_GET_PRIVATE(object);
     switch (property_id) {
     case PROP_PARENT:
         priv->parent = g_value_get_object(value);
@@ -157,48 +146,34 @@ trg_remote_prefs_dialog_set_property(GObject * object,
     }
 }
 
-static void
-trg_remote_prefs_double_special_dependent(GtkWidget * widget,
-                                          gpointer data)
+static void trg_remote_prefs_double_special_dependent(GtkWidget *widget, gpointer data)
 {
-    TrgRemotePrefsDialogPrivate *priv =
-        TRG_REMOTE_PREFS_DIALOG_GET_PRIVATE(gtk_widget_get_toplevel
-                                            (GTK_WIDGET(widget)));
+    TrgRemotePrefsDialogPrivate *priv
+        = TRG_REMOTE_PREFS_DIALOG_GET_PRIVATE(gtk_widget_get_toplevel(GTK_WIDGET(widget)));
 
-    gtk_widget_set_sensitive(GTK_WIDGET(data),
-                             gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON
-                                                          (priv->
-                                                           alt_time_check))
-                             ||
-                             gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON
-                                                          (priv->
-                                                           alt_check)));
+    gtk_widget_set_sensitive(
+        GTK_WIDGET(data),
+        gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(priv->alt_time_check))
+            || gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(priv->alt_check)));
 }
 
-static void
-trg_rprefs_time_widget_savefunc(GtkWidget * w, JsonObject * obj,
-                                gchar * key)
+static void trg_rprefs_time_widget_savefunc(GtkWidget *w, JsonObject *obj, gchar *key)
 {
     GtkWidget *hourSpin = g_object_get_data(G_OBJECT(w), "hours-spin");
     GtkWidget *minutesSpin = g_object_get_data(G_OBJECT(w), "mins-spin");
-    gint hoursValue =
-        gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON(hourSpin));
-    gint minutesValue =
-        gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON(minutesSpin));
+    gint hoursValue = gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON(hourSpin));
+    gint minutesValue = gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON(minutesSpin));
 
-    json_object_set_int_member(obj, key,
-                               (gint64) ((hoursValue * 60) +
-                                         minutesValue));
-
+    json_object_set_int_member(obj, key, (gint64)((hoursValue * 60) + minutesValue));
 }
 
-static gboolean on_output(GtkSpinButton * spin, gpointer data)
+static gboolean on_output(GtkSpinButton *spin, gpointer data)
 {
     GtkAdjustment *adj;
     gchar *text;
     int value;
     adj = gtk_spin_button_get_adjustment(spin);
-    value = (int) gtk_adjustment_get_value(adj);
+    value = (int)gtk_adjustment_get_value(adj);
     text = g_strdup_printf("%02d", value);
     gtk_entry_set_text(GTK_ENTRY(spin), text);
     g_free(text);
@@ -206,30 +181,23 @@ static gboolean on_output(GtkSpinButton * spin, gpointer data)
     return TRUE;
 }
 
-static GtkWidget *trg_rprefs_timer_widget_spin_new(gint max,
-                                                   GtkWidget *
-                                                   alt_time_check)
+static GtkWidget *trg_rprefs_timer_widget_spin_new(gint max, GtkWidget *alt_time_check)
 {
     GtkWidget *w = gtk_spin_button_new_with_range(0, max, 1);
-    gtk_widget_set_sensitive(w,
-                             gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON
-                                                          (alt_time_check)));
+    gtk_widget_set_sensitive(w, gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(alt_time_check)));
     g_signal_connect(G_OBJECT(alt_time_check), "toggled",
                      G_CALLBACK(toggle_active_arg_is_sensitive), w);
     g_signal_connect(G_OBJECT(w), "output", G_CALLBACK(on_output), NULL);
     return w;
 }
 
-static GtkWidget *trg_rprefs_time_widget_new(GList ** wl, JsonObject * obj,
-                                             const gchar * key,
-                                             GtkWidget * alt_time_check)
+static GtkWidget *trg_rprefs_time_widget_new(GList **wl, JsonObject *obj, const gchar *key,
+                                             GtkWidget *alt_time_check)
 {
     GtkWidget *hbox = trg_hbox_new(FALSE, 0);
     GtkWidget *colonLabel = gtk_label_new(":");
-    GtkWidget *hourSpin =
-        trg_rprefs_timer_widget_spin_new(23, alt_time_check);
-    GtkWidget *minutesSpin = trg_rprefs_timer_widget_spin_new(69,
-                                                              alt_time_check);
+    GtkWidget *hourSpin = trg_rprefs_timer_widget_spin_new(23, alt_time_check);
+    GtkWidget *minutesSpin = trg_rprefs_timer_widget_spin_new(69, alt_time_check);
     gint64 value = json_object_get_int_member(obj, key);
 
     trg_json_widget_desc *wd = g_new0(trg_json_widget_desc, 1);
@@ -240,10 +208,8 @@ static GtkWidget *trg_rprefs_time_widget_new(GList ** wl, JsonObject * obj,
     g_object_set_data(G_OBJECT(hbox), "hours-spin", hourSpin);
     g_object_set_data(G_OBJECT(hbox), "mins-spin", minutesSpin);
 
-    gtk_spin_button_set_value(GTK_SPIN_BUTTON(hourSpin),
-                              floor((gdouble) value / 60.0));
-    gtk_spin_button_set_value(GTK_SPIN_BUTTON(minutesSpin),
-                              (gdouble) (value % 60));
+    gtk_spin_button_set_value(GTK_SPIN_BUTTON(hourSpin), floor((gdouble)value / 60.0));
+    gtk_spin_button_set_value(GTK_SPIN_BUTTON(minutesSpin), (gdouble)(value % 60));
 
     gtk_box_pack_start(GTK_BOX(hbox), hourSpin, TRUE, FALSE, 0);
     gtk_box_pack_start(GTK_BOX(hbox), colonLabel, TRUE, FALSE, 2);
@@ -254,96 +220,78 @@ static GtkWidget *trg_rprefs_time_widget_new(GList ** wl, JsonObject * obj,
     return hbox;
 }
 
-static GtkWidget *trg_rprefs_time_begin_end_new(GList ** wl,
-                                                JsonObject * obj,
-                                                GtkWidget * alt_time_check)
+static GtkWidget *trg_rprefs_time_begin_end_new(GList **wl, JsonObject *obj,
+                                                GtkWidget *alt_time_check)
 {
     GtkWidget *hbox = trg_hbox_new(FALSE, 0);
-    GtkWidget *begin = trg_rprefs_time_widget_new(wl, obj,
-                                                  SGET_ALT_SPEED_TIME_BEGIN,
-                                                  alt_time_check);
-    GtkWidget *end = trg_rprefs_time_widget_new(wl, obj,
-                                                SGET_ALT_SPEED_TIME_END,
-                                                alt_time_check);
+    GtkWidget *begin
+        = trg_rprefs_time_widget_new(wl, obj, SGET_ALT_SPEED_TIME_BEGIN, alt_time_check);
+    GtkWidget *end = trg_rprefs_time_widget_new(wl, obj, SGET_ALT_SPEED_TIME_END, alt_time_check);
 
     gtk_box_pack_start(GTK_BOX(hbox), begin, FALSE, FALSE, 0);
-    gtk_box_pack_start(GTK_BOX(hbox), gtk_label_new("-"), FALSE, FALSE,
-                       10);
+    gtk_box_pack_start(GTK_BOX(hbox), gtk_label_new("-"), FALSE, FALSE, 10);
     gtk_box_pack_start(GTK_BOX(hbox), end, FALSE, FALSE, 0);
 
     return hbox;
 }
 
-static GtkWidget *trg_rprefs_alt_speed_spin_new(GList ** wl,
-                                                JsonObject * obj,
-                                                const gchar * key,
-                                                GtkWidget * alt_check,
-                                                GtkWidget * alt_time_check)
+static GtkWidget *trg_rprefs_alt_speed_spin_new(GList **wl, JsonObject *obj, const gchar *key,
+                                                GtkWidget *alt_check, GtkWidget *alt_time_check)
 {
-    GtkWidget *w = trg_json_widget_spin_int_new(wl, obj, key,
-                                                NULL, 0, INT_MAX, 5);
-    gtk_widget_set_sensitive(w,
-                             gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON
-                                                          (alt_check))
-                             ||
-                             gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON
-                                                          (alt_time_check)));
+    GtkWidget *w = trg_json_widget_spin_int_new(wl, obj, key, NULL, 0, INT_MAX, 5);
+    gtk_widget_set_sensitive(
+        w,
+        gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(alt_check))
+            || gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(alt_time_check)));
     g_signal_connect(G_OBJECT(alt_time_check), "toggled",
-                     G_CALLBACK(trg_remote_prefs_double_special_dependent),
-                     w);
+                     G_CALLBACK(trg_remote_prefs_double_special_dependent), w);
     g_signal_connect(G_OBJECT(alt_check), "toggled",
-                     G_CALLBACK(trg_remote_prefs_double_special_dependent),
-                     w);
+                     G_CALLBACK(trg_remote_prefs_double_special_dependent), w);
     return w;
 }
 
-static void
-trg_rprefs_alt_days_savefunc(GtkWidget * grid, JsonObject * obj,
-                                gchar * key)
+static void trg_rprefs_alt_days_savefunc(GtkWidget *grid, JsonObject *obj, gchar *key)
 {
     guint64 days = 0;
 
-    for(gint i = 0, x = 1; i < 7; i++, x<<=1) {
-        GtkWidget *w = gtk_grid_get_child_at (GTK_GRID(grid), i, 0);
-        if(gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(w)))
+    for (gint i = 0, x = 1; i < 7; i++, x <<= 1) {
+        GtkWidget *w = gtk_grid_get_child_at(GTK_GRID(grid), i, 0);
+        if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(w)))
             days += x;
     }
 
     json_object_set_int_member(obj, key, days);
 }
 
-static GtkWidget *trg_rprefs_alt_days(GList ** wl,
-                                      JsonObject * Obj,
-                                      const gchar * key,
+static GtkWidget *trg_rprefs_alt_days(GList **wl, JsonObject *Obj, const gchar *key,
                                       GtkWidget *alt_time_check)
 {
-    gchar *abdays_fallback[] = {_("Sun"), _("Mon"), _("Tue"), _("Wed"), _("Thu"), _("Fri"), _("Sat")};
+    gchar *abdays_fallback[]
+        = { _("Sun"), _("Mon"), _("Tue"), _("Wed"), _("Thu"), _("Fri"), _("Sat") };
 #if ENABLE_NL_LANGINFO
-    nl_item abdays[] = {ABDAY_1, ABDAY_2, ABDAY_3, ABDAY_4, ABDAY_5, ABDAY_6, ABDAY_7};
+    nl_item abdays[] = { ABDAY_1, ABDAY_2, ABDAY_3, ABDAY_4, ABDAY_5, ABDAY_6, ABDAY_7 };
 #endif
     GtkWidget *grid = gtk_grid_new();
-    gtk_grid_set_column_homogeneous (GTK_GRID(grid), TRUE);
+    gtk_grid_set_column_homogeneous(GTK_GRID(grid), TRUE);
     g_signal_connect(G_OBJECT(alt_time_check), "toggled",
                      G_CALLBACK(toggle_active_arg_is_sensitive), grid);
 
     gint64 days = json_object_get_int_member(Obj, key);
 
-    for(gint i = 0, x = 1; i < 7; i++, x<<=1) {
+    for (gint i = 0, x = 1; i < 7; i++, x <<= 1) {
 #if ENABLE_NL_LANGINFO
         gchar *utf8 = g_convert_with_fallback(nl_langinfo(abdays[i]), -1, "utf-8",
-                                              nl_langinfo(CODESET), NULL, NULL,
-                                              NULL, NULL);
-        GtkWidget *w = gtk_check_button_new_with_label (utf8 ? utf8 : abdays_fallback[i]);
+                                              nl_langinfo(CODESET), NULL, NULL, NULL, NULL);
+        GtkWidget *w = gtk_check_button_new_with_label(utf8 ? utf8 : abdays_fallback[i]);
         g_free(utf8);
 #else
-        GtkWidget *w = gtk_check_button_new_with_label (abdays_fallback[i]);
+        GtkWidget *w = gtk_check_button_new_with_label(abdays_fallback[i]);
 #endif
         gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(w), (days & x) == x);
         gtk_grid_attach(GTK_GRID(grid), w, i, 0, 1, 1);
     }
 
-    gtk_widget_set_sensitive(grid,
-    gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(alt_time_check)));
+    gtk_widget_set_sensitive(grid, gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(alt_time_check)));
 
     trg_json_widget_desc *wd = g_new0(trg_json_widget_desc, 1);
     wd->key = g_strdup(key);
@@ -354,11 +302,9 @@ static GtkWidget *trg_rprefs_alt_days(GList ** wl,
     return grid;
 }
 
-static GtkWidget *trg_rprefs_bandwidthPage(TrgRemotePrefsDialog * win,
-                                           JsonObject * json)
+static GtkWidget *trg_rprefs_bandwidthPage(TrgRemotePrefsDialog *win, JsonObject *json)
 {
-    TrgRemotePrefsDialogPrivate *priv =
-        TRG_REMOTE_PREFS_DIALOG_GET_PRIVATE(win);
+    TrgRemotePrefsDialogPrivate *priv = TRG_REMOTE_PREFS_DIALOG_GET_PRIVATE(win);
     GtkWidget *w, *tb, *t;
     guint row = 0;
 
@@ -366,58 +312,44 @@ static GtkWidget *trg_rprefs_bandwidthPage(TrgRemotePrefsDialog * win,
 
     hig_workarea_add_section_title(t, &row, _("Bandwidth limits"));
 
-    tb = trg_json_widget_check_new(&priv->widgets, json,
-                                   SGET_SPEED_LIMIT_DOWN_ENABLED,
+    tb = trg_json_widget_check_new(&priv->widgets, json, SGET_SPEED_LIMIT_DOWN_ENABLED,
                                    _("Down Limit (KiB/s)"), NULL);
-    w = trg_json_widget_spin_int_new(&priv->widgets, json,
-                                     SGET_SPEED_LIMIT_DOWN, tb, 0, INT_MAX, 5);
+    w = trg_json_widget_spin_int_new(&priv->widgets, json, SGET_SPEED_LIMIT_DOWN, tb, 0, INT_MAX,
+                                     5);
     hig_workarea_add_row_w(t, &row, tb, w, NULL);
 
-    tb = trg_json_widget_check_new(&priv->widgets, json,
-                                   SGET_SPEED_LIMIT_UP_ENABLED,
+    tb = trg_json_widget_check_new(&priv->widgets, json, SGET_SPEED_LIMIT_UP_ENABLED,
                                    _("Up Limit (KiB/s)"), NULL);
-    w = trg_json_widget_spin_int_new(&priv->widgets, json, SGET_SPEED_LIMIT_UP,
-                                     tb, 0, INT_MAX, 5);
+    w = trg_json_widget_spin_int_new(&priv->widgets, json, SGET_SPEED_LIMIT_UP, tb, 0, INT_MAX, 5);
     hig_workarea_add_row_w(t, &row, tb, w, NULL);
 
     hig_workarea_add_section_title(t, &row, _("Alternate limits"));
 
-    w = priv->alt_check = trg_json_widget_check_new(&priv->widgets, json,
-                                                    SGET_ALT_SPEED_ENABLED,
-                                                    _
-                                                    ("Alternate speed limits active"),
-                                                    NULL);
+    w = priv->alt_check = trg_json_widget_check_new(&priv->widgets, json, SGET_ALT_SPEED_ENABLED,
+                                                    _("Alternate speed limits active"), NULL);
     hig_workarea_add_wide_control(t, &row, w);
 
-    tb = priv->alt_time_check =
-        trg_json_widget_check_new(&priv->widgets, json,
-                                  SGET_ALT_SPEED_TIME_ENABLED,
-                                  _("Alternate time range"), NULL);
+    tb = priv->alt_time_check = trg_json_widget_check_new(
+        &priv->widgets, json, SGET_ALT_SPEED_TIME_ENABLED, _("Alternate time range"), NULL);
     w = trg_rprefs_time_begin_end_new(&priv->widgets, json, tb);
     hig_workarea_add_row_w(t, &row, tb, w, NULL);
 
-    w = trg_rprefs_alt_days(&priv->widgets, json,
-                            SGET_ALT_SPEED_TIME_DAY, priv->alt_time_check);
+    w = trg_rprefs_alt_days(&priv->widgets, json, SGET_ALT_SPEED_TIME_DAY, priv->alt_time_check);
     hig_workarea_add_row(t, &row, _("Alternate days"), w, NULL);
 
-    w = trg_rprefs_alt_speed_spin_new(&priv->widgets, json,
-                                      SGET_ALT_SPEED_DOWN, priv->alt_check,
+    w = trg_rprefs_alt_speed_spin_new(&priv->widgets, json, SGET_ALT_SPEED_DOWN, priv->alt_check,
                                       tb);
     hig_workarea_add_row(t, &row, _("Alternate down limit (KiB/s)"), w, w);
 
-    w = trg_rprefs_alt_speed_spin_new(&priv->widgets, json,
-                                      SGET_ALT_SPEED_UP, priv->alt_check,
-                                      tb);
+    w = trg_rprefs_alt_speed_spin_new(&priv->widgets, json, SGET_ALT_SPEED_UP, priv->alt_check, tb);
     hig_workarea_add_row(t, &row, _("Alternate up limit (KiB/s)"), w, w);
 
     return t;
 }
 
-static GtkWidget *trg_rprefs_limitsPage(TrgRemotePrefsDialog * win,
-                                        JsonObject * json)
+static GtkWidget *trg_rprefs_limitsPage(TrgRemotePrefsDialog *win, JsonObject *json)
 {
-    TrgRemotePrefsDialogPrivate *priv =
-        TRG_REMOTE_PREFS_DIALOG_GET_PRIVATE(win);
+    TrgRemotePrefsDialogPrivate *priv = TRG_REMOTE_PREFS_DIALOG_GET_PRIVATE(win);
     GtkWidget *w, *tb, *t;
     guint row = 0;
 
@@ -425,53 +357,42 @@ static GtkWidget *trg_rprefs_limitsPage(TrgRemotePrefsDialog * win,
 
     hig_workarea_add_section_title(t, &row, _("Seeding"));
 
-    tb = trg_json_widget_check_new(&priv->widgets, json,
-                                   SGET_SEED_RATIO_LIMITED,
+    tb = trg_json_widget_check_new(&priv->widgets, json, SGET_SEED_RATIO_LIMITED,
                                    _("Seed ratio limit"), NULL);
-    w = trg_json_widget_spin_double_new(&priv->widgets, json,
-                                        SGET_SEED_RATIO_LIMIT, tb,
-                                        0, INT_MAX, 0.1);
+    w = trg_json_widget_spin_double_new(&priv->widgets, json, SGET_SEED_RATIO_LIMIT, tb, 0, INT_MAX,
+                                        0.1);
     hig_workarea_add_row_w(t, &row, tb, w, NULL);
 
     if (json_object_has_member(json, SGET_DOWNLOAD_QUEUE_ENABLED)) {
         hig_workarea_add_section_title(t, &row, _("Queues"));
 
-        tb = trg_json_widget_check_new(&priv->widgets, json,
-                                       SGET_DOWNLOAD_QUEUE_ENABLED,
+        tb = trg_json_widget_check_new(&priv->widgets, json, SGET_DOWNLOAD_QUEUE_ENABLED,
                                        _("Download queue size"), NULL);
-        w = trg_json_widget_spin_int_new(&priv->widgets, json,
-                                         SGET_DOWNLOAD_QUEUE_SIZE, tb, 0,
+        w = trg_json_widget_spin_int_new(&priv->widgets, json, SGET_DOWNLOAD_QUEUE_SIZE, tb, 0,
                                          INT_MAX, 1);
         hig_workarea_add_row_w(t, &row, tb, w, NULL);
 
-        tb = trg_json_widget_check_new(&priv->widgets, json,
-                                       SGET_SEED_QUEUE_ENABLED,
+        tb = trg_json_widget_check_new(&priv->widgets, json, SGET_SEED_QUEUE_ENABLED,
                                        _("Seed queue size"), NULL);
-        w = trg_json_widget_spin_int_new(&priv->widgets, json,
-                                         SGET_SEED_QUEUE_SIZE, tb, 0,
-                                         INT_MAX, 1);
+        w = trg_json_widget_spin_int_new(&priv->widgets, json, SGET_SEED_QUEUE_SIZE, tb, 0, INT_MAX,
+                                         1);
         hig_workarea_add_row_w(t, &row, tb, w, NULL);
 
-        tb = trg_json_widget_check_new(&priv->widgets, json,
-                                       SGET_QUEUE_STALLED_ENABLED,
-                                       _("Ignore stalled (minutes)"),
-                                       NULL);
-        w = trg_json_widget_spin_int_new(&priv->widgets, json,
-                                         SGET_QUEUE_STALLED_MINUTES, tb,
-                                          0, INT_MAX, 1);
+        tb = trg_json_widget_check_new(&priv->widgets, json, SGET_QUEUE_STALLED_ENABLED,
+                                       _("Ignore stalled (minutes)"), NULL);
+        w = trg_json_widget_spin_int_new(&priv->widgets, json, SGET_QUEUE_STALLED_MINUTES, tb, 0,
+                                         INT_MAX, 1);
         hig_workarea_add_row_w(t, &row, tb, w, NULL);
     }
 
     hig_workarea_add_section_title(t, &row, _("Peers"));
 
-    w = trg_json_widget_spin_int_new(&priv->widgets, json,
-                                     SGET_PEER_LIMIT_GLOBAL, NULL, 0,
-                                     INT_MAX, 5);
+    w = trg_json_widget_spin_int_new(&priv->widgets, json, SGET_PEER_LIMIT_GLOBAL, NULL, 0, INT_MAX,
+                                     5);
     hig_workarea_add_row(t, &row, _("Global peer limit"), w, w);
 
-    w = trg_json_widget_spin_int_new(&priv->widgets, json,
-                                     SGET_PEER_LIMIT_PER_TORRENT, NULL,
-                                     0, INT_MAX, 5);
+    w = trg_json_widget_spin_int_new(&priv->widgets, json, SGET_PEER_LIMIT_PER_TORRENT, NULL, 0,
+                                     INT_MAX, 5);
     hig_workarea_add_row(t, &row, _("Per torrent peer limit"), w, w);
 
     return t;
@@ -479,30 +400,26 @@ static GtkWidget *trg_rprefs_limitsPage(TrgRemotePrefsDialog * win,
 
 static gboolean on_port_tested(gpointer data)
 {
-    trg_response *response = (trg_response *) data;
+    trg_response *response = (trg_response *)data;
     if (TRG_IS_REMOTE_PREFS_DIALOG(response->cb_data)) {
-        TrgRemotePrefsDialogPrivate *priv =
-            TRG_REMOTE_PREFS_DIALOG_GET_PRIVATE(response->cb_data);
+        TrgRemotePrefsDialogPrivate *priv = TRG_REMOTE_PREFS_DIALOG_GET_PRIVATE(response->cb_data);
 
-        gtk_button_set_label(GTK_BUTTON(priv->port_test_button),
-                             _("Retest"));
+        gtk_button_set_label(GTK_BUTTON(priv->port_test_button), _("Retest"));
         gtk_widget_set_sensitive(priv->port_test_button, TRUE);
 
         if (response->status == CURLE_OK) {
-            gboolean isOpen =
-                json_object_get_boolean_member(get_arguments
-                                               (response->obj),
-                                               "port-is-open");
+            gboolean isOpen
+                = json_object_get_boolean_member(get_arguments(response->obj), "port-is-open");
             if (isOpen)
-                gtk_label_set_markup(GTK_LABEL(priv->port_test_label),
-                                     _
-                                     ("Port is <span font_weight=\"bold\" fgcolor=\"darkgreen\">open</span>"));
+                gtk_label_set_markup(
+                    GTK_LABEL(priv->port_test_label),
+                    _("Port is <span font_weight=\"bold\" fgcolor=\"darkgreen\">open</span>"));
             else
-                gtk_label_set_markup(GTK_LABEL(priv->port_test_label),
-                                     _
-                                     ("Port is <span font_weight=\"bold\" fgcolor=\"red\">closed</span>"));
+                gtk_label_set_markup(
+                    GTK_LABEL(priv->port_test_label),
+                    _("Port is <span font_weight=\"bold\" fgcolor=\"red\">closed</span>"));
         } else {
-          trg_error_dialog(GTK_WINDOW(response->cb_data), response);
+            trg_error_dialog(GTK_WINDOW(response->cb_data), response);
         }
     }
 
@@ -510,10 +427,9 @@ static gboolean on_port_tested(gpointer data)
     return FALSE;
 }
 
-static void port_test_cb(GtkButton * b, gpointer data)
+static void port_test_cb(GtkButton *b, gpointer data)
 {
-    TrgRemotePrefsDialogPrivate *priv =
-        TRG_REMOTE_PREFS_DIALOG_GET_PRIVATE(data);
+    TrgRemotePrefsDialogPrivate *priv = TRG_REMOTE_PREFS_DIALOG_GET_PRIVATE(data);
     JsonNode *req = port_test();
 
     gtk_label_set_text(GTK_LABEL(priv->port_test_label), _("Port test"));
@@ -525,23 +441,19 @@ static void port_test_cb(GtkButton * b, gpointer data)
 
 static gboolean on_blocklist_updated(gpointer data)
 {
-    trg_response *response = (trg_response *) data;
+    trg_response *response = (trg_response *)data;
     if (TRG_IS_REMOTE_PREFS_DIALOG(response->cb_data)) {
-        TrgRemotePrefsDialogPrivate *priv =
-            TRG_REMOTE_PREFS_DIALOG_GET_PRIVATE(response->cb_data);
+        TrgRemotePrefsDialogPrivate *priv = TRG_REMOTE_PREFS_DIALOG_GET_PRIVATE(response->cb_data);
 
         gtk_widget_set_sensitive(priv->blocklist_update_button, TRUE);
-        gtk_button_set_label(GTK_BUTTON(priv->blocklist_update_button),
-                             _("Update"));
+        gtk_button_set_label(GTK_BUTTON(priv->blocklist_update_button), _("Update"));
 
         if (response->status == CURLE_OK) {
             JsonObject *args = get_arguments(response->obj);
-            gchar *labelText =
-                g_strdup_printf(_("Blocklist (%" G_GINT64_FORMAT " entries)"),
-                                json_object_get_int_member(args,
-                                                           SGET_BLOCKLIST_SIZE));
-            gtk_button_set_label(GTK_BUTTON(priv->blocklist_check),
-                                 labelText);
+            gchar *labelText
+                = g_strdup_printf(_("Blocklist (%" G_GINT64_FORMAT " entries)"),
+                                  json_object_get_int_member(args, SGET_BLOCKLIST_SIZE));
+            gtk_button_set_label(GTK_BUTTON(priv->blocklist_check), labelText);
             g_free(labelText);
         } else {
             trg_error_dialog(GTK_WINDOW(response->cb_data), response);
@@ -553,10 +465,9 @@ static gboolean on_blocklist_updated(gpointer data)
     return FALSE;
 }
 
-static gboolean update_blocklist_cb(GtkButton * b, gpointer data)
+static gboolean update_blocklist_cb(GtkButton *b, gpointer data)
 {
-    TrgRemotePrefsDialogPrivate *priv =
-        TRG_REMOTE_PREFS_DIALOG_GET_PRIVATE(data);
+    TrgRemotePrefsDialogPrivate *priv = TRG_REMOTE_PREFS_DIALOG_GET_PRIVATE(data);
     JsonNode *req = blocklist_update();
 
     gtk_widget_set_sensitive(GTK_WIDGET(b), FALSE);
@@ -567,11 +478,9 @@ static gboolean update_blocklist_cb(GtkButton * b, gpointer data)
     return FALSE;
 }
 
-static GtkWidget *trg_rprefs_connPage(TrgRemotePrefsDialog * win,
-                                      JsonObject * s)
+static GtkWidget *trg_rprefs_connPage(TrgRemotePrefsDialog *win, JsonObject *s)
 {
-    TrgRemotePrefsDialogPrivate *priv =
-        TRG_REMOTE_PREFS_DIALOG_GET_PRIVATE(win);
+    TrgRemotePrefsDialogPrivate *priv = TRG_REMOTE_PREFS_DIALOG_GET_PRIVATE(win);
 
     GtkWidget *w, *tb, *t;
     const gchar *stringValue;
@@ -581,8 +490,7 @@ static GtkWidget *trg_rprefs_connPage(TrgRemotePrefsDialog * win,
 
     hig_workarea_add_section_title(t, &row, _("Connections"));
 
-    w = trg_json_widget_spin_int_new(&priv->widgets, s, SGET_PEER_PORT,
-                                     NULL, 0, 65535, 1);
+    w = trg_json_widget_spin_int_new(&priv->widgets, s, SGET_PEER_PORT, NULL, 0, 65535, 1);
     hig_workarea_add_row(t, &row, _("Peer port"), w, w);
 
     priv->port_test_label = gtk_label_new(_("Port test"));
@@ -590,10 +498,8 @@ static GtkWidget *trg_rprefs_connPage(TrgRemotePrefsDialog * win,
     g_signal_connect(w, "clicked", G_CALLBACK(port_test_cb), win);
     hig_workarea_add_row_w(t, &row, priv->port_test_label, w, NULL);
 
-    w = priv->encryption_combo = gtr_combo_box_new_enum(_("Required"), 0,
-                                                        _("Preferred"), 1,
-                                                        _("Tolerated"), 2,
-                                                        NULL);
+    w = priv->encryption_combo
+        = gtr_combo_box_new_enum(_("Required"), 0, _("Preferred"), 1, _("Tolerated"), 2, NULL);
     stringValue = session_get_encryption(s);
     if (!g_strcmp0(stringValue, "required")) {
         gtk_combo_box_set_active(GTK_COMBO_BOX(w), 0);
@@ -605,61 +511,53 @@ static GtkWidget *trg_rprefs_connPage(TrgRemotePrefsDialog * win,
 
     hig_workarea_add_row(t, &row, _("Encryption"), w, NULL);
 
-    w = trg_json_widget_check_new(&priv->widgets, s,
-                                  SGET_PEER_PORT_RANDOM_ON_START,
+    w = trg_json_widget_check_new(&priv->widgets, s, SGET_PEER_PORT_RANDOM_ON_START,
                                   _("Random peer port on start"), NULL);
     hig_workarea_add_wide_control(t, &row, w);
 
-    w = trg_json_widget_check_new(&priv->widgets, s,
-                                  SGET_PORT_FORWARDING_ENABLED,
-                                  _("Request forwarding of the peer port using UPnP or NAT-PMP"), NULL);
+    w = trg_json_widget_check_new(&priv->widgets, s, SGET_PORT_FORWARDING_ENABLED,
+                                  _("Request forwarding of the peer port using UPnP or NAT-PMP"),
+                                  NULL);
     hig_workarea_add_wide_control(t, &row, w);
 
     hig_workarea_add_section_title(t, &row, _("Protocol"));
 
-    w = trg_json_widget_check_new(&priv->widgets, s, SGET_PEX_ENABLED,
-                                  _("Peer exchange (PEX)"), NULL);
+    w = trg_json_widget_check_new(&priv->widgets, s, SGET_PEX_ENABLED, _("Peer exchange (PEX)"),
+                                  NULL);
     hig_workarea_add_wide_control(t, &row, w);
 
     w = trg_json_widget_check_new(&priv->widgets, s, SGET_DHT_ENABLED,
                                   _("Distributed Hash Table (DHT)"), NULL);
     hig_workarea_add_wide_control(t, &row, w);
 
-    w = trg_json_widget_check_new(&priv->widgets, s, SGET_LPD_ENABLED,
-                                  _("Local peer discovery"), NULL);
+    w = trg_json_widget_check_new(&priv->widgets, s, SGET_LPD_ENABLED, _("Local peer discovery"),
+                                  NULL);
     hig_workarea_add_wide_control(t, &row, w);
 
     hig_workarea_add_section_title(t, &row, _("Blocklist"));
 
     stringValue = g_strdup_printf(_("Blocklist (%" G_GINT64_FORMAT " entries)"),
                                   session_get_blocklist_size(s));
-    tb = priv->blocklist_check =
-        trg_json_widget_check_new(&priv->widgets, s,
-                                  SGET_BLOCKLIST_ENABLED, stringValue,
-                                  NULL);
-    g_free((gchar *) stringValue);
+    tb = priv->blocklist_check
+        = trg_json_widget_check_new(&priv->widgets, s, SGET_BLOCKLIST_ENABLED, stringValue, NULL);
+    g_free((gchar *)stringValue);
 
-    w = priv->blocklist_update_button =
-        gtk_button_new_with_label(_("Update"));
-    g_signal_connect(G_OBJECT(w), "clicked",
-                     G_CALLBACK(update_blocklist_cb), win);
+    w = priv->blocklist_update_button = gtk_button_new_with_label(_("Update"));
+    g_signal_connect(G_OBJECT(w), "clicked", G_CALLBACK(update_blocklist_cb), win);
     hig_workarea_add_row_w(t, &row, tb, w, NULL);
 
     stringValue = session_get_blocklist_url(s);
     if (stringValue) {
-        w = trg_json_widget_entry_new(&priv->widgets, s,
-                                      SGET_BLOCKLIST_URL, NULL);
+        w = trg_json_widget_entry_new(&priv->widgets, s, SGET_BLOCKLIST_URL, NULL);
         hig_workarea_add_row(t, &row, _("Blocklist URL:"), w, NULL);
     }
 
     return t;
 }
 
-static GtkWidget *trg_rprefs_generalPage(TrgRemotePrefsDialog * win,
-                                         JsonObject * s)
+static GtkWidget *trg_rprefs_generalPage(TrgRemotePrefsDialog *win, JsonObject *s)
 {
-    TrgRemotePrefsDialogPrivate *priv =
-        TRG_REMOTE_PREFS_DIALOG_GET_PRIVATE(win);
+    TrgRemotePrefsDialogPrivate *priv = TRG_REMOTE_PREFS_DIALOG_GET_PRIVATE(win);
 
     GtkWidget *w, *tb, *t;
     guint row = 0;
@@ -669,108 +567,87 @@ static GtkWidget *trg_rprefs_generalPage(TrgRemotePrefsDialog * win,
 
     hig_workarea_add_section_title(t, &row, _("Environment"));
 
-    w = trg_json_widget_entry_new(&priv->widgets, s, SGET_DOWNLOAD_DIR,
-                                  NULL);
+    w = trg_json_widget_entry_new(&priv->widgets, s, SGET_DOWNLOAD_DIR, NULL);
     hig_workarea_add_row(t, &row, _("Download directory"), w, NULL);
 
-    tb = trg_json_widget_check_new(&priv->widgets, s,
-                                   SGET_INCOMPLETE_DIR_ENABLED,
+    tb = trg_json_widget_check_new(&priv->widgets, s, SGET_INCOMPLETE_DIR_ENABLED,
                                    _("Incomplete download dir"), NULL);
-    w = trg_json_widget_entry_new(&priv->widgets, s, SGET_INCOMPLETE_DIR,
-                                  tb);
+    w = trg_json_widget_entry_new(&priv->widgets, s, SGET_INCOMPLETE_DIR, tb);
     hig_workarea_add_row_w(t, &row, tb, w, NULL);
 
-    tb = trg_json_widget_check_new(&priv->widgets, s,
-                                   SGET_SCRIPT_TORRENT_DONE_ENABLED,
+    tb = trg_json_widget_check_new(&priv->widgets, s, SGET_SCRIPT_TORRENT_DONE_ENABLED,
                                    _("Torrent done script"), NULL);
-    w = trg_json_widget_entry_new(&priv->widgets, s,
-                                  SGET_SCRIPT_TORRENT_DONE_FILENAME, tb);
+    w = trg_json_widget_entry_new(&priv->widgets, s, SGET_SCRIPT_TORRENT_DONE_FILENAME, tb);
     hig_workarea_add_row_w(t, &row, tb, w, NULL);
 
     cache_size_mb = session_get_cache_size_mb(s);
     if (cache_size_mb >= 0) {
-        w = trg_json_widget_spin_int_new(&priv->widgets, s, SGET_CACHE_SIZE_MB,
-                                         NULL, 0, INT_MAX, 1);
+        w = trg_json_widget_spin_int_new(&priv->widgets, s, SGET_CACHE_SIZE_MB, NULL, 0, INT_MAX,
+                                         1);
         hig_workarea_add_row(t, &row, _("Cache size (MiB)"), w, w);
     }
 
     hig_workarea_add_section_title(t, &row, _("Behavior"));
 
-    w = trg_json_widget_check_new(&priv->widgets, s,
-                                  SGET_RENAME_PARTIAL_FILES,
+    w = trg_json_widget_check_new(&priv->widgets, s, SGET_RENAME_PARTIAL_FILES,
                                   _("Rename partial files"), NULL);
     hig_workarea_add_wide_control(t, &row, w);
 
-    w = trg_json_widget_check_new(&priv->widgets, s,
-                                  SGET_TRASH_ORIGINAL_TORRENT_FILES, _
-                                  ("Trash original torrent files"), NULL);
+    w = trg_json_widget_check_new(&priv->widgets, s, SGET_TRASH_ORIGINAL_TORRENT_FILES,
+                                  _("Trash original torrent files"), NULL);
     hig_workarea_add_wide_control(t, &row, w);
 
-    w = trg_json_widget_check_new(&priv->widgets, s,
-                                  SGET_START_ADDED_TORRENTS,
+    w = trg_json_widget_check_new(&priv->widgets, s, SGET_START_ADDED_TORRENTS,
                                   _("Start added torrents"), NULL);
     hig_workarea_add_wide_control(t, &row, w);
 
     return t;
 }
 
-static GObject *trg_remote_prefs_dialog_constructor(GType type,
-                                                    guint
-                                                    n_construct_properties,
-                                                    GObjectConstructParam *
-                                                    construct_params)
+static GObject *trg_remote_prefs_dialog_constructor(GType type, guint n_construct_properties,
+                                                    GObjectConstructParam *construct_params)
 {
     GObject *object;
     TrgRemotePrefsDialogPrivate *priv;
     JsonObject *session;
     GtkWidget *notebook, *contentvbox;
 
-    object = G_OBJECT_CLASS
-        (trg_remote_prefs_dialog_parent_class)->constructor(type,
-                                                            n_construct_properties,
-                                                            construct_params);
+    object = G_OBJECT_CLASS(trg_remote_prefs_dialog_parent_class)
+                 ->constructor(type, n_construct_properties, construct_params);
     priv = TRG_REMOTE_PREFS_DIALOG_GET_PRIVATE(object);
     session = trg_client_get_session(priv->client);
 
     contentvbox = gtk_dialog_get_content_area(GTK_DIALOG(object));
 
     gtk_window_set_title(GTK_WINDOW(object), _("Remote Preferences"));
-    gtk_window_set_transient_for(GTK_WINDOW(object),
-                                 GTK_WINDOW(priv->parent));
+    gtk_window_set_transient_for(GTK_WINDOW(object), GTK_WINDOW(priv->parent));
     gtk_window_set_destroy_with_parent(GTK_WINDOW(object), TRUE);
 
-    gtk_dialog_add_button(GTK_DIALOG(object), _("_Close"),
-                          GTK_RESPONSE_CLOSE);
-    gtk_dialog_add_button(GTK_DIALOG(object), _("_OK"),
-                          GTK_RESPONSE_OK);
+    gtk_dialog_add_button(GTK_DIALOG(object), _("_Close"), GTK_RESPONSE_CLOSE);
+    gtk_dialog_add_button(GTK_DIALOG(object), _("_OK"), GTK_RESPONSE_OK);
 
     gtk_container_set_border_width(GTK_CONTAINER(object), GUI_PAD);
 
     gtk_dialog_set_default_response(GTK_DIALOG(object), GTK_RESPONSE_OK);
 
-    g_signal_connect(G_OBJECT(object), "response",
-                     G_CALLBACK(trg_remote_prefs_response_cb), NULL);
+    g_signal_connect(G_OBJECT(object), "response", G_CALLBACK(trg_remote_prefs_response_cb), NULL);
 
     notebook = gtk_notebook_new();
 
     gtk_notebook_append_page(GTK_NOTEBOOK(notebook),
-                             trg_rprefs_generalPage(TRG_REMOTE_PREFS_DIALOG
-                                                    (object), session),
+                             trg_rprefs_generalPage(TRG_REMOTE_PREFS_DIALOG(object), session),
                              gtk_label_new(_("General")));
 
     gtk_notebook_append_page(GTK_NOTEBOOK(notebook),
-                             trg_rprefs_connPage(TRG_REMOTE_PREFS_DIALOG
-                                                 (object), session),
+                             trg_rprefs_connPage(TRG_REMOTE_PREFS_DIALOG(object), session),
                              gtk_label_new(_("Connections")));
 
     gtk_notebook_append_page(GTK_NOTEBOOK(notebook),
-                             trg_rprefs_bandwidthPage
-                             (TRG_REMOTE_PREFS_DIALOG(object), session),
+                             trg_rprefs_bandwidthPage(TRG_REMOTE_PREFS_DIALOG(object), session),
                              gtk_label_new(_("Bandwidth")));
 
     gtk_notebook_append_page(GTK_NOTEBOOK(notebook),
-                             trg_rprefs_limitsPage(TRG_REMOTE_PREFS_DIALOG
-                                                   (object), session),
+                             trg_rprefs_limitsPage(TRG_REMOTE_PREFS_DIALOG(object), session),
                              gtk_label_new(_("Limits")));
 
     gtk_container_set_border_width(GTK_CONTAINER(notebook), GUI_PAD);
@@ -780,8 +657,7 @@ static GObject *trg_remote_prefs_dialog_constructor(GType type,
     return object;
 }
 
-static void
-trg_remote_prefs_dialog_class_init(TrgRemotePrefsDialogClass * klass)
+static void trg_remote_prefs_dialog_class_init(TrgRemotePrefsDialogClass *klass)
 {
     GObjectClass *object_class = G_OBJECT_CLASS(klass);
 
@@ -791,51 +667,28 @@ trg_remote_prefs_dialog_class_init(TrgRemotePrefsDialogClass * klass)
     object_class->get_property = trg_remote_prefs_dialog_get_property;
     object_class->set_property = trg_remote_prefs_dialog_set_property;
 
-    g_object_class_install_property(object_class,
-                                    PROP_CLIENT,
-                                    g_param_spec_pointer("trg-client",
-                                                         "TClient",
-                                                         "Client",
-                                                         G_PARAM_READWRITE
-                                                         |
-                                                         G_PARAM_CONSTRUCT_ONLY
-                                                         |
-                                                         G_PARAM_STATIC_NAME
-                                                         |
-                                                         G_PARAM_STATIC_NICK
-                                                         |
-                                                         G_PARAM_STATIC_BLURB));
+    g_object_class_install_property(
+        object_class, PROP_CLIENT,
+        g_param_spec_pointer("trg-client", "TClient", "Client",
+                             G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME
+                                 | G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
 
-    g_object_class_install_property(object_class,
-                                    PROP_PARENT,
-                                    g_param_spec_object("parent-window",
-                                                        "Parent window",
-                                                        "Parent window",
-                                                        TRG_TYPE_MAIN_WINDOW,
-                                                        G_PARAM_READWRITE |
-                                                        G_PARAM_CONSTRUCT_ONLY
-                                                        |
-                                                        G_PARAM_STATIC_NAME
-                                                        |
-                                                        G_PARAM_STATIC_NICK
-                                                        |
-                                                        G_PARAM_STATIC_BLURB));
+    g_object_class_install_property(
+        object_class, PROP_PARENT,
+        g_param_spec_object("parent-window", "Parent window", "Parent window", TRG_TYPE_MAIN_WINDOW,
+                            G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME
+                                | G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
 }
 
-static void
-trg_remote_prefs_dialog_init(TrgRemotePrefsDialog * self G_GNUC_UNUSED)
+static void trg_remote_prefs_dialog_init(TrgRemotePrefsDialog *self G_GNUC_UNUSED)
 {
 }
 
-TrgRemotePrefsDialog *trg_remote_prefs_dialog_get_instance(TrgMainWindow *
-                                                           parent,
-                                                           TrgClient *
-                                                           client)
+TrgRemotePrefsDialog *trg_remote_prefs_dialog_get_instance(TrgMainWindow *parent, TrgClient *client)
 {
     if (instance == NULL) {
-        instance =
-            g_object_new(TRG_TYPE_REMOTE_PREFS_DIALOG, "parent-window",
-                         parent, "trg-client", client, NULL);
+        instance = g_object_new(TRG_TYPE_REMOTE_PREFS_DIALOG, "parent-window", parent, "trg-client",
+                                client, NULL);
     }
 
     return TRG_REMOTE_PREFS_DIALOG(instance);

--- a/src/trg-remote-prefs-dialog.h
+++ b/src/trg-remote-prefs-dialog.h
@@ -27,17 +27,17 @@
 
 G_BEGIN_DECLS
 #define TRG_TYPE_REMOTE_PREFS_DIALOG trg_remote_prefs_dialog_get_type()
-#define TRG_REMOTE_PREFS_DIALOG(obj) \
-  (G_TYPE_CHECK_INSTANCE_CAST ((obj), TRG_TYPE_REMOTE_PREFS_DIALOG, TrgRemotePrefsDialog))
-#define TRG_REMOTE_PREFS_DIALOG_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_CAST ((klass), TRG_TYPE_REMOTE_PREFS_DIALOG, TrgRemotePrefsDialogClass))
-#define TRG_IS_REMOTE_PREFS_DIALOG(obj) \
-  (G_TYPE_CHECK_INSTANCE_TYPE ((obj), TRG_TYPE_REMOTE_PREFS_DIALOG))
-#define TRG_IS_REMOTE_PREFS_DIALOG_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_TYPE ((klass), TRG_TYPE_REMOTE_PREFS_DIALOG))
-#define TRG_REMOTE_PREFS_DIALOG_GET_CLASS(obj) \
-  (G_TYPE_INSTANCE_GET_CLASS ((obj), TRG_TYPE_REMOTE_PREFS_DIALOG, TrgRemotePrefsDialogClass))
-    typedef struct {
+#define TRG_REMOTE_PREFS_DIALOG(obj)                                                               \
+    (G_TYPE_CHECK_INSTANCE_CAST((obj), TRG_TYPE_REMOTE_PREFS_DIALOG, TrgRemotePrefsDialog))
+#define TRG_REMOTE_PREFS_DIALOG_CLASS(klass)                                                       \
+    (G_TYPE_CHECK_CLASS_CAST((klass), TRG_TYPE_REMOTE_PREFS_DIALOG, TrgRemotePrefsDialogClass))
+#define TRG_IS_REMOTE_PREFS_DIALOG(obj)                                                            \
+    (G_TYPE_CHECK_INSTANCE_TYPE((obj), TRG_TYPE_REMOTE_PREFS_DIALOG))
+#define TRG_IS_REMOTE_PREFS_DIALOG_CLASS(klass)                                                    \
+    (G_TYPE_CHECK_CLASS_TYPE((klass), TRG_TYPE_REMOTE_PREFS_DIALOG))
+#define TRG_REMOTE_PREFS_DIALOG_GET_CLASS(obj)                                                     \
+    (G_TYPE_INSTANCE_GET_CLASS((obj), TRG_TYPE_REMOTE_PREFS_DIALOG, TrgRemotePrefsDialogClass))
+typedef struct {
     GtkDialog parent;
 } TrgRemotePrefsDialog;
 
@@ -47,10 +47,8 @@ typedef struct {
 
 GType trg_remote_prefs_dialog_get_type(void);
 
-TrgRemotePrefsDialog *trg_remote_prefs_dialog_get_instance(TrgMainWindow *
-                                                           parent,
-                                                           TrgClient *
-                                                           client);
+TrgRemotePrefsDialog *trg_remote_prefs_dialog_get_instance(TrgMainWindow *parent,
+                                                           TrgClient *client);
 
 G_END_DECLS
-#endif                          /* TRG_REMOTE_PREFS_DIALOG_H_ */
+#endif /* TRG_REMOTE_PREFS_DIALOG_H_ */

--- a/src/trg-rss-cell-renderer.c
+++ b/src/trg-rss-cell-renderer.c
@@ -2,14 +2,14 @@
 
 #if HAVE_RSS
 
-#include <gtk/gtk.h>
 #include <gdk/gdk.h>
 #include <glib/gi18n.h>
+#include <gtk/gtk.h>
 
-#include "icons.h"
 #include "hig.h"
-#include "util.h"
+#include "icons.h"
 #include "trg-rss-cell-renderer.h"
+#include "util.h"
 
 enum {
     PROP_TITLE = 1,
@@ -18,9 +18,9 @@ enum {
     PROP_UPLOADED
 };
 
-#define SMALL_SCALE 0.9
+#define SMALL_SCALE       0.9
 #define COMPACT_ICON_SIZE GTK_ICON_SIZE_MENU
-#define FULL_ICON_SIZE GTK_ICON_SIZE_DND
+#define FULL_ICON_SIZE    GTK_ICON_SIZE_DND
 
 #define FOREGROUND_COLOR_KEY "foreground-rgba"
 typedef GdkRGBA GtrColor;
@@ -38,71 +38,59 @@ struct TrgRssCellRendererPrivate {
     gboolean uploaded;
 };
 
-static void
-trg_rss_cell_renderer_render(GtkCellRenderer * cell,
-                             GtrDrawable * window, GtkWidget * widget,
-                             const GdkRectangle * background_area,
-                             const GdkRectangle * cell_area,
-                             GtkCellRendererState flags);
+static void trg_rss_cell_renderer_render(GtkCellRenderer *cell, GtrDrawable *window,
+                                         GtkWidget *widget, const GdkRectangle *background_area,
+                                         const GdkRectangle *cell_area, GtkCellRendererState flags);
 
-static void
-gtr_cell_renderer_render(GtkCellRenderer * renderer,
-                         GtrDrawable * drawable,
-                         GtkWidget * widget,
-                         const GdkRectangle * area,
-                         GtkCellRendererState flags)
+static void gtr_cell_renderer_render(GtkCellRenderer *renderer, GtrDrawable *drawable,
+                                     GtkWidget *widget, const GdkRectangle *area,
+                                     GtkCellRendererState flags)
 {
-    gtk_cell_renderer_render(renderer, drawable, widget, area, area,
-                             flags);
+    gtk_cell_renderer_render(renderer, drawable, widget, area, area, flags);
 }
 
-static void trg_rss_cell_renderer_set_property(GObject * object,
-                                               guint property_id,
-                                               const GValue * v,
-                                               GParamSpec * pspec)
+static void trg_rss_cell_renderer_set_property(GObject *object, guint property_id, const GValue *v,
+                                               GParamSpec *pspec)
 {
     TrgRssCellRenderer *self = TRG_RSS_CELL_RENDERER(object);
     struct TrgRssCellRendererPrivate *p = self->priv;
 
     switch (property_id) {
     case PROP_TITLE:
-    	g_free(p->title);
-    	p->title = g_value_dup_string(v);
+        g_free(p->title);
+        p->title = g_value_dup_string(v);
         break;
     case PROP_PUBLISHED:
-    	g_free(p->published);
-    	p->published = g_value_dup_string(v);
-    	break;
+        g_free(p->published);
+        p->published = g_value_dup_string(v);
+        break;
     case PROP_FEED:
-    	g_free(p->feed);
-    	p->feed = g_value_dup_string(v);
-    	break;
+        g_free(p->feed);
+        p->feed = g_value_dup_string(v);
+        break;
     case PROP_UPLOADED:
-    	p->uploaded = g_value_get_boolean(v);
-    	break;
+        p->uploaded = g_value_get_boolean(v);
+        break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, property_id, pspec);
         break;
     }
 }
 
-static void
-trg_rss_cell_renderer_get_property(GObject * object,
-                                   guint property_id,
-                                   GValue * v, GParamSpec * pspec)
+static void trg_rss_cell_renderer_get_property(GObject *object, guint property_id, GValue *v,
+                                               GParamSpec *pspec)
 {
     G_OBJECT_WARN_INVALID_PROPERTY_ID(object, property_id, pspec);
 }
 
-G_DEFINE_TYPE(TrgRssCellRenderer, trg_rss_cell_renderer,
-              GTK_TYPE_CELL_RENDERER)
+G_DEFINE_TYPE(TrgRssCellRenderer, trg_rss_cell_renderer, GTK_TYPE_CELL_RENDERER)
 
-static void trg_rss_cell_renderer_dispose(GObject * o)
+static void trg_rss_cell_renderer_dispose(GObject *o)
 {
     TrgRssCellRenderer *r = TRG_RSS_CELL_RENDERER(o);
 
     if (r && r->priv) {
-    	struct TrgRssCellRendererPrivate *priv = r->priv;
+        struct TrgRssCellRendererPrivate *priv = r->priv;
 
         g_string_free(priv->gstr1, TRUE);
         g_free(priv->feed);
@@ -116,25 +104,21 @@ static void trg_rss_cell_renderer_dispose(GObject * o)
     G_OBJECT_CLASS(trg_rss_cell_renderer_parent_class)->dispose(o);
 }
 
-static GdkPixbuf *get_icon(TrgRssCellRenderer * r, GtkIconSize icon_size,
-                           GtkWidget * for_widget)
+static GdkPixbuf *get_icon(TrgRssCellRenderer *r, GtkIconSize icon_size, GtkWidget *for_widget)
 {
     const char *mime_type = "file";
 
     return gtr_get_mime_type_icon(mime_type, icon_size, for_widget);
 }
 
-static void
-trg_rss_cell_renderer_get_size(GtkCellRenderer * cell, GtkWidget * widget,
-                               const GdkRectangle * cell_area,
-                               gint * x_offset,
-                               gint * y_offset,
-                               gint * width, gint * height)
+static void trg_rss_cell_renderer_get_size(GtkCellRenderer *cell, GtkWidget *widget,
+                                           const GdkRectangle *cell_area, gint *x_offset,
+                                           gint *y_offset, gint *width, gint *height)
 {
     TrgRssCellRenderer *self = TRG_RSS_CELL_RENDERER(cell);
 
     if (self) {
-    	struct TrgRssCellRendererPrivate *p = self->priv;
+        struct TrgRssCellRendererPrivate *p = self->priv;
         int xpad, ypad;
         int h = 0, w = 0;
         GtkRequisition icon_size;
@@ -149,34 +133,26 @@ trg_rss_cell_renderer_get_size(GtkCellRenderer * cell, GtkWidget * widget,
 
         /* get the idealized cell dimensions */
         g_object_set(p->icon_renderer, "pixbuf", icon, NULL);
-        gtk_cell_renderer_get_preferred_size(p->icon_renderer, widget, NULL,
-                                             &icon_size);
-        g_object_set(p->text_renderer, "text", p->title,
-                     "weight", PANGO_WEIGHT_BOLD, "scale", 1.0, "ellipsize",
-                     PANGO_ELLIPSIZE_NONE, NULL);
-        gtk_cell_renderer_get_preferred_size(p->text_renderer, widget, NULL,
-                                             &name_size);
-        g_object_set(p->text_renderer, "text", p->feed, "weight",
-                     PANGO_WEIGHT_NORMAL, "scale", SMALL_SCALE, NULL);
-        gtk_cell_renderer_get_preferred_size(p->text_renderer, widget, NULL,
-                                             &prog_size);
+        gtk_cell_renderer_get_preferred_size(p->icon_renderer, widget, NULL, &icon_size);
+        g_object_set(p->text_renderer, "text", p->title, "weight", PANGO_WEIGHT_BOLD, "scale", 1.0,
+                     "ellipsize", PANGO_ELLIPSIZE_NONE, NULL);
+        gtk_cell_renderer_get_preferred_size(p->text_renderer, widget, NULL, &name_size);
+        g_object_set(p->text_renderer, "text", p->feed, "weight", PANGO_WEIGHT_NORMAL, "scale",
+                     SMALL_SCALE, NULL);
+        gtk_cell_renderer_get_preferred_size(p->text_renderer, widget, NULL, &prog_size);
         g_object_set(p->text_renderer, "text", p->published, NULL);
-        gtk_cell_renderer_get_preferred_size(p->text_renderer, widget, NULL,
-                                             &stat_size);
+        gtk_cell_renderer_get_preferred_size(p->text_renderer, widget, NULL, &stat_size);
 
         /**
         *** LAYOUT
         **/
 
         if (width != NULL)
-            *width = w =
-                xpad * 2 + icon_size.width + GUI_PAD + MAX3(name_size.width,
-                                                            prog_size.width,
-                                                            stat_size.width);
+            *width = w = xpad * 2 + icon_size.width + GUI_PAD
+                + MAX3(name_size.width, prog_size.width, stat_size.width);
         if (height != NULL)
-            *height = h =
-                ypad * 2 + name_size.height + prog_size.height +
-                GUI_PAD_SMALL + stat_size.height;
+            *height = h
+                = ypad * 2 + name_size.height + prog_size.height + GUI_PAD_SMALL + stat_size.height;
 
         /* cleanup */
         g_object_unref(icon);
@@ -187,21 +163,17 @@ trg_rss_cell_renderer_get_size(GtkCellRenderer * cell, GtkWidget * widget,
         if (y_offset) {
             int xpad, ypad;
             gtk_cell_renderer_get_padding(cell, &xpad, &ypad);
-            *y_offset =
-                cell_area ? (int) ((cell_area->height - (ypad * 2 + h)) /
-                                   2.0) : 0;
+            *y_offset = cell_area ? (int)((cell_area->height - (ypad * 2 + h)) / 2.0) : 0;
         }
     }
 }
 
-static void
-trg_rss_cell_renderer_class_init(TrgRssCellRendererClass * klass)
+static void trg_rss_cell_renderer_class_init(TrgRssCellRendererClass *klass)
 {
     GObjectClass *gobject_class = G_OBJECT_CLASS(klass);
     GtkCellRendererClass *cell_class = GTK_CELL_RENDERER_CLASS(klass);
 
-    g_type_class_add_private(klass,
-                             sizeof(struct TrgRssCellRendererPrivate));
+    g_type_class_add_private(klass, sizeof(struct TrgRssCellRendererPrivate));
 
     cell_class->render = trg_rss_cell_renderer_render;
     cell_class->get_size = trg_rss_cell_renderer_get_size;
@@ -209,57 +181,29 @@ trg_rss_cell_renderer_class_init(TrgRssCellRendererClass * klass)
     gobject_class->get_property = trg_rss_cell_renderer_get_property;
     gobject_class->dispose = trg_rss_cell_renderer_dispose;
 
-    g_object_class_install_property(gobject_class,
-                                    PROP_TITLE,
-                                    g_param_spec_string("title",
-                                                        "title",
-                                                        "Title",
-                                                        NULL,
-                                                        G_PARAM_READWRITE |
-                                                        G_PARAM_STATIC_NAME
-                                                        |
-                                                        G_PARAM_STATIC_NICK
-                                                        |
-                                                        G_PARAM_STATIC_BLURB));
+    g_object_class_install_property(gobject_class, PROP_TITLE,
+                                    g_param_spec_string("title", "title", "Title", NULL,
+                                                        G_PARAM_READWRITE | G_PARAM_STATIC_NAME
+                                                            | G_PARAM_STATIC_NICK
+                                                            | G_PARAM_STATIC_BLURB));
 
-    g_object_class_install_property(gobject_class,
-                                    PROP_PUBLISHED,
-                                    g_param_spec_string("published",
-                                                        "published",
-                                                        "Published",
-                                                        NULL,
-                                                        G_PARAM_READWRITE |
-                                                        G_PARAM_STATIC_NAME
-                                                        |
-                                                        G_PARAM_STATIC_NICK
-                                                        |
-                                                        G_PARAM_STATIC_BLURB));
+    g_object_class_install_property(gobject_class, PROP_PUBLISHED,
+                                    g_param_spec_string("published", "published", "Published", NULL,
+                                                        G_PARAM_READWRITE | G_PARAM_STATIC_NAME
+                                                            | G_PARAM_STATIC_NICK
+                                                            | G_PARAM_STATIC_BLURB));
 
-    g_object_class_install_property(gobject_class,
-                                    PROP_FEED,
-                                    g_param_spec_string("feed",
-                                                        "feed",
-                                                        "Feed",
-                                                        NULL,
-                                                        G_PARAM_READWRITE |
-                                                        G_PARAM_STATIC_NAME
-                                                        |
-                                                        G_PARAM_STATIC_NICK
-                                                        |
-                                                        G_PARAM_STATIC_BLURB));
+    g_object_class_install_property(gobject_class, PROP_FEED,
+                                    g_param_spec_string("feed", "feed", "Feed", NULL,
+                                                        G_PARAM_READWRITE | G_PARAM_STATIC_NAME
+                                                            | G_PARAM_STATIC_NICK
+                                                            | G_PARAM_STATIC_BLURB));
 
-    g_object_class_install_property(gobject_class,
-                                    PROP_UPLOADED,
-                                    g_param_spec_boolean("uploaded",
-                                                        "uploaded",
-                                                        "Uploaded",
-                                                        FALSE,
-                                                        G_PARAM_READWRITE |
-                                                        G_PARAM_STATIC_NAME
-                                                        |
-                                                        G_PARAM_STATIC_NICK
-                                                        |
-                                                        G_PARAM_STATIC_BLURB));
+    g_object_class_install_property(gobject_class, PROP_UPLOADED,
+                                    g_param_spec_boolean("uploaded", "uploaded", "Uploaded", FALSE,
+                                                         G_PARAM_READWRITE | G_PARAM_STATIC_NAME
+                                                             | G_PARAM_STATIC_NICK
+                                                             | G_PARAM_STATIC_BLURB));
 
     /*g_object_class_install_property(gobject_class, P_BAR_HEIGHT,
                                     g_param_spec_int("bar-height", NULL,
@@ -267,17 +211,14 @@ trg_rss_cell_renderer_class_init(TrgRssCellRendererClass * klass)
                                                      1, INT_MAX,
                                                      DEFAULT_BAR_HEIGHT,
                                                      G_PARAM_READWRITE));*/
-
 }
 
-static void trg_rss_cell_renderer_init(TrgRssCellRenderer * self)
+static void trg_rss_cell_renderer_init(TrgRssCellRenderer *self)
 {
     struct TrgRssCellRendererPrivate *p;
 
-    p = self->priv = G_TYPE_INSTANCE_GET_PRIVATE(self,
-                                                 TRG_RSS_CELL_RENDERER_TYPE,
-                                                 struct
-                                                 TrgRssCellRendererPrivate);
+    p = self->priv = G_TYPE_INSTANCE_GET_PRIVATE(self, TRG_RSS_CELL_RENDERER_TYPE,
+                                                 struct TrgRssCellRendererPrivate);
 
     p->gstr1 = g_string_new(NULL);
     p->gstr2 = g_string_new(NULL);
@@ -288,16 +229,12 @@ static void trg_rss_cell_renderer_init(TrgRssCellRenderer * self)
     g_object_ref_sink(p->icon_renderer);
 }
 
-
 GtkCellRenderer *trg_rss_cell_renderer_new(void)
 {
-    return (GtkCellRenderer *) g_object_new(TRG_RSS_CELL_RENDERER_TYPE,
-                                            NULL);
+    return (GtkCellRenderer *)g_object_new(TRG_RSS_CELL_RENDERER_TYPE, NULL);
 }
 
-static void
-get_text_color(TrgRssCellRenderer * r, GtkWidget * widget,
-               GtrColor * setme)
+static void get_text_color(TrgRssCellRenderer *r, GtkWidget *widget, GtrColor *setme)
 {
     struct TrgRssCellRendererPrivate *p = r->priv;
 
@@ -305,16 +242,13 @@ get_text_color(TrgRssCellRenderer * r, GtkWidget * widget,
         gtk_style_context_get_color(gtk_widget_get_style_context(widget),
                                     GTK_STATE_FLAG_INSENSITIVE, setme);
     else
-        gtk_style_context_get_color(gtk_widget_get_style_context(widget),
-                                    GTK_STATE_FLAG_NORMAL, setme);
+        gtk_style_context_get_color(gtk_widget_get_style_context(widget), GTK_STATE_FLAG_NORMAL,
+                                    setme);
 }
 
-static void
-trg_rss_cell_renderer_render(GtkCellRenderer * cell,
-                             GtrDrawable * window, GtkWidget * widget,
-                             const GdkRectangle * background_area,
-                             const GdkRectangle * cell_area,
-                             GtkCellRendererState flags)
+static void trg_rss_cell_renderer_render(GtkCellRenderer *cell, GtrDrawable *window,
+                                         GtkWidget *widget, const GdkRectangle *background_area,
+                                         const GdkRectangle *cell_area, GtkCellRendererState flags)
 {
     TrgRssCellRenderer *self = TRG_RSS_CELL_RENDERER(cell);
     int xpad, ypad;
@@ -330,7 +264,7 @@ trg_rss_cell_renderer_render(GtkCellRenderer * cell,
     struct TrgRssCellRendererPrivate *p;
 
     if (!self)
-    	return;
+        return;
 
     p = self->priv;
 
@@ -340,26 +274,21 @@ trg_rss_cell_renderer_render(GtkCellRenderer * cell,
 
     /* get the idealized cell dimensions */
     g_object_set(p->icon_renderer, "pixbuf", icon, NULL);
-    gtk_cell_renderer_get_preferred_size(p->icon_renderer, widget, NULL,
-                                         &size);
+    gtk_cell_renderer_get_preferred_size(p->icon_renderer, widget, NULL, &size);
     icon_area.width = size.width;
     icon_area.height = size.height;
-    g_object_set(p->text_renderer, "text", p->title,
-                 "weight", PANGO_WEIGHT_BOLD, "ellipsize",
+    g_object_set(p->text_renderer, "text", p->title, "weight", PANGO_WEIGHT_BOLD, "ellipsize",
                  PANGO_ELLIPSIZE_NONE, "scale", 1.0, NULL);
-    gtk_cell_renderer_get_preferred_size(p->text_renderer, widget, NULL,
-                                         &size);
+    gtk_cell_renderer_get_preferred_size(p->text_renderer, widget, NULL, &size);
     name_area.width = size.width;
     name_area.height = size.height;
-    g_object_set(p->text_renderer, "text", p->feed, "weight",
-                 PANGO_WEIGHT_NORMAL, "scale", SMALL_SCALE, NULL);
-    gtk_cell_renderer_get_preferred_size(p->text_renderer, widget, NULL,
-                                         &size);
+    g_object_set(p->text_renderer, "text", p->feed, "weight", PANGO_WEIGHT_NORMAL, "scale",
+                 SMALL_SCALE, NULL);
+    gtk_cell_renderer_get_preferred_size(p->text_renderer, widget, NULL, &size);
     prog_area.width = size.width;
     prog_area.height = size.height;
     g_object_set(p->text_renderer, "text", p->published, NULL);
-    gtk_cell_renderer_get_preferred_size(p->text_renderer, widget, NULL,
-                                         &size);
+    gtk_cell_renderer_get_preferred_size(p->text_renderer, widget, NULL, &size);
     stat_area.width = size.width;
     stat_area.height = size.height;
 
@@ -380,8 +309,7 @@ trg_rss_cell_renderer_render(GtkCellRenderer * cell,
     /* name */
     name_area.x = icon_area.x + icon_area.width + GUI_PAD;
     name_area.y = fill_area.y;
-    name_area.width =
-        fill_area.width - GUI_PAD - icon_area.width - GUI_PAD_SMALL;
+    name_area.width = fill_area.width - GUI_PAD - icon_area.width - GUI_PAD_SMALL;
 
     /* prog */
     prog_area.x = name_area.x;
@@ -403,24 +331,16 @@ trg_rss_cell_renderer_render(GtkCellRenderer * cell,
     *** RENDER
     **/
 
-    g_object_set(p->icon_renderer, "pixbuf", icon, "sensitive", TRUE,
-                 NULL);
-    gtr_cell_renderer_render(p->icon_renderer, window, widget, &icon_area,
-                             flags);
-    g_object_set(p->text_renderer, "text", p->title,
-                 "scale", 1.0, FOREGROUND_COLOR_KEY, &text_color,
-                 "ellipsize", PANGO_ELLIPSIZE_END, "weight",
-                 PANGO_WEIGHT_BOLD, NULL);
-    gtr_cell_renderer_render(p->text_renderer, window, widget, &name_area,
-                             flags);
-    g_object_set(p->text_renderer, "text", p->feed, "scale",
-                 SMALL_SCALE, "weight", PANGO_WEIGHT_NORMAL, NULL);
-    gtr_cell_renderer_render(p->text_renderer, window, widget, &prog_area,
-                             flags);
-    g_object_set(p->text_renderer, "text", p->published,
-                 FOREGROUND_COLOR_KEY, &text_color, NULL);
-    gtr_cell_renderer_render(p->text_renderer, window, widget, &stat_area,
-                             flags);
+    g_object_set(p->icon_renderer, "pixbuf", icon, "sensitive", TRUE, NULL);
+    gtr_cell_renderer_render(p->icon_renderer, window, widget, &icon_area, flags);
+    g_object_set(p->text_renderer, "text", p->title, "scale", 1.0, FOREGROUND_COLOR_KEY,
+                 &text_color, "ellipsize", PANGO_ELLIPSIZE_END, "weight", PANGO_WEIGHT_BOLD, NULL);
+    gtr_cell_renderer_render(p->text_renderer, window, widget, &name_area, flags);
+    g_object_set(p->text_renderer, "text", p->feed, "scale", SMALL_SCALE, "weight",
+                 PANGO_WEIGHT_NORMAL, NULL);
+    gtr_cell_renderer_render(p->text_renderer, window, widget, &prog_area, flags);
+    g_object_set(p->text_renderer, "text", p->published, FOREGROUND_COLOR_KEY, &text_color, NULL);
+    gtr_cell_renderer_render(p->text_renderer, window, widget, &stat_area, flags);
 
     /* cleanup */
     g_object_unref(icon);

--- a/src/trg-rss-cell-renderer.h
+++ b/src/trg-rss-cell-renderer.h
@@ -24,12 +24,10 @@
 
 #include <gtk/gtk.h>
 
-#define TRG_RSS_CELL_RENDERER_TYPE ( trg_rss_cell_renderer_get_type( ) )
+#define TRG_RSS_CELL_RENDERER_TYPE (trg_rss_cell_renderer_get_type())
 
-#define TRG_RSS_CELL_RENDERER( o ) \
-    ( G_TYPE_CHECK_INSTANCE_CAST( ( o ), \
-                                 TRG_RSS_CELL_RENDERER_TYPE, \
-                                 TrgRssCellRenderer ) )
+#define TRG_RSS_CELL_RENDERER(o)                                                                   \
+    (G_TYPE_CHECK_INSTANCE_CAST((o), TRG_RSS_CELL_RENDERER_TYPE, TrgRssCellRenderer))
 
 typedef struct TrgRssCellRenderer TrgRssCellRenderer;
 
@@ -50,4 +48,4 @@ GtkCellRenderer *trg_rss_cell_renderer_new(void);
 
 #endif
 
-#endif                          /* TRG_RSS_CELL_RENDERER_H */
+#endif /* TRG_RSS_CELL_RENDERER_H */

--- a/src/trg-rss-model.c
+++ b/src/trg-rss-model.c
@@ -31,244 +31,235 @@
 #include "trg-rss-model.h"
 
 enum {
-	PROP_0, PROP_CLIENT
+    PROP_0,
+    PROP_CLIENT
 };
 
 enum {
-	SIGNAL_GET_ERROR, SIGNAL_PARSE_ERROR, SIGNAL_COUNT
+    SIGNAL_GET_ERROR,
+    SIGNAL_PARSE_ERROR,
+    SIGNAL_COUNT
 };
 
 static guint signals[SIGNAL_COUNT] = { 0 };
 
 G_DEFINE_TYPE(TrgRssModel, trg_rss_model, GTK_TYPE_LIST_STORE)
-#define TRG_RSS_MODEL_GET_PRIVATE(o) \
-  (G_TYPE_INSTANCE_GET_PRIVATE ((o), TRG_TYPE_RSS_MODEL, TrgRssModelPrivate))
+#define TRG_RSS_MODEL_GET_PRIVATE(o)                                                               \
+    (G_TYPE_INSTANCE_GET_PRIVATE((o), TRG_TYPE_RSS_MODEL, TrgRssModelPrivate))
 typedef struct _TrgRssModelPrivate TrgRssModelPrivate;
 
 struct _TrgRssModelPrivate {
-	TrgClient *client;
-	GHashTable *table;
-	guint index;
+    TrgClient *client;
+    GHashTable *table;
+    guint index;
 };
 
 typedef struct {
-	TrgRssModel *model;
-	gchar *feed_id;
-	gchar *feed_url;
-	gchar *feed_cookie;
-	GError *error;
-	trg_response *response;
+    TrgRssModel *model;
+    gchar *feed_id;
+    gchar *feed_url;
+    gchar *feed_cookie;
+    GError *error;
+    trg_response *response;
 } feed_update;
 
-static void feed_update_free(feed_update *update) {
-	if (update->error)
-		g_error_free(update->error);
+static void feed_update_free(feed_update *update)
+{
+    if (update->error)
+        g_error_free(update->error);
 
-	g_free(update->feed_id);
-	g_free(update->feed_url);
-	g_free(update->feed_cookie);
+    g_free(update->feed_id);
+    g_free(update->feed_url);
+    g_free(update->feed_cookie);
 
-	g_free(update);
+    g_free(update);
 }
 
-static gboolean on_rss_receive(gpointer data) {
-	trg_response *response = (trg_response *) data;
-	feed_update *update = (feed_update*) response->cb_data;
-	TrgRssModel *model = update->model;
-	TrgRssModelPrivate *priv = TRG_RSS_MODEL_GET_PRIVATE(model);
+static gboolean on_rss_receive(gpointer data)
+{
+    trg_response *response = (trg_response *)data;
+    feed_update *update = (feed_update *)response->cb_data;
+    TrgRssModel *model = update->model;
+    TrgRssModelPrivate *priv = TRG_RSS_MODEL_GET_PRIVATE(model);
 
-	if (response->status == CURLE_OK) {
-		RssParser* parser = rss_parser_new();
-		GError *error = NULL;
-		if (rss_parser_load_from_data(parser, response->raw,
-				response->size, &error)) {
-			RssDocument *doc = rss_parser_get_document(parser);
-			GtkTreeIter iter;
-			GList *list, *tmp;
+    if (response->status == CURLE_OK) {
+        RssParser *parser = rss_parser_new();
+        GError *error = NULL;
+        if (rss_parser_load_from_data(parser, response->raw, response->size, &error)) {
+            RssDocument *doc = rss_parser_get_document(parser);
+            GtkTreeIter iter;
+            GList *list, *tmp;
 
-			list = rss_document_get_items(doc);
+            list = rss_document_get_items(doc);
 
-			for (tmp = list; tmp != NULL; tmp = tmp->next) {
-				RssItem *item = (RssItem*) tmp->data;
-				const gchar *guid = rss_item_get_guid(item);
-				if (g_hash_table_lookup(priv->table, guid) != (void*) 1) {
-					gtk_list_store_append(GTK_LIST_STORE(model), &iter);
-					gtk_list_store_set(GTK_LIST_STORE(model), &iter, RSSCOL_ID,
-							guid, RSSCOL_TITLE, rss_item_get_title(item),
-							RSSCOL_LINK, rss_item_get_link(item), RSSCOL_FEED,
-							update->feed_id, RSSCOL_COOKIE, update->feed_cookie, RSSCOL_PUBDATE,
-							rss_item_get_pub_date(item), -1);
-					g_hash_table_insert(priv->table, g_strdup(guid), (void*) 1);
-				}
-			}
+            for (tmp = list; tmp != NULL; tmp = tmp->next) {
+                RssItem *item = (RssItem *)tmp->data;
+                const gchar *guid = rss_item_get_guid(item);
+                if (g_hash_table_lookup(priv->table, guid) != (void *)1) {
+                    gtk_list_store_append(GTK_LIST_STORE(model), &iter);
+                    gtk_list_store_set(GTK_LIST_STORE(model), &iter, RSSCOL_ID, guid, RSSCOL_TITLE,
+                                       rss_item_get_title(item), RSSCOL_LINK,
+                                       rss_item_get_link(item), RSSCOL_FEED, update->feed_id,
+                                       RSSCOL_COOKIE, update->feed_cookie, RSSCOL_PUBDATE,
+                                       rss_item_get_pub_date(item), -1);
+                    g_hash_table_insert(priv->table, g_strdup(guid), (void *)1);
+                }
+            }
 
-			g_list_free(list);
-			g_object_unref(doc);
-			g_object_unref(parser);
-		} else {
-			rss_parse_error perror;
-			perror.error = error;
-			perror.feed_id = update->feed_id;
+            g_list_free(list);
+            g_object_unref(doc);
+            g_object_unref(parser);
+        } else {
+            rss_parse_error perror;
+            perror.error = error;
+            perror.feed_id = update->feed_id;
 
-		    g_signal_emit(model, signals[SIGNAL_PARSE_ERROR], 0,
-		                  &perror);
+            g_signal_emit(model, signals[SIGNAL_PARSE_ERROR], 0, &perror);
 
-		    g_message("parse error: %s", error->message);
-			g_error_free(error);
-		}
-	} else {
-		rss_get_error get_error;
-		get_error.error_code = response->status;
-		get_error.feed_id = update->feed_id;
+            g_message("parse error: %s", error->message);
+            g_error_free(error);
+        }
+    } else {
+        rss_get_error get_error;
+        get_error.error_code = response->status;
+        get_error.feed_id = update->feed_id;
 
-	    g_signal_emit(model, signals[SIGNAL_GET_ERROR], 0,
-	                  &get_error);
-	}
+        g_signal_emit(model, signals[SIGNAL_GET_ERROR], 0, &get_error);
+    }
 
-	trg_response_free(response);
-	feed_update_free(update);
+    trg_response_free(response);
+    feed_update_free(update);
 
-	return FALSE;
+    return FALSE;
 }
 
-void trg_rss_model_update(TrgRssModel * model) {
-	TrgRssModelPrivate *priv = TRG_RSS_MODEL_GET_PRIVATE(model);
-	TrgPrefs *prefs = trg_client_get_prefs(priv->client);
-	JsonArray *feeds = trg_prefs_get_rss(prefs);
-	GRegex *cookie_regex;
-	GList *li;
+void trg_rss_model_update(TrgRssModel *model)
+{
+    TrgRssModelPrivate *priv = TRG_RSS_MODEL_GET_PRIVATE(model);
+    TrgPrefs *prefs = trg_client_get_prefs(priv->client);
+    JsonArray *feeds = trg_prefs_get_rss(prefs);
+    GRegex *cookie_regex;
+    GList *li;
 
-	if (!feeds)
-	    return;
+    if (!feeds)
+        return;
 
-	cookie_regex = g_regex_new("(.*):COOKIE:(.*)", 0, 0, NULL);
+    cookie_regex = g_regex_new("(.*):COOKIE:(.*)", 0, 0, NULL);
 
-	for (li = json_array_get_elements(feeds); li != NULL;
-			li = g_list_next(li)) {
-		JsonObject *feed = json_node_get_object((JsonNode *) li->data);
-		const gchar *feed_url = json_object_get_string_member(feed, "url");
-		const gchar *id = json_object_get_string_member(feed, "id");
-		feed_update *update;
-		GMatchInfo *match;
+    for (li = json_array_get_elements(feeds); li != NULL; li = g_list_next(li)) {
+        JsonObject *feed = json_node_get_object((JsonNode *)li->data);
+        const gchar *feed_url = json_object_get_string_member(feed, "url");
+        const gchar *id = json_object_get_string_member(feed, "id");
+        feed_update *update;
+        GMatchInfo *match;
 
-		if (!feed_url || !id)
-			continue;
+        if (!feed_url || !id)
+            continue;
 
-		update = g_new0(feed_update, 1);
-		update->feed_id = g_strdup(id);
-		update->model = model;
+        update = g_new0(feed_update, 1);
+        update->feed_id = g_strdup(id);
+        update->model = model;
 
-		if (g_regex_match (cookie_regex, feed_url, 0, &match)) {
-			update->feed_url = g_match_info_fetch(match, 1);
-			update->feed_cookie = g_match_info_fetch(match, 2);
-			g_match_info_free(match);
-		} else {
-			update->feed_url = g_strdup(feed_url);
-		}
+        if (g_regex_match(cookie_regex, feed_url, 0, &match)) {
+            update->feed_url = g_match_info_fetch(match, 1);
+            update->feed_cookie = g_match_info_fetch(match, 2);
+            g_match_info_free(match);
+        } else {
+            update->feed_url = g_strdup(feed_url);
+        }
 
-		async_http_request(priv->client, update->feed_url, update->feed_cookie, on_rss_receive,
-				update);
-	}
+        async_http_request(priv->client, update->feed_url, update->feed_cookie, on_rss_receive,
+                           update);
+    }
 
-	g_regex_unref(cookie_regex);
+    g_regex_unref(cookie_regex);
 
-	/*trg_model_remove_removed(GTK_LIST_STORE(model),
-	 RSSCOL_UPDATESERIAL, updateSerial);*/
+    /*trg_model_remove_removed(GTK_LIST_STORE(model),
+     RSSCOL_UPDATESERIAL, updateSerial);*/
 }
 
-static void trg_rss_model_set_property(GObject * object, guint prop_id,
-		const GValue * value, GParamSpec * pspec G_GNUC_UNUSED) {
-	TrgRssModelPrivate *priv = TRG_RSS_MODEL_GET_PRIVATE(object);
+static void trg_rss_model_set_property(GObject *object, guint prop_id, const GValue *value,
+                                       GParamSpec *pspec G_GNUC_UNUSED)
+{
+    TrgRssModelPrivate *priv = TRG_RSS_MODEL_GET_PRIVATE(object);
 
-	switch (prop_id) {
-	case PROP_CLIENT:
-		priv->client = g_value_get_pointer(value);
-		break;
-	}
+    switch (prop_id) {
+    case PROP_CLIENT:
+        priv->client = g_value_get_pointer(value);
+        break;
+    }
 }
 
-static void trg_rss_model_get_property(GObject * object, guint prop_id,
-		GValue * value, GParamSpec * pspec G_GNUC_UNUSED) {
+static void trg_rss_model_get_property(GObject *object, guint prop_id, GValue *value,
+                                       GParamSpec *pspec G_GNUC_UNUSED)
+{
 }
 
-static GObject *trg_rss_model_constructor(GType type,
-		guint n_construct_properties, GObjectConstructParam * construct_params) {
-	GObject *obj = G_OBJECT_CLASS
-	(trg_rss_model_parent_class)->constructor(type,
-			n_construct_properties, construct_params);
-	TrgRssModelPrivate *priv = TRG_RSS_MODEL_GET_PRIVATE(obj);
+static GObject *trg_rss_model_constructor(GType type, guint n_construct_properties,
+                                          GObjectConstructParam *construct_params)
+{
+    GObject *obj = G_OBJECT_CLASS(trg_rss_model_parent_class)
+                       ->constructor(type, n_construct_properties, construct_params);
+    TrgRssModelPrivate *priv = TRG_RSS_MODEL_GET_PRIVATE(obj);
 
-	priv->table = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, NULL);
+    priv->table = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, NULL);
 
-	return obj;
+    return obj;
 }
 
-static void trg_rss_model_dispose(GObject * object) {
-	TrgRssModelPrivate *priv = TRG_RSS_MODEL_GET_PRIVATE(object);
-	g_hash_table_destroy(priv->table);
-	G_OBJECT_CLASS(trg_rss_model_parent_class)->dispose(object);
+static void trg_rss_model_dispose(GObject *object)
+{
+    TrgRssModelPrivate *priv = TRG_RSS_MODEL_GET_PRIVATE(object);
+    g_hash_table_destroy(priv->table);
+    G_OBJECT_CLASS(trg_rss_model_parent_class)->dispose(object);
 }
 
-static void trg_rss_model_class_init(TrgRssModelClass * klass) {
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
+static void trg_rss_model_class_init(TrgRssModelClass *klass)
+{
+    GObjectClass *object_class = G_OBJECT_CLASS(klass);
 
-	g_type_class_add_private(klass, sizeof(TrgRssModelPrivate));
+    g_type_class_add_private(klass, sizeof(TrgRssModelPrivate));
 
-	object_class->set_property = trg_rss_model_set_property;
-	object_class->get_property = trg_rss_model_get_property;
-	object_class->constructor = trg_rss_model_constructor;
-	object_class->dispose = trg_rss_model_dispose;
+    object_class->set_property = trg_rss_model_set_property;
+    object_class->get_property = trg_rss_model_get_property;
+    object_class->constructor = trg_rss_model_constructor;
+    object_class->dispose = trg_rss_model_dispose;
 
-	g_object_class_install_property(object_class, PROP_CLIENT,
-			g_param_spec_pointer("client", "client", "client",
-					G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY
-							| G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK
-							| G_PARAM_STATIC_BLURB));
+    g_object_class_install_property(
+        object_class, PROP_CLIENT,
+        g_param_spec_pointer("client", "client", "client",
+                             G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME
+                                 | G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
 
-    signals[SIGNAL_GET_ERROR] = g_signal_new("get-error",
-                                                     G_TYPE_FROM_CLASS
-                                                     (object_class),
-                                                     G_SIGNAL_RUN_LAST |
-                                                     G_SIGNAL_ACTION,
-                                                     G_STRUCT_OFFSET
-                                                     (TrgRssModelClass,
-                                                      get_error),
-                                                     NULL, NULL,
-                                                     g_cclosure_marshal_VOID__POINTER,
-                                                     G_TYPE_NONE, 1,
-                                                     G_TYPE_POINTER);
+    signals[SIGNAL_GET_ERROR] = g_signal_new(
+        "get-error", G_TYPE_FROM_CLASS(object_class), G_SIGNAL_RUN_LAST | G_SIGNAL_ACTION,
+        G_STRUCT_OFFSET(TrgRssModelClass, get_error), NULL, NULL, g_cclosure_marshal_VOID__POINTER,
+        G_TYPE_NONE, 1, G_TYPE_POINTER);
 
-    signals[SIGNAL_PARSE_ERROR] = g_signal_new("parse-error",
-                                                     G_TYPE_FROM_CLASS
-                                                     (object_class),
-                                                     G_SIGNAL_RUN_LAST |
-                                                     G_SIGNAL_ACTION,
-                                                     G_STRUCT_OFFSET
-                                                     (TrgRssModelClass,
-                                                      parse_error),
-                                                     NULL, NULL,
-                                                     g_cclosure_marshal_VOID__POINTER,
-                                                     G_TYPE_NONE, 1,
-                                                     G_TYPE_POINTER);
+    signals[SIGNAL_PARSE_ERROR] = g_signal_new(
+        "parse-error", G_TYPE_FROM_CLASS(object_class), G_SIGNAL_RUN_LAST | G_SIGNAL_ACTION,
+        G_STRUCT_OFFSET(TrgRssModelClass, parse_error), NULL, NULL,
+        g_cclosure_marshal_VOID__POINTER, G_TYPE_NONE, 1, G_TYPE_POINTER);
 }
 
-static void trg_rss_model_init(TrgRssModel * self) {
-	GType column_types[RSSCOL_COLUMNS];
+static void trg_rss_model_init(TrgRssModel *self)
+{
+    GType column_types[RSSCOL_COLUMNS];
 
-	column_types[RSSCOL_ID] = G_TYPE_STRING;
-	column_types[RSSCOL_TITLE] = G_TYPE_STRING;
-	column_types[RSSCOL_LINK] = G_TYPE_STRING;
-	column_types[RSSCOL_COOKIE] = G_TYPE_STRING;
-	column_types[RSSCOL_FEED] = G_TYPE_STRING;
-	column_types[RSSCOL_PUBDATE] = G_TYPE_STRING;
-	column_types[RSSCOL_UPLOADED] = G_TYPE_BOOLEAN;
+    column_types[RSSCOL_ID] = G_TYPE_STRING;
+    column_types[RSSCOL_TITLE] = G_TYPE_STRING;
+    column_types[RSSCOL_LINK] = G_TYPE_STRING;
+    column_types[RSSCOL_COOKIE] = G_TYPE_STRING;
+    column_types[RSSCOL_FEED] = G_TYPE_STRING;
+    column_types[RSSCOL_PUBDATE] = G_TYPE_STRING;
+    column_types[RSSCOL_UPLOADED] = G_TYPE_BOOLEAN;
 
-	gtk_list_store_set_column_types(GTK_LIST_STORE(self), RSSCOL_COLUMNS,
-			column_types);
+    gtk_list_store_set_column_types(GTK_LIST_STORE(self), RSSCOL_COLUMNS, column_types);
 }
 
-TrgRssModel *trg_rss_model_new(TrgClient *client) {
-	return g_object_new(TRG_TYPE_RSS_MODEL, "client", client, NULL);
+TrgRssModel *trg_rss_model_new(TrgClient *client)
+{
+    return g_object_new(TRG_TYPE_RSS_MODEL, "client", client, NULL);
 }
 
 #endif

--- a/src/trg-rss-model.h
+++ b/src/trg-rss-model.h
@@ -30,36 +30,31 @@
 
 G_BEGIN_DECLS
 #define TRG_TYPE_RSS_MODEL trg_rss_model_get_type()
-#define TRG_RSS_MODEL(obj) \
-  (G_TYPE_CHECK_INSTANCE_CAST ((obj), TRG_TYPE_RSS_MODEL, TrgRssModel))
-#define TRG_RSS_MODEL_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_CAST ((klass), TRG_TYPE_RSS_MODEL, TrgRssModelClass))
-#define TRG_IS_RSS_MODEL(obj) \
-  (G_TYPE_CHECK_INSTANCE_TYPE ((obj), TRG_TYPE_RSS_MODEL))
-#define TRG_IS_RSS_MODEL_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_TYPE ((klass), TRG_TYPE_RSS_MODEL))
-#define TRG_RSS_MODEL_GET_CLASS(obj) \
-  (G_TYPE_INSTANCE_GET_CLASS ((obj), TRG_TYPE_RSS_MODEL, TrgRssModelClass))
-    typedef struct {
+#define TRG_RSS_MODEL(obj) (G_TYPE_CHECK_INSTANCE_CAST((obj), TRG_TYPE_RSS_MODEL, TrgRssModel))
+#define TRG_RSS_MODEL_CLASS(klass)                                                                 \
+    (G_TYPE_CHECK_CLASS_CAST((klass), TRG_TYPE_RSS_MODEL, TrgRssModelClass))
+#define TRG_IS_RSS_MODEL(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), TRG_TYPE_RSS_MODEL))
+#define TRG_IS_RSS_MODEL_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass), TRG_TYPE_RSS_MODEL))
+#define TRG_RSS_MODEL_GET_CLASS(obj)                                                               \
+    (G_TYPE_INSTANCE_GET_CLASS((obj), TRG_TYPE_RSS_MODEL, TrgRssModelClass))
+typedef struct {
     GtkListStore parent;
 } TrgRssModel;
 
 typedef struct {
-	gchar *feed_id;
-	gint error_code;
+    gchar *feed_id;
+    gint error_code;
 } rss_get_error;
 
 typedef struct {
-	GError *error;
-	gchar *feed_id;
+    GError *error;
+    gchar *feed_id;
 } rss_parse_error;
 
 typedef struct {
     GtkListStoreClass parent_class;
-    void (*get_error) (TrgRssModel * model,
-                               rss_get_error *error);
-    void (*parse_error) (TrgRssModel * model,
-                               rss_parse_error *error);
+    void (*get_error)(TrgRssModel *model, rss_get_error *error);
+    void (*parse_error)(TrgRssModel *model, rss_parse_error *error);
 } TrgRssModelClass;
 
 GType trg_rss_model_get_type(void);
@@ -67,7 +62,7 @@ GType trg_rss_model_get_type(void);
 TrgRssModel *trg_rss_model_new(TrgClient *client);
 
 G_END_DECLS
-void trg_rss_model_update(TrgRssModel * model);
+void trg_rss_model_update(TrgRssModel *model);
 
 enum {
     RSSCOL_ID,
@@ -82,4 +77,4 @@ enum {
 
 #endif
 
-#endif                          /* TRG_RSS_MODEL_H_ */
+#endif /* TRG_RSS_MODEL_H_ */

--- a/src/trg-rss-window.c
+++ b/src/trg-rss-window.c
@@ -21,25 +21,26 @@
 
 #if HAVE_RSS
 
-#include <gtk/gtk.h>
 #include <glib/gi18n.h>
+#include <gtk/gtk.h>
 #include <rss-glib/rss-glib.h>
 
-#include "trg-rss-window.h"
-#include "trg-rss-model.h"
-#include "trg-rss-cell-renderer.h"
-#include "trg-torrent-add-dialog.h"
-#include "trg-preferences-dialog.h"
 #include "trg-client.h"
+#include "trg-preferences-dialog.h"
+#include "trg-rss-cell-renderer.h"
+#include "trg-rss-model.h"
+#include "trg-rss-window.h"
+#include "trg-torrent-add-dialog.h"
 #include "upload.h"
 #include "util.h"
 
-G_DEFINE_TYPE(TrgRssWindow, trg_rss_window,
-              GTK_TYPE_WINDOW)
-#define TRG_RSS_WINDOW_GET_PRIVATE(o) \
-(G_TYPE_INSTANCE_GET_PRIVATE ((o), TRG_TYPE_RSS_WINDOW, TrgRssWindowPrivate))
+G_DEFINE_TYPE(TrgRssWindow, trg_rss_window, GTK_TYPE_WINDOW)
+#define TRG_RSS_WINDOW_GET_PRIVATE(o)                                                              \
+    (G_TYPE_INSTANCE_GET_PRIVATE((o), TRG_TYPE_RSS_WINDOW, TrgRssWindowPrivate))
 enum {
-	PROP_0, PROP_PARENT, PROP_CLIENT
+    PROP_0,
+    PROP_PARENT,
+    PROP_CLIENT
 };
 
 typedef struct _TrgRssWindowPrivate TrgRssWindowPrivate;
@@ -53,13 +54,10 @@ struct _TrgRssWindowPrivate {
 
 static GObject *instance = NULL;
 
-static void
-trg_rss_window_get_property(GObject * object,
-                                     guint property_id,
-                                     GValue * value, GParamSpec * pspec)
+static void trg_rss_window_get_property(GObject *object, guint property_id, GValue *value,
+                                        GParamSpec *pspec)
 {
-    TrgRssWindowPrivate *priv =
-        TRG_RSS_WINDOW_GET_PRIVATE(object);
+    TrgRssWindowPrivate *priv = TRG_RSS_WINDOW_GET_PRIVATE(object);
     switch (property_id) {
     case PROP_CLIENT:
         g_value_set_pointer(value, priv->client);
@@ -73,14 +71,10 @@ trg_rss_window_get_property(GObject * object,
     }
 }
 
-static void
-trg_rss_window_set_property(GObject * object,
-                                     guint property_id,
-                                     const GValue * value,
-                                     GParamSpec * pspec)
+static void trg_rss_window_set_property(GObject *object, guint property_id, const GValue *value,
+                                        GParamSpec *pspec)
 {
-    TrgRssWindowPrivate *priv =
-        TRG_RSS_WINDOW_GET_PRIVATE(object);
+    TrgRssWindowPrivate *priv = TRG_RSS_WINDOW_GET_PRIVATE(object);
     switch (property_id) {
     case PROP_PARENT:
         priv->parent = g_value_get_object(value);
@@ -94,81 +88,78 @@ trg_rss_window_set_property(GObject * object,
     }
 }
 
-static gboolean upload_complete_searchfunc(GtkTreeModel *model,
-                                                         GtkTreePath *path,
-                                                         GtkTreeIter *iter,
-                                                         gpointer data) {
-	trg_upload *upload = (trg_upload*)data;
-	gchar *item_guid = NULL;
-	gboolean stop = FALSE;
-
-	gtk_tree_model_get(model, iter, RSSCOL_ID, &item_guid, -1);
-
-	if (!g_strcmp0(item_guid, upload->uid)) {
-		gtk_list_store_set(GTK_LIST_STORE(model), iter, RSSCOL_UPLOADED, TRUE, -1);
-		stop = TRUE;
-	}
-
-	g_free(item_guid);
-
-	return stop;
-}
-
-static gboolean on_upload_complete(gpointer data) {
-	trg_response *response = (trg_response*)data;
-	trg_upload *upload = (trg_upload*)response->cb_data;
-	TrgRssWindowPrivate *priv = TRG_RSS_WINDOW_GET_PRIVATE(upload->cb_data);
-
-	if (response->status == CURLE_OK)
-		gtk_tree_model_foreach(GTK_TREE_MODEL(priv->tree_model), upload_complete_searchfunc, upload);
-
-	return FALSE;
-}
-
-static gboolean on_torrent_receive(gpointer data) {
-	trg_response *response = (trg_response *) data;
-	trg_upload *upload = (trg_upload*)response->cb_data;
-	TrgRssWindowPrivate *priv = TRG_RSS_WINDOW_GET_PRIVATE(upload->cb_data);
-	TrgClient *client = priv->client;
-	TrgPrefs *prefs = trg_client_get_prefs(client);
-	TrgMainWindow *main_win = priv->parent;
-
-	upload->upload_response = response;
-
-	if (response->status == CURLE_OK) {
-	    if (trg_prefs_get_bool(prefs, TRG_PREFS_KEY_ADD_OPTIONS_DIALOG,
-	                           TRG_PREFS_GLOBAL)) {
-	        TrgTorrentAddDialog *dialog =
-	            trg_torrent_add_dialog_new_from_upload(main_win, client,
-	                                       upload);
-	        gtk_widget_show_all(GTK_WIDGET(dialog));
-	    } else {
-	    	trg_do_upload(upload);
-	    }
-	} else {
-		trg_error_dialog(GTK_WINDOW(main_win), response);
-		trg_upload_free(upload);
-	}
-
-	return FALSE;
-}
-
-static void
-rss_item_activated(GtkTreeView * treeview,
-                          GtkTreePath * path,
-                          GtkTreeViewColumn *
-                          col G_GNUC_UNUSED, gpointer userdata)
+static gboolean upload_complete_searchfunc(GtkTreeModel *model, GtkTreePath *path,
+                                           GtkTreeIter *iter, gpointer data)
 {
-	TrgRssWindow *win = TRG_RSS_WINDOW(userdata);
-	TrgRssWindowPrivate *priv = TRG_RSS_WINDOW_GET_PRIVATE(win);
-	TrgClient *client = priv->client;
-	TrgPrefs *prefs = trg_client_get_prefs(client);
-	GtkTreeModel *model = gtk_tree_view_get_model(treeview);
-	trg_upload *upload = g_new0(trg_upload, 1);
-	GtkTreeIter iter;
-	gchar *link, *uid, *cookie;
+    trg_upload *upload = (trg_upload *)data;
+    gchar *item_guid = NULL;
+    gboolean stop = FALSE;
 
-    //upload->upload_response = response;
+    gtk_tree_model_get(model, iter, RSSCOL_ID, &item_guid, -1);
+
+    if (!g_strcmp0(item_guid, upload->uid)) {
+        gtk_list_store_set(GTK_LIST_STORE(model), iter, RSSCOL_UPLOADED, TRUE, -1);
+        stop = TRUE;
+    }
+
+    g_free(item_guid);
+
+    return stop;
+}
+
+static gboolean on_upload_complete(gpointer data)
+{
+    trg_response *response = (trg_response *)data;
+    trg_upload *upload = (trg_upload *)response->cb_data;
+    TrgRssWindowPrivate *priv = TRG_RSS_WINDOW_GET_PRIVATE(upload->cb_data);
+
+    if (response->status == CURLE_OK)
+        gtk_tree_model_foreach(GTK_TREE_MODEL(priv->tree_model), upload_complete_searchfunc,
+                               upload);
+
+    return FALSE;
+}
+
+static gboolean on_torrent_receive(gpointer data)
+{
+    trg_response *response = (trg_response *)data;
+    trg_upload *upload = (trg_upload *)response->cb_data;
+    TrgRssWindowPrivate *priv = TRG_RSS_WINDOW_GET_PRIVATE(upload->cb_data);
+    TrgClient *client = priv->client;
+    TrgPrefs *prefs = trg_client_get_prefs(client);
+    TrgMainWindow *main_win = priv->parent;
+
+    upload->upload_response = response;
+
+    if (response->status == CURLE_OK) {
+        if (trg_prefs_get_bool(prefs, TRG_PREFS_KEY_ADD_OPTIONS_DIALOG, TRG_PREFS_GLOBAL)) {
+            TrgTorrentAddDialog *dialog
+                = trg_torrent_add_dialog_new_from_upload(main_win, client, upload);
+            gtk_widget_show_all(GTK_WIDGET(dialog));
+        } else {
+            trg_do_upload(upload);
+        }
+    } else {
+        trg_error_dialog(GTK_WINDOW(main_win), response);
+        trg_upload_free(upload);
+    }
+
+    return FALSE;
+}
+
+static void rss_item_activated(GtkTreeView *treeview, GtkTreePath *path,
+                               GtkTreeViewColumn *col G_GNUC_UNUSED, gpointer userdata)
+{
+    TrgRssWindow *win = TRG_RSS_WINDOW(userdata);
+    TrgRssWindowPrivate *priv = TRG_RSS_WINDOW_GET_PRIVATE(win);
+    TrgClient *client = priv->client;
+    TrgPrefs *prefs = trg_client_get_prefs(client);
+    GtkTreeModel *model = gtk_tree_view_get_model(treeview);
+    trg_upload *upload = g_new0(trg_upload, 1);
+    GtkTreeIter iter;
+    gchar *link, *uid, *cookie;
+
+    // upload->upload_response = response;
     upload->main_window = priv->parent;
     upload->client = client;
     upload->extra_args = FALSE;
@@ -176,68 +167,65 @@ rss_item_activated(GtkTreeView * treeview,
     upload->callback = on_upload_complete;
     upload->cb_data = win;
 
-	gtk_tree_model_get_iter(model, &iter, path);
+    gtk_tree_model_get_iter(model, &iter, path);
 
-	gtk_tree_model_get(model, &iter, RSSCOL_LINK, &link, RSSCOL_ID, &uid, RSSCOL_COOKIE, &cookie, -1);
+    gtk_tree_model_get(model, &iter, RSSCOL_LINK, &link, RSSCOL_ID, &uid, RSSCOL_COOKIE, &cookie,
+                       -1);
 
-	upload->uid = uid;
+    upload->uid = uid;
 
-	async_http_request(priv->client, link, cookie, on_torrent_receive, upload);
+    async_http_request(priv->client, link, cookie, on_torrent_receive, upload);
 
-	g_free(cookie);
-	g_free(link);
+    g_free(cookie);
+    g_free(link);
 }
 
-static void trg_rss_on_get_error(TrgRssModel *model, rss_get_error *error, gpointer data) {
-	GtkWindow *win = GTK_WINDOW(data);
-	gchar *msg;
-	if (error->error_code <= -100) {
-		msg = g_strdup_printf(_("Request failed with HTTP code %d"), -(error->error_code + 100));
-	} else {
-		msg = g_strdup(curl_easy_strerror(error->error_code));
-	}
-    GtkWidget *dialog = gtk_message_dialog_new(win,
-                                               GTK_DIALOG_MODAL,
-                                               GTK_MESSAGE_ERROR,
-                                               GTK_BUTTONS_OK,
-                                               "%s", msg);
+static void trg_rss_on_get_error(TrgRssModel *model, rss_get_error *error, gpointer data)
+{
+    GtkWindow *win = GTK_WINDOW(data);
+    gchar *msg;
+    if (error->error_code <= -100) {
+        msg = g_strdup_printf(_("Request failed with HTTP code %d"), -(error->error_code + 100));
+    } else {
+        msg = g_strdup(curl_easy_strerror(error->error_code));
+    }
+    GtkWidget *dialog = gtk_message_dialog_new(win, GTK_DIALOG_MODAL, GTK_MESSAGE_ERROR,
+                                               GTK_BUTTONS_OK, "%s", msg);
     g_free(msg);
     gtk_window_set_title(GTK_WINDOW(dialog), _("Error"));
     gtk_dialog_run(GTK_DIALOG(dialog));
     gtk_widget_destroy(dialog);
 }
 
-static void trg_rss_on_parse_error(TrgRssModel *model, rss_parse_error *error, gpointer data) {
-	GtkWindow *win = GTK_WINDOW(data);
-	gchar *msg = g_strdup_printf(_("Error parsing RSS feed \"%s\": %s"), error->feed_id, error->error->message);
-    GtkWidget *dialog = gtk_message_dialog_new(win,
-                                               GTK_DIALOG_MODAL,
-                                               GTK_MESSAGE_ERROR,
-                                               GTK_BUTTONS_OK,
-                                               "%s", msg);
+static void trg_rss_on_parse_error(TrgRssModel *model, rss_parse_error *error, gpointer data)
+{
+    GtkWindow *win = GTK_WINDOW(data);
+    gchar *msg = g_strdup_printf(_("Error parsing RSS feed \"%s\": %s"), error->feed_id,
+                                 error->error->message);
+    GtkWidget *dialog = gtk_message_dialog_new(win, GTK_DIALOG_MODAL, GTK_MESSAGE_ERROR,
+                                               GTK_BUTTONS_OK, "%s", msg);
     g_free(msg);
     gtk_window_set_title(GTK_WINDOW(dialog), _("Error"));
     gtk_dialog_run(GTK_DIALOG(dialog));
     gtk_widget_destroy(dialog);
 }
 
-static void on_configure(GtkWidget *widget, gpointer data) {
-	TrgRssWindowPrivate *priv = TRG_RSS_WINDOW_GET_PRIVATE(data);
-	GtkWidget *dlg = trg_preferences_dialog_get_instance(priv->parent, priv->client);
-	gtk_widget_show_all(dlg);
-	trg_preferences_dialog_set_page(TRG_PREFERENCES_DIALOG(dlg), 5);
+static void on_configure(GtkWidget *widget, gpointer data)
+{
+    TrgRssWindowPrivate *priv = TRG_RSS_WINDOW_GET_PRIVATE(data);
+    GtkWidget *dlg = trg_preferences_dialog_get_instance(priv->parent, priv->client);
+    gtk_widget_show_all(dlg);
+    trg_preferences_dialog_set_page(TRG_PREFERENCES_DIALOG(dlg), 5);
 }
 
-static void on_refresh(GtkWidget *widget, gpointer data) {
-	TrgRssWindowPrivate *priv = TRG_RSS_WINDOW_GET_PRIVATE(data);
-	trg_rss_model_update(priv->tree_model);
+static void on_refresh(GtkWidget *widget, gpointer data)
+{
+    TrgRssWindowPrivate *priv = TRG_RSS_WINDOW_GET_PRIVATE(data);
+    trg_rss_model_update(priv->tree_model);
 }
 
-static GObject *trg_rss_window_constructor(GType type,
-                                                    guint
-                                                    n_construct_properties,
-                                                    GObjectConstructParam *
-                                                    construct_params)
+static GObject *trg_rss_window_constructor(GType type, guint n_construct_properties,
+                                           GObjectConstructParam *construct_params)
 {
     GObject *object;
     TrgRssWindowPrivate *priv;
@@ -245,18 +233,14 @@ static GObject *trg_rss_window_constructor(GType type,
     GtkToolItem *item;
     GtkWidget *toolbar;
 
-    object = G_OBJECT_CLASS
-        (trg_rss_window_parent_class)->constructor(type,
-                                                            n_construct_properties,
-                                                            construct_params);
+    object = G_OBJECT_CLASS(trg_rss_window_parent_class)
+                 ->constructor(type, n_construct_properties, construct_params);
     priv = TRG_RSS_WINDOW_GET_PRIVATE(object);
 
     priv->tree_model = trg_rss_model_new(priv->client);
 
-    g_signal_connect(priv->tree_model, "get-error",
-                      G_CALLBACK(trg_rss_on_get_error), object);
-    g_signal_connect(priv->tree_model, "parse-error",
-                      G_CALLBACK(trg_rss_on_parse_error), object);
+    g_signal_connect(priv->tree_model, "get-error", G_CALLBACK(trg_rss_on_get_error), object);
+    g_signal_connect(priv->tree_model, "parse-error", G_CALLBACK(trg_rss_on_parse_error), object);
 
     trg_rss_model_update(priv->tree_model);
 
@@ -264,26 +248,24 @@ static GObject *trg_rss_window_constructor(GType type,
     gtk_tree_view_set_headers_visible(priv->tree_view, FALSE);
     gtk_tree_view_set_model(priv->tree_view, GTK_TREE_MODEL(priv->tree_model));
 
-    gtk_tree_view_insert_column_with_attributes(priv->tree_view, -1, NULL, trg_rss_cell_renderer_new(), "title", RSSCOL_TITLE, "feed", RSSCOL_FEED, "published", RSSCOL_PUBDATE, "uploaded", RSSCOL_UPLOADED, NULL);
+    gtk_tree_view_insert_column_with_attributes(
+        priv->tree_view, -1, NULL, trg_rss_cell_renderer_new(), "title", RSSCOL_TITLE, "feed",
+        RSSCOL_FEED, "published", RSSCOL_PUBDATE, "uploaded", RSSCOL_UPLOADED, NULL);
 
-    g_signal_connect(priv->tree_view, "row-activated",
-                      G_CALLBACK(rss_item_activated), object);
+    g_signal_connect(priv->tree_view, "row-activated", G_CALLBACK(rss_item_activated), object);
 
     gtk_window_set_title(GTK_WINDOW(object), _("RSS Feeds"));
 
     toolbar = gtk_toolbar_new();
 
-
-    img = gtk_image_new_from_icon_name("view-refresh",
-                                       GTK_ICON_SIZE_LARGE_TOOLBAR);
+    img = gtk_image_new_from_icon_name("view-refresh", GTK_ICON_SIZE_LARGE_TOOLBAR);
     item = gtk_tool_button_new(img, "Refresh");
     gtk_widget_set_sensitive(GTK_WIDGET(item), TRUE);
     gtk_tool_item_set_tooltip_text(item, "Refresh");
     g_signal_connect(G_OBJECT(item), "clicked", G_CALLBACK(on_refresh), object);
     gtk_toolbar_insert(GTK_TOOLBAR(toolbar), item, 0);
 
-    img = gtk_image_new_from_icon_name("preferences-system",
-                                       GTK_ICON_SIZE_LARGE_TOOLBAR);
+    img = gtk_image_new_from_icon_name("preferences-system", GTK_ICON_SIZE_LARGE_TOOLBAR);
     item = gtk_tool_button_new(img, "Refresh");
     gtk_widget_set_sensitive(GTK_WIDGET(item), TRUE);
     gtk_tool_item_set_tooltip_text(item, "Configure Feeds");
@@ -292,10 +274,9 @@ static GObject *trg_rss_window_constructor(GType type,
 
     vbox = trg_vbox_new(FALSE, 0);
 
-    gtk_box_pack_start(GTK_BOX(vbox), GTK_WIDGET(toolbar),
-                           FALSE, FALSE, 0);
-    gtk_box_pack_start(GTK_BOX(vbox), my_scrolledwin_new(GTK_WIDGET(priv->tree_view)),
-                           TRUE, TRUE, 0);
+    gtk_box_pack_start(GTK_BOX(vbox), GTK_WIDGET(toolbar), FALSE, FALSE, 0);
+    gtk_box_pack_start(GTK_BOX(vbox), my_scrolledwin_new(GTK_WIDGET(priv->tree_view)), TRUE, TRUE,
+                       0);
 
     gtk_container_add(GTK_CONTAINER(object), vbox);
 
@@ -307,14 +288,13 @@ static GObject *trg_rss_window_constructor(GType type,
     return object;
 }
 
-static void trg_rss_window_dispose(GObject * object)
+static void trg_rss_window_dispose(GObject *object)
 {
-	instance = NULL;
+    instance = NULL;
     G_OBJECT_CLASS(trg_rss_window_parent_class)->dispose(object);
 }
 
-static void
-trg_rss_window_class_init(TrgRssWindowClass * klass)
+static void trg_rss_window_class_init(TrgRssWindowClass *klass)
 {
     GObjectClass *object_class = G_OBJECT_CLASS(klass);
 
@@ -325,47 +305,28 @@ trg_rss_window_class_init(TrgRssWindowClass * klass)
     object_class->set_property = trg_rss_window_set_property;
     object_class->dispose = trg_rss_window_dispose;
 
-    g_object_class_install_property(object_class,
-                                    PROP_CLIENT,
-                                    g_param_spec_pointer("trg-client",
-                                                         "TClient",
-                                                         "Client",
-                                                         G_PARAM_READWRITE
-                                                         |
-                                                         G_PARAM_CONSTRUCT_ONLY
-                                                         |
-                                                         G_PARAM_STATIC_NAME
-                                                         |
-                                                         G_PARAM_STATIC_NICK
-                                                         |
-                                                         G_PARAM_STATIC_BLURB));
+    g_object_class_install_property(
+        object_class, PROP_CLIENT,
+        g_param_spec_pointer("trg-client", "TClient", "Client",
+                             G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME
+                                 | G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
 
-    g_object_class_install_property(object_class,
-                                    PROP_PARENT,
-                                    g_param_spec_object("parent-window",
-                                                        "Parent window",
-                                                        "Parent window",
-                                                        TRG_TYPE_MAIN_WINDOW,
-                                                        G_PARAM_READWRITE |
-                                                        G_PARAM_CONSTRUCT_ONLY
-                                                        |
-                                                        G_PARAM_STATIC_NAME
-                                                        |
-                                                        G_PARAM_STATIC_NICK
-                                                        |
-                                                        G_PARAM_STATIC_BLURB));
+    g_object_class_install_property(
+        object_class, PROP_PARENT,
+        g_param_spec_object("parent-window", "Parent window", "Parent window", TRG_TYPE_MAIN_WINDOW,
+                            G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME
+                                | G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
 }
 
-static void
-trg_rss_window_init(TrgRssWindow * self G_GNUC_UNUSED)
+static void trg_rss_window_init(TrgRssWindow *self G_GNUC_UNUSED)
 {
 }
 
 TrgRssWindow *trg_rss_window_get_instance(TrgMainWindow *parent, TrgClient *client)
 {
     if (instance == NULL) {
-        instance =
-            g_object_new(TRG_TYPE_RSS_WINDOW, "parent-window", parent, "trg-client", client, NULL);
+        instance = g_object_new(TRG_TYPE_RSS_WINDOW, "parent-window", parent, "trg-client", client,
+                                NULL);
     }
 
     return TRG_RSS_WINDOW(instance);

--- a/src/trg-rss-window.h
+++ b/src/trg-rss-window.h
@@ -29,17 +29,14 @@
 
 G_BEGIN_DECLS
 #define TRG_TYPE_RSS_WINDOW trg_rss_window_get_type()
-#define TRG_RSS_WINDOW(obj) \
-  (G_TYPE_CHECK_INSTANCE_CAST ((obj), TRG_TYPE_RSS_WINDOW, TrgRssWindow))
-#define TRG_RSS_WINDOW_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_CAST ((klass), TRG_TYPE_RSS_WINDOW, TrgRssWindowClass))
-#define TRG_IS_RSS_WINDOW(obj) \
-  (G_TYPE_CHECK_INSTANCE_TYPE ((obj), TRG_TYPE_RSS_WINDOW))
-#define TRG_IS_RSS_WINDOW_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_TYPE ((klass), TRG_TYPE_RSS_WINDOW))
-#define TRG_RSS_WINDOW_GET_CLASS(obj) \
-  (G_TYPE_INSTANCE_GET_CLASS ((obj), TRG_TYPE_RSS_WINDOW, TrgRssWindowClass))
-    typedef struct {
+#define TRG_RSS_WINDOW(obj) (G_TYPE_CHECK_INSTANCE_CAST((obj), TRG_TYPE_RSS_WINDOW, TrgRssWindow))
+#define TRG_RSS_WINDOW_CLASS(klass)                                                                \
+    (G_TYPE_CHECK_CLASS_CAST((klass), TRG_TYPE_RSS_WINDOW, TrgRssWindowClass))
+#define TRG_IS_RSS_WINDOW(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), TRG_TYPE_RSS_WINDOW))
+#define TRG_IS_RSS_WINDOW_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass), TRG_TYPE_RSS_WINDOW))
+#define TRG_RSS_WINDOW_GET_CLASS(obj)                                                              \
+    (G_TYPE_INSTANCE_GET_CLASS((obj), TRG_TYPE_RSS_WINDOW, TrgRssWindowClass))
+typedef struct {
     GtkWindow parent;
 } TrgRssWindow;
 
@@ -55,4 +52,4 @@ G_END_DECLS
 
 #endif
 
-#endif                          /* TRG_RSS_WINDOW_H_ */
+#endif /* TRG_RSS_WINDOW_H_ */

--- a/src/trg-sortable-filtered-model.c
+++ b/src/trg-sortable-filtered-model.c
@@ -29,176 +29,108 @@
  * so that a TreeViewColumn can track changes for indicators.
  */
 
-static void
-trg_sortable_filtered_model_tree_sortable_init(GtkTreeSortableIface *
-                                               iface);
+static void trg_sortable_filtered_model_tree_sortable_init(GtkTreeSortableIface *iface);
 
 /* TreeSortable interface */
-static GtkTreeSortable
-    * trg_sortable_filtered_model_get_real_sortable(GtkTreeSortable *
-                                                    sortable);
-static gboolean
-trg_sortable_filtered_model_sort_get_sort_column_id(GtkTreeSortable *
-                                                    sortable,
-                                                    gint * sort_column_id,
-                                                    GtkSortType * order);
-static void
-trg_sortable_filtered_model_sort_set_sort_column_id(GtkTreeSortable *
-                                                    sortable,
-                                                    gint sort_column_id,
-                                                    GtkSortType order);
-static void trg_sortable_filtered_model_sort_set_sort_func(GtkTreeSortable
-                                                           * sortable,
-                                                           gint
-                                                           sort_column_id,
-                                                           GtkTreeIterCompareFunc
-                                                           func,
-                                                           gpointer data,
-                                                           GDestroyNotify
-                                                           destroy);
-static void
-trg_sortable_filtered_model_sort_set_default_sort_func(GtkTreeSortable *
-                                                       sortable,
-                                                       GtkTreeIterCompareFunc
-                                                       func, gpointer data,
-                                                       GDestroyNotify
-                                                       destroy);
-static gboolean
-trg_sortable_filtered_model_sort_has_default_sort_func(GtkTreeSortable *
-                                                       sortable);
-static void trg_sortable_filtered_model_sort_column_changed(GtkTreeSortable
-                                                            * realSortable,
-                                                            GtkTreeSortable
-                                                            *
-                                                            fakeSortable);
+static GtkTreeSortable *trg_sortable_filtered_model_get_real_sortable(GtkTreeSortable *sortable);
+static gboolean trg_sortable_filtered_model_sort_get_sort_column_id(GtkTreeSortable *sortable,
+                                                                    gint *sort_column_id,
+                                                                    GtkSortType *order);
+static void trg_sortable_filtered_model_sort_set_sort_column_id(GtkTreeSortable *sortable,
+                                                                gint sort_column_id,
+                                                                GtkSortType order);
+static void trg_sortable_filtered_model_sort_set_sort_func(GtkTreeSortable *sortable,
+                                                           gint sort_column_id,
+                                                           GtkTreeIterCompareFunc func,
+                                                           gpointer data, GDestroyNotify destroy);
+static void trg_sortable_filtered_model_sort_set_default_sort_func(GtkTreeSortable *sortable,
+                                                                   GtkTreeIterCompareFunc func,
+                                                                   gpointer data,
+                                                                   GDestroyNotify destroy);
+static gboolean trg_sortable_filtered_model_sort_has_default_sort_func(GtkTreeSortable *sortable);
+static void trg_sortable_filtered_model_sort_column_changed(GtkTreeSortable *realSortable,
+                                                            GtkTreeSortable *fakeSortable);
 
-G_DEFINE_TYPE_WITH_CODE(TrgSortableFilteredModel,
-                        trg_sortable_filtered_model,
+G_DEFINE_TYPE_WITH_CODE(TrgSortableFilteredModel, trg_sortable_filtered_model,
                         GTK_TYPE_TREE_MODEL_FILTER,
                         G_IMPLEMENT_INTERFACE(GTK_TYPE_TREE_SORTABLE,
                                               trg_sortable_filtered_model_tree_sortable_init))
-static void
-trg_sortable_filtered_model_class_init(TrgSortableFilteredModelClass *
-                                       klass)
+static void trg_sortable_filtered_model_class_init(TrgSortableFilteredModelClass *klass)
 {
 }
 
-static void
-trg_sortable_filtered_model_init(TrgSortableFilteredModel * self)
+static void trg_sortable_filtered_model_init(TrgSortableFilteredModel *self)
 {
 }
 
-static void
-trg_sortable_filtered_model_tree_sortable_init(GtkTreeSortableIface *
-                                               iface)
+static void trg_sortable_filtered_model_tree_sortable_init(GtkTreeSortableIface *iface)
 {
-    iface->get_sort_column_id =
-        trg_sortable_filtered_model_sort_get_sort_column_id;
-    iface->set_sort_column_id =
-        trg_sortable_filtered_model_sort_set_sort_column_id;
+    iface->get_sort_column_id = trg_sortable_filtered_model_sort_get_sort_column_id;
+    iface->set_sort_column_id = trg_sortable_filtered_model_sort_set_sort_column_id;
     iface->set_sort_func = trg_sortable_filtered_model_sort_set_sort_func;
-    iface->set_default_sort_func =
-        trg_sortable_filtered_model_sort_set_default_sort_func;
-    iface->has_default_sort_func =
-        trg_sortable_filtered_model_sort_has_default_sort_func;
+    iface->set_default_sort_func = trg_sortable_filtered_model_sort_set_default_sort_func;
+    iface->has_default_sort_func = trg_sortable_filtered_model_sort_has_default_sort_func;
 }
 
 static void
-trg_sortable_filtered_model_sort_column_changed(GtkTreeSortable
-                                                *
-                                                realSortable
-                                                G_GNUC_UNUSED,
-                                                GtkTreeSortable
-                                                * fakeSortable)
+trg_sortable_filtered_model_sort_column_changed(GtkTreeSortable *realSortable G_GNUC_UNUSED,
+                                                GtkTreeSortable *fakeSortable)
 {
     g_signal_emit_by_name(fakeSortable, "sort-column-changed");
 }
 
-GtkTreeModel *trg_sortable_filtered_model_new(GtkTreeSortable *
-                                              child_model,
-                                              GtkTreePath * root)
+GtkTreeModel *trg_sortable_filtered_model_new(GtkTreeSortable *child_model, GtkTreePath *root)
 {
-    GObject *obj = g_object_new(TRG_TYPE_SORTABLE_FILTERED_MODEL,
-                                "child-model", GTK_TREE_MODEL(child_model),
-                                "virtual-root", root,
-                                NULL);
+    GObject *obj = g_object_new(TRG_TYPE_SORTABLE_FILTERED_MODEL, "child-model",
+                                GTK_TREE_MODEL(child_model), "virtual-root", root, NULL);
 
     g_signal_connect(child_model, "sort-column-changed",
-                     G_CALLBACK
-                     (trg_sortable_filtered_model_sort_column_changed),
-                     obj);
+                     G_CALLBACK(trg_sortable_filtered_model_sort_column_changed), obj);
 
     return GTK_TREE_MODEL(obj);
 }
 
-static GtkTreeSortable
-    * trg_sortable_filtered_model_get_real_sortable(GtkTreeSortable *
-                                                    sortable)
+static GtkTreeSortable *trg_sortable_filtered_model_get_real_sortable(GtkTreeSortable *sortable)
 {
-    return
-        GTK_TREE_SORTABLE(gtk_tree_model_filter_get_model
-                          (GTK_TREE_MODEL_FILTER(sortable)));
+    return GTK_TREE_SORTABLE(gtk_tree_model_filter_get_model(GTK_TREE_MODEL_FILTER(sortable)));
 }
 
-static gboolean
-trg_sortable_filtered_model_sort_get_sort_column_id(GtkTreeSortable *
-                                                    sortable,
-                                                    gint * sort_column_id,
-                                                    GtkSortType * order)
+static gboolean trg_sortable_filtered_model_sort_get_sort_column_id(GtkTreeSortable *sortable,
+                                                                    gint *sort_column_id,
+                                                                    GtkSortType *order)
 {
-    GtkTreeSortable *realSortable =
-        trg_sortable_filtered_model_get_real_sortable(sortable);
-    return gtk_tree_sortable_get_sort_column_id(realSortable,
-                                                sort_column_id, order);
+    GtkTreeSortable *realSortable = trg_sortable_filtered_model_get_real_sortable(sortable);
+    return gtk_tree_sortable_get_sort_column_id(realSortable, sort_column_id, order);
 }
 
-static void
-trg_sortable_filtered_model_sort_set_sort_column_id(GtkTreeSortable *
-                                                    sortable,
-                                                    gint sort_column_id,
-                                                    GtkSortType order)
+static void trg_sortable_filtered_model_sort_set_sort_column_id(GtkTreeSortable *sortable,
+                                                                gint sort_column_id,
+                                                                GtkSortType order)
 {
-    GtkTreeSortable *realSortable =
-        trg_sortable_filtered_model_get_real_sortable(sortable);
-    gtk_tree_sortable_set_sort_column_id(realSortable, sort_column_id,
-                                         order);
+    GtkTreeSortable *realSortable = trg_sortable_filtered_model_get_real_sortable(sortable);
+    gtk_tree_sortable_set_sort_column_id(realSortable, sort_column_id, order);
 }
 
-static void
-trg_sortable_filtered_model_sort_set_sort_func(GtkTreeSortable
-                                               * sortable,
-                                               gint
-                                               sort_column_id,
-                                               GtkTreeIterCompareFunc
-                                               func,
-                                               gpointer data,
-                                               GDestroyNotify destroy)
+static void trg_sortable_filtered_model_sort_set_sort_func(GtkTreeSortable *sortable,
+                                                           gint sort_column_id,
+                                                           GtkTreeIterCompareFunc func,
+                                                           gpointer data, GDestroyNotify destroy)
 {
-    GtkTreeSortable *realSortable =
-        trg_sortable_filtered_model_get_real_sortable(sortable);
-    gtk_tree_sortable_set_sort_func(realSortable, sort_column_id, func,
-                                    data, destroy);
+    GtkTreeSortable *realSortable = trg_sortable_filtered_model_get_real_sortable(sortable);
+    gtk_tree_sortable_set_sort_func(realSortable, sort_column_id, func, data, destroy);
 }
 
-static void
-trg_sortable_filtered_model_sort_set_default_sort_func(GtkTreeSortable *
-                                                       sortable,
-                                                       GtkTreeIterCompareFunc
-                                                       func, gpointer data,
-                                                       GDestroyNotify
-                                                       destroy)
+static void trg_sortable_filtered_model_sort_set_default_sort_func(GtkTreeSortable *sortable,
+                                                                   GtkTreeIterCompareFunc func,
+                                                                   gpointer data,
+                                                                   GDestroyNotify destroy)
 {
-    GtkTreeSortable *realSortable =
-        trg_sortable_filtered_model_get_real_sortable(sortable);
-    gtk_tree_sortable_set_default_sort_func(realSortable, func, data,
-                                            destroy);
+    GtkTreeSortable *realSortable = trg_sortable_filtered_model_get_real_sortable(sortable);
+    gtk_tree_sortable_set_default_sort_func(realSortable, func, data, destroy);
 }
 
-static gboolean
-trg_sortable_filtered_model_sort_has_default_sort_func(GtkTreeSortable *
-                                                       sortable)
+static gboolean trg_sortable_filtered_model_sort_has_default_sort_func(GtkTreeSortable *sortable)
 {
-    GtkTreeSortable *realSortable =
-        trg_sortable_filtered_model_get_real_sortable(sortable);
+    GtkTreeSortable *realSortable = trg_sortable_filtered_model_get_real_sortable(sortable);
     return gtk_tree_sortable_has_default_sort_func(realSortable);
 }

--- a/src/trg-sortable-filtered-model.h
+++ b/src/trg-sortable-filtered-model.h
@@ -25,17 +25,19 @@
 
 G_BEGIN_DECLS
 #define TRG_TYPE_SORTABLE_FILTERED_MODEL trg_sortable_filtered_model_get_type()
-#define TRG_SORTABLE_FILTERED_MODEL(obj) \
-  (G_TYPE_CHECK_INSTANCE_CAST ((obj), TRG_TYPE_SORTABLE_FILTERED_MODEL, TrgSortableFilteredModel))
-#define TRG_SORTABLE_FILTERED_MODEL_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_CAST ((klass), TRG_TYPE_SORTABLE_FILTERED_MODEL, TrgSortableFilteredModelClass))
-#define TRG_IS_SORTABLE_FILTERED_MODEL(obj) \
-  (G_TYPE_CHECK_INSTANCE_TYPE ((obj), TRG_TYPE_SORTABLE_FILTERED_MODEL))
-#define TRG_IS_SORTABLE_FILTERED_MODEL_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_TYPE ((klass), TRG_TYPE_SORTABLE_FILTERED_MODEL))
-#define TRG_SORTABLE_FILTERED_MODEL_GET_CLASS(obj) \
-  (G_TYPE_INSTANCE_GET_CLASS ((obj), TRG_TYPE_SORTABLE_FILTERED_MODEL, TrgSortableFilteredModelClass))
-    typedef struct {
+#define TRG_SORTABLE_FILTERED_MODEL(obj)                                                           \
+    (G_TYPE_CHECK_INSTANCE_CAST((obj), TRG_TYPE_SORTABLE_FILTERED_MODEL, TrgSortableFilteredModel))
+#define TRG_SORTABLE_FILTERED_MODEL_CLASS(klass)                                                   \
+    (G_TYPE_CHECK_CLASS_CAST((klass), TRG_TYPE_SORTABLE_FILTERED_MODEL,                            \
+                             TrgSortableFilteredModelClass))
+#define TRG_IS_SORTABLE_FILTERED_MODEL(obj)                                                        \
+    (G_TYPE_CHECK_INSTANCE_TYPE((obj), TRG_TYPE_SORTABLE_FILTERED_MODEL))
+#define TRG_IS_SORTABLE_FILTERED_MODEL_CLASS(klass)                                                \
+    (G_TYPE_CHECK_CLASS_TYPE((klass), TRG_TYPE_SORTABLE_FILTERED_MODEL))
+#define TRG_SORTABLE_FILTERED_MODEL_GET_CLASS(obj)                                                 \
+    (G_TYPE_INSTANCE_GET_CLASS((obj), TRG_TYPE_SORTABLE_FILTERED_MODEL,                            \
+                               TrgSortableFilteredModelClass))
+typedef struct {
     GtkTreeModelFilter parent;
 } TrgSortableFilteredModel;
 
@@ -45,9 +47,7 @@ typedef struct {
 
 GType trg_sortable_filtered_model_get_type(void);
 
-GtkTreeModel *trg_sortable_filtered_model_new(GtkTreeSortable *
-                                              child_model,
-                                              GtkTreePath * root);
+GtkTreeModel *trg_sortable_filtered_model_new(GtkTreeSortable *child_model, GtkTreePath *root);
 
 G_END_DECLS
-#endif                          /* _TRG_SORTABLE_FILTERED_MODEL */
+#endif /* _TRG_SORTABLE_FILTERED_MODEL */

--- a/src/trg-state-selector.c
+++ b/src/trg-state-selector.c
@@ -20,31 +20,33 @@
 #include "config.h"
 
 #include <glib-object.h>
-#include <json-glib/json-glib.h>
 #include <glib/gi18n.h>
 #include <gtk/gtk.h>
+#include <json-glib/json-glib.h>
 
 #include "torrent.h"
 #include "trg-cell-renderer-counter.h"
+#include "trg-client.h"
+#include "trg-prefs.h"
 #include "trg-state-selector.h"
 #include "trg-torrent-model.h"
 #include "util.h"
-#include "trg-prefs.h"
-#include "trg-client.h"
 
 enum {
-    SELECTOR_STATE_CHANGED, SELECTOR_SIGNAL_COUNT
+    SELECTOR_STATE_CHANGED,
+    SELECTOR_SIGNAL_COUNT
 };
 
 enum {
-    PROP_0, PROP_CLIENT
+    PROP_0,
+    PROP_CLIENT
 };
 
 static guint signals[SELECTOR_SIGNAL_COUNT] = { 0 };
 
 G_DEFINE_TYPE(TrgStateSelector, trg_state_selector, GTK_TYPE_TREE_VIEW)
-#define TRG_STATE_SELECTOR_GET_PRIVATE(o) \
-  (G_TYPE_INSTANCE_GET_PRIVATE ((o), TRG_TYPE_STATE_SELECTOR, TrgStateSelectorPrivate))
+#define TRG_STATE_SELECTOR_GET_PRIVATE(o)                                                          \
+    (G_TYPE_INSTANCE_GET_PRIVATE((o), TRG_TYPE_STATE_SELECTOR, TrgStateSelectorPrivate))
 typedef struct _TrgStateSelectorPrivate TrgStateSelectorPrivate;
 
 struct _TrgStateSelectorPrivate {
@@ -72,20 +74,19 @@ struct _TrgStateSelectorPrivate {
     GtkTreeRowReference *down_wait_rr;
 };
 
-GRegex *trg_state_selector_get_url_host_regex(TrgStateSelector * s)
+GRegex *trg_state_selector_get_url_host_regex(TrgStateSelector *s)
 {
     TrgStateSelectorPrivate *priv = TRG_STATE_SELECTOR_GET_PRIVATE(s);
     return priv->urlHostRegex;
 }
 
-guint32 trg_state_selector_get_flag(TrgStateSelector * s)
+guint32 trg_state_selector_get_flag(TrgStateSelector *s)
 {
     TrgStateSelectorPrivate *priv = TRG_STATE_SELECTOR_GET_PRIVATE(s);
     return priv->flag;
 }
 
-static void
-state_selection_changed(GtkTreeSelection * selection, gpointer data)
+static void state_selection_changed(GtkTreeSelection *selection, gpointer data)
 {
     TrgStateSelectorPrivate *priv;
     GtkTreeIter iter;
@@ -95,20 +96,17 @@ state_selection_changed(GtkTreeSelection * selection, gpointer data)
     priv = TRG_STATE_SELECTOR_GET_PRIVATE(data);
 
     if (gtk_tree_selection_get_selected(selection, &stateModel, &iter))
-        gtk_tree_model_get(stateModel, &iter, STATE_SELECTOR_BIT,
-                           &priv->flag, STATE_SELECTOR_INDEX, &index, -1);
+        gtk_tree_model_get(stateModel, &iter, STATE_SELECTOR_BIT, &priv->flag, STATE_SELECTOR_INDEX,
+                           &index, -1);
     else
         priv->flag = 0;
 
-    trg_prefs_set_int(priv->prefs, TRG_PREFS_STATE_SELECTOR_LAST, index,
-                      TRG_PREFS_GLOBAL);
+    trg_prefs_set_int(priv->prefs, TRG_PREFS_STATE_SELECTOR_LAST, index, TRG_PREFS_GLOBAL);
 
-    g_signal_emit(TRG_STATE_SELECTOR(data),
-                  signals[SELECTOR_STATE_CHANGED], 0, priv->flag);
+    g_signal_emit(TRG_STATE_SELECTOR(data), signals[SELECTOR_STATE_CHANGED], 0, priv->flag);
 }
 
-static GtkTreeRowReference *quick_tree_ref_new(GtkTreeModel * model,
-                                               GtkTreeIter * iter)
+static GtkTreeRowReference *quick_tree_ref_new(GtkTreeModel *model, GtkTreeIter *iter)
 {
     GtkTreePath *path = gtk_tree_model_get_path(model, iter);
     GtkTreeRowReference *rr = gtk_tree_row_reference_new(model, path);
@@ -121,12 +119,10 @@ struct cruft_remove_args {
     gint64 serial;
 };
 
-static gboolean
-trg_state_selector_remove_cruft(gpointer key, gpointer value,
-                                gpointer data)
+static gboolean trg_state_selector_remove_cruft(gpointer key, gpointer value, gpointer data)
 {
-    struct cruft_remove_args *args = (struct cruft_remove_args *) data;
-    GtkTreeRowReference *rr = (GtkTreeRowReference *) value;
+    struct cruft_remove_args *args = (struct cruft_remove_args *)data;
+    GtkTreeRowReference *rr = (GtkTreeRowReference *)value;
     GtkTreeModel *model = gtk_tree_row_reference_get_model(rr);
     GtkTreePath *path = gtk_tree_row_reference_get_path(rr);
     gboolean remove;
@@ -135,8 +131,7 @@ trg_state_selector_remove_cruft(gpointer key, gpointer value,
     gint64 currentSerial;
 
     gtk_tree_model_get_iter(model, &iter, path);
-    gtk_tree_model_get(model, &iter, STATE_SELECTOR_SERIAL, &currentSerial,
-                       -1);
+    gtk_tree_model_get(model, &iter, STATE_SELECTOR_SERIAL, &currentSerial, -1);
 
     remove = (args->serial != currentSerial);
 
@@ -145,7 +140,7 @@ trg_state_selector_remove_cruft(gpointer key, gpointer value,
     return remove;
 }
 
-gchar *trg_state_selector_get_selected_text(TrgStateSelector * s)
+gchar *trg_state_selector_get_selected_text(TrgStateSelector *s)
 {
     GtkTreeSelection *sel = gtk_tree_view_get_selection(GTK_TREE_VIEW(s));
     GtkTreeModel *model;
@@ -158,10 +153,8 @@ gchar *trg_state_selector_get_selected_text(TrgStateSelector * s)
     return name;
 }
 
-static void
-trg_state_selector_update_dynamic_filter(GtkTreeModel * model,
-                                         GtkTreeRowReference *
-                                         rr, gint64 serial)
+static void trg_state_selector_update_dynamic_filter(GtkTreeModel *model, GtkTreeRowReference *rr,
+                                                     gint64 serial)
 {
     GtkTreeIter iter;
     GtkTreePath *path = gtk_tree_row_reference_get_path(rr);
@@ -170,41 +163,35 @@ trg_state_selector_update_dynamic_filter(GtkTreeModel * model,
     gint oldCount;
 
     gtk_tree_model_get_iter(model, &iter, path);
-    gtk_tree_model_get(model, &iter, STATE_SELECTOR_SERIAL, &oldSerial,
-                       STATE_SELECTOR_COUNT, &oldCount, -1);
+    gtk_tree_model_get(model, &iter, STATE_SELECTOR_SERIAL, &oldSerial, STATE_SELECTOR_COUNT,
+                       &oldCount, -1);
 
     if (oldSerial != serial) {
         g_value_init(&gvalue, G_TYPE_INT);
         g_value_set_int(&gvalue, 1);
-        gtk_list_store_set_value(GTK_LIST_STORE(model), &iter,
-                                 STATE_SELECTOR_COUNT, &gvalue);
+        gtk_list_store_set_value(GTK_LIST_STORE(model), &iter, STATE_SELECTOR_COUNT, &gvalue);
 
         memset(&gvalue, 0, sizeof(GValue));
         g_value_init(&gvalue, G_TYPE_INT64);
         g_value_set_int64(&gvalue, serial);
-        gtk_list_store_set_value(GTK_LIST_STORE(model), &iter,
-                                 STATE_SELECTOR_SERIAL, &gvalue);
+        gtk_list_store_set_value(GTK_LIST_STORE(model), &iter, STATE_SELECTOR_SERIAL, &gvalue);
     } else {
         g_value_init(&gvalue, G_TYPE_INT);
         g_value_set_int(&gvalue, ++oldCount);
-        gtk_list_store_set_value(GTK_LIST_STORE(model), &iter,
-                                 STATE_SELECTOR_COUNT, &gvalue);
+        gtk_list_store_set_value(GTK_LIST_STORE(model), &iter, STATE_SELECTOR_COUNT, &gvalue);
     }
 
     gtk_tree_path_free(path);
 }
 
-static void refresh_statelist_cb(GtkWidget * w, gpointer data)
+static void refresh_statelist_cb(GtkWidget *w, gpointer data)
 {
     TrgStateSelectorPrivate *priv = TRG_STATE_SELECTOR_GET_PRIVATE(data);
     trg_client_inc_serial(priv->client);
-    trg_state_selector_update(TRG_STATE_SELECTOR(data),
-                              TORRENT_UPDATE_ADDREMOVE);
+    trg_state_selector_update(TRG_STATE_SELECTOR(data), TORRENT_UPDATE_ADDREMOVE);
 }
 
-static void
-view_popup_menu(GtkWidget * treeview, GdkEventButton * event,
-                gpointer data G_GNUC_UNUSED)
+static void view_popup_menu(GtkWidget *treeview, GdkEventButton *event, gpointer data G_GNUC_UNUSED)
 {
     GtkWidget *menu, *item, *box, *img, *label;
 
@@ -221,8 +208,7 @@ view_popup_menu(GtkWidget * treeview, GdkEventButton * event,
 
     gtk_container_add(GTK_CONTAINER(item), box);
 
-    g_signal_connect(item, "activate", G_CALLBACK(refresh_statelist_cb),
-                     treeview);
+    g_signal_connect(item, "activate", G_CALLBACK(refresh_statelist_cb), treeview);
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), item);
 
     gtk_widget_show_all(menu);
@@ -230,15 +216,13 @@ view_popup_menu(GtkWidget * treeview, GdkEventButton * event,
     gtk_menu_popup_at_pointer(GTK_MENU(menu), (GdkEvent *)event);
 }
 
-static gboolean view_onPopupMenu(GtkWidget * treeview, gpointer userdata)
+static gboolean view_onPopupMenu(GtkWidget *treeview, gpointer userdata)
 {
     view_popup_menu(treeview, NULL, userdata);
     return TRUE;
 }
 
-static gboolean
-view_onButtonPressed(GtkWidget * treeview,
-                     GdkEventButton * event, gpointer userdata)
+static gboolean view_onButtonPressed(GtkWidget *treeview, GdkEventButton *event, gpointer userdata)
 {
     if (event->type == GDK_BUTTON_PRESS && event->button == 3) {
         view_popup_menu(treeview, event, userdata);
@@ -255,20 +239,17 @@ struct state_find_pos {
     const gchar *name;
 };
 
-static gboolean
-trg_state_selector_find_pos_foreach(GtkTreeModel * model,
-                                    GtkTreePath * path,
-                                    GtkTreeIter * iter, gpointer data)
+static gboolean trg_state_selector_find_pos_foreach(GtkTreeModel *model, GtkTreePath *path,
+                                                    GtkTreeIter *iter, gpointer data)
 {
-    struct state_find_pos *args = (struct state_find_pos *) data;
+    struct state_find_pos *args = (struct state_find_pos *)data;
     gchar *name;
     gboolean res;
 
     if (args->pos < args->offset) {
         args->pos++;
         return FALSE;
-    } else if (args->range >= 0
-               && args->pos > args->offset + args->range - 1) {
+    } else if (args->range >= 0 && args->pos > args->offset + args->range - 1) {
         return TRUE;
     }
 
@@ -282,10 +263,8 @@ trg_state_selector_find_pos_foreach(GtkTreeModel * model,
     return res;
 }
 
-static void
-trg_state_selector_insert(TrgStateSelector * s, int offset,
-                          gint range, const gchar * name,
-                          GtkTreeIter * iter)
+static void trg_state_selector_insert(TrgStateSelector *s, int offset, gint range,
+                                      const gchar *name, GtkTreeIter *iter)
 {
     GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(s));
 
@@ -295,12 +274,11 @@ trg_state_selector_insert(TrgStateSelector * s, int offset,
     args.range = range;
     args.name = name;
 
-    gtk_tree_model_foreach(model, trg_state_selector_find_pos_foreach,
-                           &args);
+    gtk_tree_model_foreach(model, trg_state_selector_find_pos_foreach, &args);
     gtk_list_store_insert(GTK_LIST_STORE(model), iter, args.pos);
 }
 
-void trg_state_selector_update(TrgStateSelector * s, guint whatsChanged)
+void trg_state_selector_update(TrgStateSelector *s, guint whatsChanged)
 {
     TrgStateSelectorPrivate *priv = TRG_STATE_SELECTOR_GET_PRIVATE(s);
     GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(s));
@@ -318,19 +296,17 @@ void trg_state_selector_update(TrgStateSelector * s, guint whatsChanged)
     if (!trg_client_is_connected(client))
         return;
 
-    torrentItemRefs =
-        g_hash_table_get_values(trg_client_get_torrent_table(client));
+    torrentItemRefs = g_hash_table_get_values(trg_client_get_torrent_table(client));
 
     for (li = torrentItemRefs; li; li = g_list_next(li)) {
         JsonObject *t = NULL;
-        rr = (GtkTreeRowReference *) li->data;
+        rr = (GtkTreeRowReference *)li->data;
         path = gtk_tree_row_reference_get_path(rr);
         torrentModel = gtk_tree_row_reference_get_model(rr);
 
         if (path) {
             if (gtk_tree_model_get_iter(torrentModel, &torrentIter, path)) {
-                gtk_tree_model_get(torrentModel, &torrentIter,
-                                   TORRENT_COLUMN_JSON, &t, -1);
+                gtk_tree_model_get(torrentModel, &torrentIter, TORRENT_COLUMN_JSON, &t, -1);
             }
             gtk_tree_path_free(path);
         }
@@ -338,19 +314,12 @@ void trg_state_selector_update(TrgStateSelector * s, guint whatsChanged)
         if (!t)
             continue;
 
-        if (priv->showTrackers
-            && (whatsChanged & TORRENT_UPDATE_ADDREMOVE)) {
-            trackersList =
-                json_array_get_elements(torrent_get_tracker_stats(t));
-            for (trackerItem = trackersList; trackerItem;
-                 trackerItem = g_list_next(trackerItem)) {
-                JsonObject *tracker =
-                    json_node_get_object((JsonNode *) trackerItem->data);
-                const gchar *announceUrl =
-                    tracker_stats_get_announce(tracker);
-                gchar *announceHost =
-                    trg_gregex_get_first(priv->urlHostRegex,
-                                         announceUrl);
+        if (priv->showTrackers && (whatsChanged & TORRENT_UPDATE_ADDREMOVE)) {
+            trackersList = json_array_get_elements(torrent_get_tracker_stats(t));
+            for (trackerItem = trackersList; trackerItem; trackerItem = g_list_next(trackerItem)) {
+                JsonObject *tracker = json_node_get_object((JsonNode *)trackerItem->data);
+                const gchar *announceUrl = tracker_stats_get_announce(tracker);
+                gchar *announceHost = trg_gregex_get_first(priv->urlHostRegex, announceUrl);
 
                 if (!announceHost)
                     continue;
@@ -358,27 +327,23 @@ void trg_state_selector_update(TrgStateSelector * s, guint whatsChanged)
                 result = g_hash_table_lookup(priv->trackers, announceHost);
 
                 if (result) {
-                    trg_state_selector_update_dynamic_filter(model,
-                                                             (GtkTreeRowReference
-                                                              *) result,
+                    trg_state_selector_update_dynamic_filter(model, (GtkTreeRowReference *)result,
                                                              updateSerial);
                     g_free(announceHost);
                 } else {
-					if (priv->dirsFirst){
-							trg_state_selector_insert(s, priv->n_categories +
-										g_hash_table_size(priv->directories), -1, announceHost, &iter);
-					} else {
-						trg_state_selector_insert(s, priv->n_categories,
-										g_hash_table_size(priv->trackers), announceHost, &iter);
-					}
-                    gtk_list_store_set(GTK_LIST_STORE(model), &iter,
-                                       STATE_SELECTOR_ICON,
-                                       "network-workgroup",
-                                       STATE_SELECTOR_NAME, announceHost,
-                                       STATE_SELECTOR_SERIAL, updateSerial,
-                                       STATE_SELECTOR_COUNT, 1,
-                                       STATE_SELECTOR_BIT,
-                                       FILTER_FLAG_TRACKER,
+                    if (priv->dirsFirst) {
+                        trg_state_selector_insert(
+                            s, priv->n_categories + g_hash_table_size(priv->directories), -1,
+                            announceHost, &iter);
+                    } else {
+                        trg_state_selector_insert(s, priv->n_categories,
+                                                  g_hash_table_size(priv->trackers), announceHost,
+                                                  &iter);
+                    }
+                    gtk_list_store_set(GTK_LIST_STORE(model), &iter, STATE_SELECTOR_ICON,
+                                       "network-workgroup", STATE_SELECTOR_NAME, announceHost,
+                                       STATE_SELECTOR_SERIAL, updateSerial, STATE_SELECTOR_COUNT, 1,
+                                       STATE_SELECTOR_BIT, FILTER_FLAG_TRACKER,
                                        STATE_SELECTOR_INDEX, 0, -1);
                     g_hash_table_insert(priv->trackers, announceHost,
                                         quick_tree_ref_new(model, &iter));
@@ -387,34 +352,28 @@ void trg_state_selector_update(TrgStateSelector * s, guint whatsChanged)
             g_list_free(trackersList);
         }
 
-        if (priv->showDirs && ((whatsChanged & TORRENT_UPDATE_ADDREMOVE)
-                               || (whatsChanged &
-                                   TORRENT_UPDATE_PATH_CHANGE))) {
+        if (priv->showDirs
+            && ((whatsChanged & TORRENT_UPDATE_ADDREMOVE)
+                || (whatsChanged & TORRENT_UPDATE_PATH_CHANGE))) {
             gchar *dir;
-            gtk_tree_model_get(torrentModel, &torrentIter,
-                               TORRENT_COLUMN_DOWNLOADDIR_SHORT, &dir, -1);
+            gtk_tree_model_get(torrentModel, &torrentIter, TORRENT_COLUMN_DOWNLOADDIR_SHORT, &dir,
+                               -1);
 
             result = g_hash_table_lookup(priv->directories, dir);
             if (result) {
-                trg_state_selector_update_dynamic_filter(model,
-                                                         (GtkTreeRowReference
-                                                          *) result,
+                trg_state_selector_update_dynamic_filter(model, (GtkTreeRowReference *)result,
                                                          updateSerial);
             } else {
-                if (priv->dirsFirst){
-					trg_state_selector_insert(s, priv->n_categories,
-								g_hash_table_size(priv->directories), dir, &iter);
-				} else {
-					trg_state_selector_insert(s, priv->n_categories +
-									g_hash_table_size(priv->trackers), -1, dir, &iter);
-				}
-                gtk_list_store_set(GTK_LIST_STORE(model), &iter,
-                                   STATE_SELECTOR_ICON,
-                                   "folder",
-                                   STATE_SELECTOR_NAME, dir,
-                                   STATE_SELECTOR_SERIAL, updateSerial,
-                                   STATE_SELECTOR_BIT, FILTER_FLAG_DIR,
-                                   STATE_SELECTOR_COUNT, 1,
+                if (priv->dirsFirst) {
+                    trg_state_selector_insert(s, priv->n_categories,
+                                              g_hash_table_size(priv->directories), dir, &iter);
+                } else {
+                    trg_state_selector_insert(
+                        s, priv->n_categories + g_hash_table_size(priv->trackers), -1, dir, &iter);
+                }
+                gtk_list_store_set(GTK_LIST_STORE(model), &iter, STATE_SELECTOR_ICON, "folder",
+                                   STATE_SELECTOR_NAME, dir, STATE_SELECTOR_SERIAL, updateSerial,
+                                   STATE_SELECTOR_BIT, FILTER_FLAG_DIR, STATE_SELECTOR_COUNT, 1,
                                    STATE_SELECTOR_INDEX, 0, -1);
                 g_hash_table_insert(priv->directories, g_strdup(dir),
                                     quick_tree_ref_new(model, &iter));
@@ -430,21 +389,18 @@ void trg_state_selector_update(TrgStateSelector * s, guint whatsChanged)
 
     if (priv->showTrackers && ((whatsChanged & TORRENT_UPDATE_ADDREMOVE))) {
         cruft.table = priv->trackers;
-        g_hash_table_foreach_remove(priv->trackers,
-                                    trg_state_selector_remove_cruft,
-                                    &cruft);
+        g_hash_table_foreach_remove(priv->trackers, trg_state_selector_remove_cruft, &cruft);
     }
 
-    if (priv->showDirs && ((whatsChanged & TORRENT_UPDATE_ADDREMOVE)
-                           || (whatsChanged & TORRENT_UPDATE_PATH_CHANGE))) {
+    if (priv->showDirs
+        && ((whatsChanged & TORRENT_UPDATE_ADDREMOVE)
+            || (whatsChanged & TORRENT_UPDATE_PATH_CHANGE))) {
         cruft.table = priv->directories;
-        g_hash_table_foreach_remove(priv->directories,
-                                    trg_state_selector_remove_cruft,
-                                    &cruft);
+        g_hash_table_foreach_remove(priv->directories, trg_state_selector_remove_cruft, &cruft);
     }
 }
 
-void trg_state_selector_set_show_dirs(TrgStateSelector * s, gboolean show)
+void trg_state_selector_set_show_dirs(TrgStateSelector *s, gboolean show)
 {
     TrgStateSelectorPrivate *priv = TRG_STATE_SELECTOR_GET_PRIVATE(s);
     priv->showDirs = show;
@@ -454,22 +410,16 @@ void trg_state_selector_set_show_dirs(TrgStateSelector * s, gboolean show)
         trg_state_selector_update(s, TORRENT_UPDATE_PATH_CHANGE);
 }
 
-static void
-on_torrents_state_change(TrgTorrentModel * model,
-                         guint whatsChanged, gpointer data)
+static void on_torrents_state_change(TrgTorrentModel *model, guint whatsChanged, gpointer data)
 {
     TrgStateSelector *selector = TRG_STATE_SELECTOR(data);
     trg_state_selector_update(selector, whatsChanged);
 
-    if ((whatsChanged & TORRENT_UPDATE_ADDREMOVE)
-        || (whatsChanged & TORRENT_UPDATE_STATE_CHANGE))
-        trg_state_selector_stats_update(selector,
-                                        trg_torrent_model_get_stats
-                                        (model));
+    if ((whatsChanged & TORRENT_UPDATE_ADDREMOVE) || (whatsChanged & TORRENT_UPDATE_STATE_CHANGE))
+        trg_state_selector_stats_update(selector, trg_torrent_model_get_stats(model));
 }
 
-void
-trg_state_selector_set_show_trackers(TrgStateSelector * s, gboolean show)
+void trg_state_selector_set_show_trackers(TrgStateSelector *s, gboolean show)
 {
     TrgStateSelectorPrivate *priv = TRG_STATE_SELECTOR_GET_PRIVATE(s);
     priv->showTrackers = show;
@@ -479,37 +429,30 @@ trg_state_selector_set_show_trackers(TrgStateSelector * s, gboolean show)
         trg_state_selector_update(s, TORRENT_UPDATE_ADDREMOVE);
 }
 
-void
-trg_state_selector_set_directories_first(TrgStateSelector * s, gboolean _dirsFirst){
-	TrgStateSelectorPrivate *priv = TRG_STATE_SELECTOR_GET_PRIVATE(s);
-	priv->dirsFirst = _dirsFirst;
-	g_hash_table_remove_all(priv->directories);
-	g_hash_table_remove_all(priv->trackers);
-	trg_state_selector_update(s, TORRENT_UPDATE_ADDREMOVE);
+void trg_state_selector_set_directories_first(TrgStateSelector *s, gboolean _dirsFirst)
+{
+    TrgStateSelectorPrivate *priv = TRG_STATE_SELECTOR_GET_PRIVATE(s);
+    priv->dirsFirst = _dirsFirst;
+    g_hash_table_remove_all(priv->directories);
+    g_hash_table_remove_all(priv->trackers);
+    trg_state_selector_update(s, TORRENT_UPDATE_ADDREMOVE);
 }
 
-static void
-trg_state_selector_add_state(TrgStateSelector * selector,
-                             GtkTreeIter * iter, gint pos,
-                             gchar * icon, gchar * name,
-                             guint32 flag, GtkTreeRowReference ** rr)
+static void trg_state_selector_add_state(TrgStateSelector *selector, GtkTreeIter *iter, gint pos,
+                                         gchar *icon, gchar *name, guint32 flag,
+                                         GtkTreeRowReference **rr)
 {
-    TrgStateSelectorPrivate *priv =
-        TRG_STATE_SELECTOR_GET_PRIVATE(selector);
-    GtkListStore *model =
-        GTK_LIST_STORE(gtk_tree_view_get_model(GTK_TREE_VIEW(selector)));
+    TrgStateSelectorPrivate *priv = TRG_STATE_SELECTOR_GET_PRIVATE(selector);
+    GtkListStore *model = GTK_LIST_STORE(gtk_tree_view_get_model(GTK_TREE_VIEW(selector)));
 
     if (pos < 0)
         gtk_list_store_append(priv->store, iter);
     else
         gtk_list_store_insert(priv->store, iter, pos);
 
-    gtk_list_store_set(model, iter, STATE_SELECTOR_ICON, icon,
-                       STATE_SELECTOR_NAME, name, STATE_SELECTOR_BIT, flag,
-                       STATE_SELECTOR_INDEX,
-                       gtk_tree_model_iter_n_children(GTK_TREE_MODEL
-                                                      (model), NULL) - 1,
-                       -1);
+    gtk_list_store_set(model, iter, STATE_SELECTOR_ICON, icon, STATE_SELECTOR_NAME, name,
+                       STATE_SELECTOR_BIT, flag, STATE_SELECTOR_INDEX,
+                       gtk_tree_model_iter_n_children(GTK_TREE_MODEL(model), NULL) - 1, -1);
 
     if (rr)
         *rr = quick_tree_ref_new(GTK_TREE_MODEL(model), iter);
@@ -517,7 +460,7 @@ trg_state_selector_add_state(TrgStateSelector * selector,
     priv->n_categories++;
 }
 
-static void remove_row_ref_and_free(GtkTreeRowReference * rr)
+static void remove_row_ref_and_free(GtkTreeRowReference *rr)
 {
     GtkTreeModel *model = gtk_tree_row_reference_get_model(rr);
     GtkTreePath *path = gtk_tree_row_reference_get_path(rr);
@@ -529,8 +472,7 @@ static void remove_row_ref_and_free(GtkTreeRowReference * rr)
     gtk_tree_row_reference_free(rr);
 }
 
-static void
-trg_state_selector_update_stat(GtkTreeRowReference * rr, gint count)
+static void trg_state_selector_update_stat(GtkTreeRowReference *rr, gint count)
 {
     if (rr) {
         GValue gvalue = G_VALUE_INIT;
@@ -542,22 +484,18 @@ trg_state_selector_update_stat(GtkTreeRowReference * rr, gint count)
 
         g_value_init(&gvalue, G_TYPE_INT);
         g_value_set_int(&gvalue, count);
-        gtk_list_store_set_value(GTK_LIST_STORE(model), &iter,
-                                 STATE_SELECTOR_COUNT, &gvalue);
+        gtk_list_store_set_value(GTK_LIST_STORE(model), &iter, STATE_SELECTOR_COUNT, &gvalue);
 
         gtk_tree_path_free(path);
     }
 }
 
-void
-trg_state_selector_stats_update(TrgStateSelector * s,
-                                trg_torrent_model_update_stats * stats)
+void trg_state_selector_stats_update(TrgStateSelector *s, trg_torrent_model_update_stats *stats)
 {
     TrgStateSelectorPrivate *priv = TRG_STATE_SELECTOR_GET_PRIVATE(s);
     GtkTreeIter iter;
     if (stats->error > 0 && !priv->error_rr) {
-        trg_state_selector_add_state(s, &iter, priv->n_categories - 1,
-                                     "dialog-warning", _("Error"),
+        trg_state_selector_add_state(s, &iter, priv->n_categories - 1, "dialog-warning", _("Error"),
                                      TORRENT_FLAG_ERROR, &priv->error_rr);
 
     } else if (stats->error < 1 && priv->error_rr) {
@@ -579,7 +517,7 @@ trg_state_selector_stats_update(TrgStateSelector * s,
     trg_state_selector_update_stat(priv->seed_wait_rr, stats->seed_wait);
 }
 
-void trg_state_selector_disconnect(TrgStateSelector * s)
+void trg_state_selector_disconnect(TrgStateSelector *s)
 {
     TrgStateSelectorPrivate *priv = TRG_STATE_SELECTOR_GET_PRIVATE(s);
 
@@ -603,26 +541,20 @@ void trg_state_selector_disconnect(TrgStateSelector * s)
     trg_state_selector_update_stat(priv->checking_rr, -1);
 }
 
-static void trg_state_selector_init(TrgStateSelector * self)
+static void trg_state_selector_init(TrgStateSelector *self)
 {
 }
 
-TrgStateSelector *trg_state_selector_new(TrgClient * client,
-                                         TrgTorrentModel * tmodel)
+TrgStateSelector *trg_state_selector_new(TrgClient *client, TrgTorrentModel *tmodel)
 {
-    TrgStateSelector *selector =
-        g_object_new(TRG_TYPE_STATE_SELECTOR, "client",
-                     client, NULL);
-    g_signal_connect(tmodel, "torrents-state-change",
-                     G_CALLBACK(on_torrents_state_change), selector);
+    TrgStateSelector *selector = g_object_new(TRG_TYPE_STATE_SELECTOR, "client", client, NULL);
+    g_signal_connect(tmodel, "torrents-state-change", G_CALLBACK(on_torrents_state_change),
+                     selector);
     return selector;
 }
 
-static GObject *trg_state_selector_constructor(GType type,
-                                               guint
-                                               n_construct_properties,
-                                               GObjectConstructParam *
-                                               construct_params)
+static GObject *trg_state_selector_constructor(GType type, guint n_construct_properties,
+                                               GObjectConstructParam *construct_params)
 {
     GObject *object;
     TrgStateSelector *selector;
@@ -634,21 +566,17 @@ static GObject *trg_state_selector_constructor(GType type,
     gint index;
     GtkTreeSelection *selection;
 
-    object = G_OBJECT_CLASS
-        (trg_state_selector_parent_class)->constructor(type,
-                                                       n_construct_properties,
-                                                       construct_params);
+    object = G_OBJECT_CLASS(trg_state_selector_parent_class)
+                 ->constructor(type, n_construct_properties, construct_params);
 
     selector = TRG_STATE_SELECTOR(object);
     priv = TRG_STATE_SELECTOR_GET_PRIVATE(object);
 
     priv->urlHostRegex = trg_uri_host_regex_new();
     priv->trackers = g_hash_table_new_full(g_str_hash, g_str_equal, g_free,
-                                           (GDestroyNotify)
-                                           remove_row_ref_and_free);
-    priv->directories =
-        g_hash_table_new_full(g_str_hash, g_str_equal, g_free,
-                              (GDestroyNotify) remove_row_ref_and_free);
+                                           (GDestroyNotify)remove_row_ref_and_free);
+    priv->directories = g_hash_table_new_full(g_str_hash, g_str_equal, g_free,
+                                              (GDestroyNotify)remove_row_ref_and_free);
 
     gtk_tree_view_set_headers_visible(GTK_TREE_VIEW(object), FALSE);
 
@@ -657,109 +585,75 @@ static GObject *trg_state_selector_constructor(GType type,
     renderer = gtk_cell_renderer_pixbuf_new();
     gtk_tree_view_column_pack_start(column, renderer, FALSE);
     g_object_set(renderer, "stock-size", 4, NULL);
-    gtk_tree_view_column_set_attributes(column, renderer, "icon-name",
-                                        STATE_SELECTOR_ICON, NULL);
+    gtk_tree_view_column_set_attributes(column, renderer, "icon-name", STATE_SELECTOR_ICON, NULL);
 
     renderer = trg_cell_renderer_counter_new();
     gtk_tree_view_column_pack_start(column, renderer, TRUE);
-    gtk_tree_view_column_set_attributes(column, renderer, "state-label",
-                                        STATE_SELECTOR_NAME, "state-count",
-                                        STATE_SELECTOR_COUNT, NULL);
+    gtk_tree_view_column_set_attributes(column, renderer, "state-label", STATE_SELECTOR_NAME,
+                                        "state-count", STATE_SELECTOR_COUNT, NULL);
 
     gtk_tree_view_append_column(GTK_TREE_VIEW(object), column);
 
-    store = priv->store = gtk_list_store_new(STATE_SELECTOR_COLUMNS,
-                                             G_TYPE_STRING, G_TYPE_STRING,
-                                             G_TYPE_INT, G_TYPE_UINT,
-                                             G_TYPE_INT64, G_TYPE_UINT);
+    store = priv->store = gtk_list_store_new(STATE_SELECTOR_COLUMNS, G_TYPE_STRING, G_TYPE_STRING,
+                                             G_TYPE_INT, G_TYPE_UINT, G_TYPE_INT64, G_TYPE_UINT);
     gtk_tree_view_set_model(GTK_TREE_VIEW(object), GTK_TREE_MODEL(store));
 
-    trg_state_selector_add_state(selector, &iter, -1, "help-about",
-                                 _("All"), 0, &priv->all_rr);
-    trg_state_selector_add_state(selector, &iter, -1, "go-down",
-                                 _("Downloading"),
+    trg_state_selector_add_state(selector, &iter, -1, "help-about", _("All"), 0, &priv->all_rr);
+    trg_state_selector_add_state(selector, &iter, -1, "go-down", _("Downloading"),
                                  TORRENT_FLAG_DOWNLOADING, &priv->down_rr);
-    trg_state_selector_add_state(selector, &iter, -1,
-                                 "media-seek-backward", _("Queue Down"),
-                                 TORRENT_FLAG_DOWNLOADING_WAIT,
-                                 &priv->down_wait_rr);
-    trg_state_selector_add_state(selector, &iter, -1, "go-up",
-                                 _("Seeding"), TORRENT_FLAG_SEEDING,
+    trg_state_selector_add_state(selector, &iter, -1, "media-seek-backward", _("Queue Down"),
+                                 TORRENT_FLAG_DOWNLOADING_WAIT, &priv->down_wait_rr);
+    trg_state_selector_add_state(selector, &iter, -1, "go-up", _("Seeding"), TORRENT_FLAG_SEEDING,
                                  &priv->seeding_rr);
-    trg_state_selector_add_state(selector, &iter, -1,
-                                 "media-seek-forward", _("Queue Up"),
-                                 TORRENT_FLAG_SEEDING_WAIT,
-                                 &priv->seed_wait_rr);
-    trg_state_selector_add_state(selector, &iter, -1,
-                                 "media-playback-pause", _("Paused"),
+    trg_state_selector_add_state(selector, &iter, -1, "media-seek-forward", _("Queue Up"),
+                                 TORRENT_FLAG_SEEDING_WAIT, &priv->seed_wait_rr);
+    trg_state_selector_add_state(selector, &iter, -1, "media-playback-pause", _("Paused"),
                                  TORRENT_FLAG_PAUSED, &priv->paused_rr);
-    trg_state_selector_add_state(selector, &iter, -1, "trg-gtk-apply",
-                                 _("Complete"), TORRENT_FLAG_COMPLETE,
-                                 &priv->complete_rr);
-    trg_state_selector_add_state(selector, &iter, -1, "edit-select-all",
-                                 _("Incomplete"), TORRENT_FLAG_INCOMPLETE,
-                                 &priv->incomplete_rr);
-    trg_state_selector_add_state(selector, &iter, -1, "network-workgroup",
-                                 _("Active"), TORRENT_FLAG_ACTIVE,
-                                 &priv->active_rr);
-    trg_state_selector_add_state(selector, &iter, -1, "view-refresh",
-                                 _("Checking"), TORRENT_FLAG_CHECKING_ANY,
-                                 &priv->checking_rr);
+    trg_state_selector_add_state(selector, &iter, -1, "trg-gtk-apply", _("Complete"),
+                                 TORRENT_FLAG_COMPLETE, &priv->complete_rr);
+    trg_state_selector_add_state(selector, &iter, -1, "edit-select-all", _("Incomplete"),
+                                 TORRENT_FLAG_INCOMPLETE, &priv->incomplete_rr);
+    trg_state_selector_add_state(selector, &iter, -1, "network-workgroup", _("Active"),
+                                 TORRENT_FLAG_ACTIVE, &priv->active_rr);
+    trg_state_selector_add_state(selector, &iter, -1, "view-refresh", _("Checking"),
+                                 TORRENT_FLAG_CHECKING_ANY, &priv->checking_rr);
     trg_state_selector_add_state(selector, &iter, -1, NULL, NULL, 0, NULL);
 
     gtk_tree_view_set_rubber_banding(GTK_TREE_VIEW(object), TRUE);
 
     selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(object));
 
-    g_signal_connect(G_OBJECT(selection), "changed",
-                     G_CALLBACK(state_selection_changed), object);
-    g_signal_connect(object, "button-press-event",
-                     G_CALLBACK(view_onButtonPressed), NULL);
-    g_signal_connect(object, "popup-menu", G_CALLBACK(view_onPopupMenu),
-                     NULL);
+    g_signal_connect(G_OBJECT(selection), "changed", G_CALLBACK(state_selection_changed), object);
+    g_signal_connect(object, "button-press-event", G_CALLBACK(view_onButtonPressed), NULL);
+    g_signal_connect(object, "popup-menu", G_CALLBACK(view_onPopupMenu), NULL);
 
-    gtk_tree_view_set_search_column(GTK_TREE_VIEW(object),
-                                    STATE_SELECTOR_NAME);
+    gtk_tree_view_set_search_column(GTK_TREE_VIEW(object), STATE_SELECTOR_NAME);
 
-    index = trg_prefs_get_int(priv->prefs, TRG_PREFS_STATE_SELECTOR_LAST,
-                              TRG_PREFS_GLOBAL);
-    if (index > 0
-        && gtk_tree_model_iter_nth_child(GTK_TREE_MODEL(store), &iter,
-                                         NULL, index)) {
-        GtkTreeSelection *selection =
-            gtk_tree_view_get_selection(GTK_TREE_VIEW(object));
+    index = trg_prefs_get_int(priv->prefs, TRG_PREFS_STATE_SELECTOR_LAST, TRG_PREFS_GLOBAL);
+    if (index > 0 && gtk_tree_model_iter_nth_child(GTK_TREE_MODEL(store), &iter, NULL, index)) {
+        GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(object));
         gtk_tree_selection_select_iter(selection, &iter);
     }
 
-    priv->showDirs =
-        trg_prefs_get_bool(priv->prefs, TRG_PREFS_KEY_FILTER_DIRS,
-                           TRG_PREFS_GLOBAL);
-    priv->showTrackers =
-        trg_prefs_get_bool(priv->prefs, TRG_PREFS_KEY_FILTER_TRACKERS,
-                           TRG_PREFS_GLOBAL);
-	priv->dirsFirst =
-		trg_prefs_get_bool(priv->prefs, TRG_PREFS_KEY_DIRECTORIES_FIRST,
-							TRG_PREFS_GLOBAL);
+    priv->showDirs = trg_prefs_get_bool(priv->prefs, TRG_PREFS_KEY_FILTER_DIRS, TRG_PREFS_GLOBAL);
+    priv->showTrackers
+        = trg_prefs_get_bool(priv->prefs, TRG_PREFS_KEY_FILTER_TRACKERS, TRG_PREFS_GLOBAL);
+    priv->dirsFirst
+        = trg_prefs_get_bool(priv->prefs, TRG_PREFS_KEY_DIRECTORIES_FIRST, TRG_PREFS_GLOBAL);
 
     return object;
 }
 
-void
-trg_state_selector_set_queues_enabled(TrgStateSelector * s,
-                                      gboolean enabled)
+void trg_state_selector_set_queues_enabled(TrgStateSelector *s, gboolean enabled)
 {
     TrgStateSelectorPrivate *priv = TRG_STATE_SELECTOR_GET_PRIVATE(s);
     GtkTreeIter iter;
 
     if (enabled) {
-        trg_state_selector_add_state(s, &iter, 2, "media-seek-backward",
-                                     _("Queue Down"),
-                                     TORRENT_FLAG_DOWNLOADING_WAIT,
-                                     &priv->down_wait_rr);
-        trg_state_selector_add_state(s, &iter, 4, "media-seek-forward",
-                                     _("Queue Up"),
-                                     TORRENT_FLAG_SEEDING_WAIT,
-                                     &priv->seed_wait_rr);
+        trg_state_selector_add_state(s, &iter, 2, "media-seek-backward", _("Queue Down"),
+                                     TORRENT_FLAG_DOWNLOADING_WAIT, &priv->down_wait_rr);
+        trg_state_selector_add_state(s, &iter, 4, "media-seek-forward", _("Queue Up"),
+                                     TORRENT_FLAG_SEEDING_WAIT, &priv->seed_wait_rr);
     } else {
         remove_row_ref_and_free(priv->seed_wait_rr);
         remove_row_ref_and_free(priv->down_wait_rr);
@@ -769,10 +663,8 @@ trg_state_selector_set_queues_enabled(TrgStateSelector * s,
     }
 }
 
-static void
-trg_state_selector_get_property(GObject * object,
-                                guint property_id,
-                                GValue * value, GParamSpec * pspec)
+static void trg_state_selector_get_property(GObject *object, guint property_id, GValue *value,
+                                            GParamSpec *pspec)
 {
     TrgStateSelectorPrivate *priv = TRG_STATE_SELECTOR_GET_PRIVATE(object);
     switch (property_id) {
@@ -785,11 +677,8 @@ trg_state_selector_get_property(GObject * object,
     }
 }
 
-static void
-trg_state_selector_set_property(GObject * object,
-                                guint prop_id,
-                                const GValue * value,
-                                GParamSpec * pspec G_GNUC_UNUSED)
+static void trg_state_selector_set_property(GObject *object, guint prop_id, const GValue *value,
+                                            GParamSpec *pspec G_GNUC_UNUSED)
 {
     TrgStateSelectorPrivate *priv = TRG_STATE_SELECTOR_GET_PRIVATE(object);
 
@@ -801,40 +690,24 @@ trg_state_selector_set_property(GObject * object,
     }
 }
 
-static void trg_state_selector_class_init(TrgStateSelectorClass * klass)
+static void trg_state_selector_class_init(TrgStateSelectorClass *klass)
 {
     GObjectClass *object_class = G_OBJECT_CLASS(klass);
     object_class->constructor = trg_state_selector_constructor;
     object_class->set_property = trg_state_selector_set_property;
     object_class->get_property = trg_state_selector_get_property;
 
-    signals[SELECTOR_STATE_CHANGED] = g_signal_new("torrent-state-changed",
-                                                   G_TYPE_FROM_CLASS
-                                                   (object_class),
-                                                   G_SIGNAL_RUN_LAST |
-                                                   G_SIGNAL_ACTION,
-                                                   G_STRUCT_OFFSET
-                                                   (TrgStateSelectorClass,
-                                                    torrent_state_changed),
-                                                   NULL, NULL,
-                                                   g_cclosure_marshal_VOID__UINT,
-                                                   G_TYPE_NONE, 1,
-                                                   G_TYPE_UINT);
+    signals[SELECTOR_STATE_CHANGED]
+        = g_signal_new("torrent-state-changed", G_TYPE_FROM_CLASS(object_class),
+                       G_SIGNAL_RUN_LAST | G_SIGNAL_ACTION,
+                       G_STRUCT_OFFSET(TrgStateSelectorClass, torrent_state_changed), NULL, NULL,
+                       g_cclosure_marshal_VOID__UINT, G_TYPE_NONE, 1, G_TYPE_UINT);
 
-    g_object_class_install_property(object_class,
-                                    PROP_CLIENT,
-                                    g_param_spec_object("client",
-                                                        "Client",
-                                                        "Client",
-                                                        TRG_TYPE_CLIENT,
-                                                        G_PARAM_READWRITE |
-                                                        G_PARAM_CONSTRUCT_ONLY
-                                                        |
-                                                        G_PARAM_STATIC_NAME
-                                                        |
-                                                        G_PARAM_STATIC_NICK
-                                                        |
-                                                        G_PARAM_STATIC_BLURB));
+    g_object_class_install_property(
+        object_class, PROP_CLIENT,
+        g_param_spec_object("client", "Client", "Client", TRG_TYPE_CLIENT,
+                            G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME
+                                | G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
 
     g_type_class_add_private(klass, sizeof(TrgStateSelectorPrivate));
 }

--- a/src/trg-state-selector.h
+++ b/src/trg-state-selector.h
@@ -23,8 +23,8 @@
 #include <glib-object.h>
 #include <json-glib/json-glib.h>
 
-#include "trg-torrent-model.h"
 #include "trg-client.h"
+#include "trg-torrent-model.h"
 
 enum {
     STATE_SELECTOR_ICON,
@@ -38,45 +38,38 @@ enum {
 
 G_BEGIN_DECLS
 #define TRG_TYPE_STATE_SELECTOR trg_state_selector_get_type()
-#define TRG_STATE_SELECTOR(obj) \
-  (G_TYPE_CHECK_INSTANCE_CAST ((obj), TRG_TYPE_STATE_SELECTOR, TrgStateSelector))
-#define TRG_STATE_SELECTOR_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_CAST ((klass), TRG_TYPE_STATE_SELECTOR, TrgStateSelectorClass))
-#define TRG_IS_STATE_SELECTOR(obj) \
-  (G_TYPE_CHECK_INSTANCE_TYPE ((obj), TRG_TYPE_STATE_SELECTOR))
-#define TRG_IS_STATE_SELECTOR_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_TYPE ((klass), TRG_TYPE_STATE_SELECTOR))
-#define TRG_STATE_SELECTOR_GET_CLASS(obj) \
-  (G_TYPE_INSTANCE_GET_CLASS ((obj), TRG_TYPE_STATE_SELECTOR, TrgStateSelectorClass))
-    typedef struct {
+#define TRG_STATE_SELECTOR(obj)                                                                    \
+    (G_TYPE_CHECK_INSTANCE_CAST((obj), TRG_TYPE_STATE_SELECTOR, TrgStateSelector))
+#define TRG_STATE_SELECTOR_CLASS(klass)                                                            \
+    (G_TYPE_CHECK_CLASS_CAST((klass), TRG_TYPE_STATE_SELECTOR, TrgStateSelectorClass))
+#define TRG_IS_STATE_SELECTOR(obj) (G_TYPE_CHECK_INSTANCE_TYPE((obj), TRG_TYPE_STATE_SELECTOR))
+#define TRG_IS_STATE_SELECTOR_CLASS(klass)                                                         \
+    (G_TYPE_CHECK_CLASS_TYPE((klass), TRG_TYPE_STATE_SELECTOR))
+#define TRG_STATE_SELECTOR_GET_CLASS(obj)                                                          \
+    (G_TYPE_INSTANCE_GET_CLASS((obj), TRG_TYPE_STATE_SELECTOR, TrgStateSelectorClass))
+typedef struct {
     GtkTreeView parent;
 } TrgStateSelector;
 
 typedef struct {
     GtkTreeViewClass parent_class;
 
-    void (*torrent_state_changed) (TrgStateSelector * selector,
-                                   guint flag, gpointer data);
+    void (*torrent_state_changed)(TrgStateSelector *selector, guint flag, gpointer data);
 
 } TrgStateSelectorClass;
 
 GType trg_state_selector_get_type(void);
-TrgStateSelector *trg_state_selector_new(TrgClient * client,
-                                         TrgTorrentModel * tmodel);
+TrgStateSelector *trg_state_selector_new(TrgClient *client, TrgTorrentModel *tmodel);
 
-G_END_DECLS guint32 trg_state_selector_get_flag(TrgStateSelector * s);
-void trg_state_selector_update(TrgStateSelector * s, guint whatsChanged);
-gchar *trg_state_selector_get_selected_text(TrgStateSelector * s);
-GRegex *trg_state_selector_get_url_host_regex(TrgStateSelector * s);
-void trg_state_selector_disconnect(TrgStateSelector * s);
-void trg_state_selector_set_show_trackers(TrgStateSelector * s,
-                                          gboolean show);
-void trg_state_selector_set_directories_first(TrgStateSelector * s, gboolean _dirsFirst);
-void trg_state_selector_set_show_dirs(TrgStateSelector * s, gboolean show);
-void trg_state_selector_set_queues_enabled(TrgStateSelector * s,
-                                           gboolean enabled);
-void trg_state_selector_stats_update(TrgStateSelector * s,
-                                     trg_torrent_model_update_stats *
-                                     stats);
+G_END_DECLS guint32 trg_state_selector_get_flag(TrgStateSelector *s);
+void trg_state_selector_update(TrgStateSelector *s, guint whatsChanged);
+gchar *trg_state_selector_get_selected_text(TrgStateSelector *s);
+GRegex *trg_state_selector_get_url_host_regex(TrgStateSelector *s);
+void trg_state_selector_disconnect(TrgStateSelector *s);
+void trg_state_selector_set_show_trackers(TrgStateSelector *s, gboolean show);
+void trg_state_selector_set_directories_first(TrgStateSelector *s, gboolean _dirsFirst);
+void trg_state_selector_set_show_dirs(TrgStateSelector *s, gboolean show);
+void trg_state_selector_set_queues_enabled(TrgStateSelector *s, gboolean enabled);
+void trg_state_selector_stats_update(TrgStateSelector *s, trg_torrent_model_update_stats *stats);
 
-#endif                          /* TRG_STATE_LIST_H_ */
+#endif /* TRG_STATE_LIST_H_ */

--- a/src/trg-stats-dialog.c
+++ b/src/trg-stats-dialog.c
@@ -19,19 +19,19 @@
 
 #include "config.h"
 
+#include <curl/curl.h>
 #include <glib/gi18n.h>
 #include <gtk/gtk.h>
 #include <json-glib/json-glib.h>
-#include <curl/curl.h>
 
 #include "hig.h"
-#include "requests.h"
 #include "json.h"
-#include "util.h"
+#include "requests.h"
 #include "trg-client.h"
-#include "trg-stats-dialog.h"
 #include "trg-main-window.h"
+#include "trg-stats-dialog.h"
 #include "trg-tree-view.h"
+#include "util.h"
 
 enum {
     STATCOL_STAT,
@@ -49,8 +49,8 @@ enum {
 #define STATS_UPDATE_INTERVAL 5
 
 G_DEFINE_TYPE(TrgStatsDialog, trg_stats_dialog, GTK_TYPE_DIALOG)
-#define TRG_STATS_DIALOG_GET_PRIVATE(o) \
-  (G_TYPE_INSTANCE_GET_PRIVATE ((o), TRG_TYPE_STATS_DIALOG, TrgStatsDialogPrivate))
+#define TRG_STATS_DIALOG_GET_PRIVATE(o)                                                            \
+    (G_TYPE_INSTANCE_GET_PRIVATE((o), TRG_TYPE_STATS_DIALOG, TrgStatsDialogPrivate))
 typedef struct _TrgStatsDialogPrivate TrgStatsDialogPrivate;
 
 struct _TrgStatsDialogPrivate {
@@ -58,24 +58,22 @@ struct _TrgStatsDialogPrivate {
     TrgMainWindow *parent;
     GtkWidget *tv;
     GtkListStore *model;
-    GtkTreeRowReference *rr_down, *rr_up, *rr_ratio, *rr_files_added,
-        *rr_session_count, *rr_active, *rr_version;
+    GtkTreeRowReference *rr_down, *rr_up, *rr_ratio, *rr_files_added, *rr_session_count, *rr_active,
+        *rr_version;
 };
 
 static GObject *instance = NULL;
 static gboolean trg_update_stats_timerfunc(gpointer data);
 static gboolean on_stats_reply(gpointer data);
 
-static void
-trg_stats_dialog_get_property(GObject * object, guint property_id,
-                              GValue * value, GParamSpec * pspec)
+static void trg_stats_dialog_get_property(GObject *object, guint property_id, GValue *value,
+                                          GParamSpec *pspec)
 {
     G_OBJECT_WARN_INVALID_PROPERTY_ID(object, property_id, pspec);
 }
 
-static void
-trg_stats_dialog_set_property(GObject * object, guint property_id,
-                              const GValue * value, GParamSpec * pspec)
+static void trg_stats_dialog_set_property(GObject *object, guint property_id, const GValue *value,
+                                          GParamSpec *pspec)
 {
     TrgStatsDialogPrivate *priv = TRG_STATS_DIALOG_GET_PRIVATE(object);
     switch (property_id) {
@@ -91,16 +89,13 @@ trg_stats_dialog_set_property(GObject * object, guint property_id,
     }
 }
 
-static void
-trg_stats_response_cb(GtkDialog * dlg, gint res_id,
-                      gpointer data G_GNUC_UNUSED)
+static void trg_stats_response_cb(GtkDialog *dlg, gint res_id, gpointer data G_GNUC_UNUSED)
 {
     gtk_widget_destroy(GTK_WIDGET(dlg));
     instance = NULL;
 }
 
-static GtkTreeRowReference *stats_dialog_add_statistic(GtkListStore *
-                                                       model, gchar * name)
+static GtkTreeRowReference *stats_dialog_add_statistic(GtkListStore *model, gchar *name)
 {
     GtkTreeIter iter;
     GtkTreePath *path;
@@ -116,9 +111,7 @@ static GtkTreeRowReference *stats_dialog_add_statistic(GtkListStore *
     return rr;
 }
 
-static void
-update_statistic(GtkTreeRowReference * rr, gchar * session,
-                 gchar * cumulat)
+static void update_statistic(GtkTreeRowReference *rr, gchar *session, gchar *cumulat)
 {
     GtkTreePath *path = gtk_tree_row_reference_get_path(rr);
     GtkTreeModel *model = gtk_tree_row_reference_get_model(rr);
@@ -126,25 +119,23 @@ update_statistic(GtkTreeRowReference * rr, gchar * session,
 
     gtk_tree_model_get_iter(model, &iter, path);
 
-    gtk_list_store_set(GTK_LIST_STORE(model), &iter, STATCOL_SESSION,
-                       session, STATCOL_CUMULAT, cumulat, -1);
+    gtk_list_store_set(GTK_LIST_STORE(model), &iter, STATCOL_SESSION, session, STATCOL_CUMULAT,
+                       cumulat, -1);
 
     gtk_tree_path_free(path);
 }
 
-static JsonObject *get_session_arg(JsonObject * args)
+static JsonObject *get_session_arg(JsonObject *args)
 {
     return json_object_get_object_member(args, "current-stats");
 }
 
-static JsonObject *get_cumulat_arg(JsonObject * args)
+static JsonObject *get_cumulat_arg(JsonObject *args)
 {
     return json_object_get_object_member(args, "cumulative-stats");
 }
 
-static void
-update_int_stat(JsonObject * args, GtkTreeRowReference * rr,
-                gchar * jsonKey)
+static void update_int_stat(JsonObject *args, GtkTreeRowReference *rr, gchar *jsonKey)
 {
     gchar session_val[32];
     gchar cumulat_val[32];
@@ -157,53 +148,42 @@ update_int_stat(JsonObject * args, GtkTreeRowReference * rr,
     update_statistic(rr, session_val, cumulat_val);
 }
 
-static void
-update_size_stat(JsonObject * args, GtkTreeRowReference * rr, gchar * jsonKey)
+static void update_size_stat(JsonObject *args, GtkTreeRowReference *rr, gchar *jsonKey)
 {
     gchar session_val[32];
     gchar cumulat_val[32];
 
-    trg_strlsize(cumulat_val,
-                 json_object_get_int_member(get_cumulat_arg(args),
-                                            jsonKey));
-    trg_strlsize(session_val,
-                 json_object_get_int_member(get_session_arg(args),
-                                            jsonKey));
+    trg_strlsize(cumulat_val, json_object_get_int_member(get_cumulat_arg(args), jsonKey));
+    trg_strlsize(session_val, json_object_get_int_member(get_session_arg(args), jsonKey));
 
     update_statistic(rr, session_val, cumulat_val);
 }
 
-static void
-update_ratio_stat(JsonObject * args, GtkTreeRowReference * rr, gchar * jsonKeyA, gchar * jsonKeyB)
-{
-	gchar session_val[32];
-	gchar cumulat_val[32];
-
-	trg_strlratio(session_val, 
-				  json_object_get_double_member(get_session_arg(args), jsonKeyA) /
-				  json_object_get_double_member(get_session_arg(args), jsonKeyB) );
-
-	trg_strlratio(cumulat_val, 
-				  json_object_get_double_member(get_cumulat_arg(args), jsonKeyA) /
-				  json_object_get_double_member(get_cumulat_arg(args), jsonKeyB) );
-
-    update_statistic(rr, session_val, cumulat_val);
-}
-
-static void
-update_time_stat(JsonObject * args, GtkTreeRowReference * rr,
-                 gchar * jsonKey)
+static void update_ratio_stat(JsonObject *args, GtkTreeRowReference *rr, gchar *jsonKeyA,
+                              gchar *jsonKeyB)
 {
     gchar session_val[32];
     gchar cumulat_val[32];
 
-    tr_strltime_long(session_val,
-                     json_object_get_int_member(get_session_arg(args),
-                                                jsonKey),
+    trg_strlratio(session_val,
+                  json_object_get_double_member(get_session_arg(args), jsonKeyA)
+                      / json_object_get_double_member(get_session_arg(args), jsonKeyB));
+
+    trg_strlratio(cumulat_val,
+                  json_object_get_double_member(get_cumulat_arg(args), jsonKeyA)
+                      / json_object_get_double_member(get_cumulat_arg(args), jsonKeyB));
+
+    update_statistic(rr, session_val, cumulat_val);
+}
+
+static void update_time_stat(JsonObject *args, GtkTreeRowReference *rr, gchar *jsonKey)
+{
+    gchar session_val[32];
+    gchar cumulat_val[32];
+
+    tr_strltime_long(session_val, json_object_get_int_member(get_session_arg(args), jsonKey),
                      sizeof(session_val));
-    tr_strltime_long(cumulat_val,
-                     json_object_get_int_member(get_cumulat_arg(args),
-                                                jsonKey),
+    tr_strltime_long(cumulat_val, json_object_get_int_member(get_cumulat_arg(args), jsonKey),
                      sizeof(cumulat_val));
 
     update_statistic(rr, session_val, cumulat_val);
@@ -211,7 +191,7 @@ update_time_stat(JsonObject * args, GtkTreeRowReference * rr,
 
 static gboolean on_stats_reply(gpointer data)
 {
-    trg_response *response = (trg_response *) data;
+    trg_response *response = (trg_response *)data;
     TrgStatsDialogPrivate *priv;
     JsonObject *args;
     char versionStr[32];
@@ -238,8 +218,7 @@ static gboolean on_stats_reply(gpointer data)
         update_time_stat(args, priv->rr_active, "secondsActive");
 
         if (trg_client_is_connected(priv->client))
-            g_timeout_add_seconds(STATS_UPDATE_INTERVAL,
-                                  trg_update_stats_timerfunc,
+            g_timeout_add_seconds(STATS_UPDATE_INTERVAL, trg_update_stats_timerfunc,
                                   response->cb_data);
     } else {
         trg_error_dialog(GTK_WINDOW(data), response);
@@ -256,97 +235,71 @@ static gboolean trg_update_stats_timerfunc(gpointer data)
     if (TRG_IS_STATS_DIALOG(data)) {
         priv = TRG_STATS_DIALOG_GET_PRIVATE(data);
         if (trg_client_is_connected(priv->client))
-            dispatch_async(priv->client, session_stats(), on_stats_reply,
-                           data);
+            dispatch_async(priv->client, session_stats(), on_stats_reply, data);
     }
 
     return FALSE;
 }
 
-static void
-trg_stats_add_column(GtkTreeView * tv, gint index, gchar * title,
-                     gint width)
+static void trg_stats_add_column(GtkTreeView *tv, gint index, gchar *title, gint width)
 {
     GtkCellRenderer *renderer = gtk_cell_renderer_text_new();
-    GtkTreeViewColumn *column =
-        gtk_tree_view_column_new_with_attributes(title, renderer,
-                                                 "text", index, NULL);
+    GtkTreeViewColumn *column
+        = gtk_tree_view_column_new_with_attributes(title, renderer, "text", index, NULL);
     gtk_tree_view_column_set_sizing(column, GTK_TREE_VIEW_COLUMN_FIXED);
     gtk_tree_view_column_set_fixed_width(column, width);
 
     gtk_tree_view_append_column(tv, column);
 }
 
-static GObject *trg_stats_dialog_constructor(GType type,
-                                             guint
-                                             n_construct_properties,
-                                             GObjectConstructParam *
-                                             construct_params)
+static GObject *trg_stats_dialog_constructor(GType type, guint n_construct_properties,
+                                             GObjectConstructParam *construct_params)
 {
     GtkWidget *tv;
 
-    GObject *obj = G_OBJECT_CLASS
-        (trg_stats_dialog_parent_class)->constructor(type,
-                                                     n_construct_properties,
-                                                     construct_params);
+    GObject *obj = G_OBJECT_CLASS(trg_stats_dialog_parent_class)
+                       ->constructor(type, n_construct_properties, construct_params);
     TrgStatsDialogPrivate *priv = TRG_STATS_DIALOG_GET_PRIVATE(obj);
 
     gtk_window_set_title(GTK_WINDOW(obj), _("Statistics"));
-    gtk_window_set_transient_for(GTK_WINDOW(obj),
-                                 GTK_WINDOW(priv->parent));
+    gtk_window_set_transient_for(GTK_WINDOW(obj), GTK_WINDOW(priv->parent));
     gtk_window_set_destroy_with_parent(GTK_WINDOW(obj), TRUE);
-    gtk_dialog_add_button(GTK_DIALOG(obj), _("_Close"),
-                          GTK_RESPONSE_CLOSE);
+    gtk_dialog_add_button(GTK_DIALOG(obj), _("_Close"), GTK_RESPONSE_CLOSE);
 
     gtk_container_set_border_width(GTK_CONTAINER(obj), GUI_PAD);
 
     gtk_dialog_set_default_response(GTK_DIALOG(obj), GTK_RESPONSE_CLOSE);
 
-    g_signal_connect(G_OBJECT(obj),
-                     "response", G_CALLBACK(trg_stats_response_cb), NULL);
+    g_signal_connect(G_OBJECT(obj), "response", G_CALLBACK(trg_stats_response_cb), NULL);
 
-    priv->model =
-        gtk_list_store_new(STATCOL_COLUMNS, G_TYPE_STRING, G_TYPE_STRING,
-                           G_TYPE_STRING);
+    priv->model = gtk_list_store_new(STATCOL_COLUMNS, G_TYPE_STRING, G_TYPE_STRING, G_TYPE_STRING);
 
-    priv->rr_version =
-        stats_dialog_add_statistic(priv->model, _("Version"));
-    priv->rr_down =
-        stats_dialog_add_statistic(priv->model, _("Download Total"));
-    priv->rr_up =
-        stats_dialog_add_statistic(priv->model, _("Upload Total"));
-    priv->rr_ratio =
-        stats_dialog_add_statistic(priv->model, _("Ratio"));
-    priv->rr_files_added =
-        stats_dialog_add_statistic(priv->model, _("Files Added"));
-    priv->rr_session_count =
-        stats_dialog_add_statistic(priv->model, _("Session Count"));
-    priv->rr_active =
-        stats_dialog_add_statistic(priv->model, _("Time Active"));
+    priv->rr_version = stats_dialog_add_statistic(priv->model, _("Version"));
+    priv->rr_down = stats_dialog_add_statistic(priv->model, _("Download Total"));
+    priv->rr_up = stats_dialog_add_statistic(priv->model, _("Upload Total"));
+    priv->rr_ratio = stats_dialog_add_statistic(priv->model, _("Ratio"));
+    priv->rr_files_added = stats_dialog_add_statistic(priv->model, _("Files Added"));
+    priv->rr_session_count = stats_dialog_add_statistic(priv->model, _("Session Count"));
+    priv->rr_active = stats_dialog_add_statistic(priv->model, _("Time Active"));
 
     tv = priv->tv = trg_tree_view_new();
     gtk_widget_set_sensitive(tv, TRUE);
 
-    trg_stats_add_column(GTK_TREE_VIEW(tv), STATCOL_STAT, _("Statistic"),
-                         200);
-    trg_stats_add_column(GTK_TREE_VIEW(tv), STATCOL_SESSION, _("Session"),
-                         200);
-    trg_stats_add_column(GTK_TREE_VIEW(tv), STATCOL_CUMULAT,
-                         _("Cumulative"), 200);
+    trg_stats_add_column(GTK_TREE_VIEW(tv), STATCOL_STAT, _("Statistic"), 200);
+    trg_stats_add_column(GTK_TREE_VIEW(tv), STATCOL_SESSION, _("Session"), 200);
+    trg_stats_add_column(GTK_TREE_VIEW(tv), STATCOL_CUMULAT, _("Cumulative"), 200);
 
-    gtk_tree_view_set_model(GTK_TREE_VIEW(tv),
-                            GTK_TREE_MODEL(priv->model));
+    gtk_tree_view_set_model(GTK_TREE_VIEW(tv), GTK_TREE_MODEL(priv->model));
 
     gtk_container_set_border_width(GTK_CONTAINER(tv), GUI_PAD);
-    gtk_box_pack_start(GTK_BOX(gtk_bin_get_child(GTK_BIN(obj))), tv, TRUE,
-                       TRUE, 0);
+    gtk_box_pack_start(GTK_BOX(gtk_bin_get_child(GTK_BIN(obj))), tv, TRUE, TRUE, 0);
 
     dispatch_async(priv->client, session_stats(), on_stats_reply, obj);
 
     return obj;
 }
 
-static void trg_stats_dialog_class_init(TrgStatsDialogClass * klass)
+static void trg_stats_dialog_class_init(TrgStatsDialogClass *klass)
 {
     GObjectClass *object_class = G_OBJECT_CLASS(klass);
 
@@ -356,41 +309,28 @@ static void trg_stats_dialog_class_init(TrgStatsDialogClass * klass)
     object_class->set_property = trg_stats_dialog_set_property;
     object_class->constructor = trg_stats_dialog_constructor;
 
-    g_object_class_install_property(object_class,
-                                    PROP_PARENT,
-                                    g_param_spec_object
-                                    ("parent-window", "Parent window",
-                                     "Parent window",
-                                     TRG_TYPE_MAIN_WINDOW,
-                                     G_PARAM_READWRITE |
-                                     G_PARAM_CONSTRUCT_ONLY |
-                                     G_PARAM_STATIC_NAME |
-                                     G_PARAM_STATIC_NICK |
-                                     G_PARAM_STATIC_BLURB));
+    g_object_class_install_property(
+        object_class, PROP_PARENT,
+        g_param_spec_object("parent-window", "Parent window", "Parent window", TRG_TYPE_MAIN_WINDOW,
+                            G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME
+                                | G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
 
-    g_object_class_install_property(object_class,
-                                    PROP_CLIENT,
-                                    g_param_spec_pointer
-                                    ("trg-client", "TClient",
-                                     "Client",
-                                     G_PARAM_READWRITE |
-                                     G_PARAM_CONSTRUCT_ONLY |
-                                     G_PARAM_STATIC_NAME |
-                                     G_PARAM_STATIC_NICK |
-                                     G_PARAM_STATIC_BLURB));
+    g_object_class_install_property(
+        object_class, PROP_CLIENT,
+        g_param_spec_pointer("trg-client", "TClient", "Client",
+                             G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME
+                                 | G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
 }
 
-static void trg_stats_dialog_init(TrgStatsDialog * self)
+static void trg_stats_dialog_init(TrgStatsDialog *self)
 {
 }
 
-TrgStatsDialog *trg_stats_dialog_get_instance(TrgMainWindow * parent,
-                                              TrgClient * client)
+TrgStatsDialog *trg_stats_dialog_get_instance(TrgMainWindow *parent, TrgClient *client)
 {
     if (instance == NULL) {
-        instance = g_object_new(TRG_TYPE_STATS_DIALOG,
-                                "trg-client", client,
-                                "parent-window", parent, NULL);
+        instance = g_object_new(TRG_TYPE_STATS_DIALOG, "trg-client", client, "parent-window",
+                                parent, NULL);
     }
 
     return TRG_STATS_DIALOG(instance);

--- a/src/trg-stats-dialog.h
+++ b/src/trg-stats-dialog.h
@@ -29,17 +29,15 @@
 
 G_BEGIN_DECLS
 #define TRG_TYPE_STATS_DIALOG trg_stats_dialog_get_type()
-#define TRG_STATS_DIALOG(obj) \
-  (G_TYPE_CHECK_INSTANCE_CAST ((obj), TRG_TYPE_STATS_DIALOG, TrgStatsDialog))
-#define TRG_STATS_DIALOG_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_CAST ((klass), TRG_TYPE_STATS_DIALOG, TrgStatsDialogClass))
-#define TRG_IS_STATS_DIALOG(obj) \
-  (G_TYPE_CHECK_INSTANCE_TYPE ((obj), TRG_TYPE_STATS_DIALOG))
-#define TRG_IS_STATS_DIALOG_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_TYPE ((klass), TRG_TYPE_STATS_DIALOG))
-#define TRG_STATS_DIALOG_GET_CLASS(obj) \
-  (G_TYPE_INSTANCE_GET_CLASS ((obj), TRG_TYPE_STATS_DIALOG, TrgStatsDialogClass))
-    typedef struct {
+#define TRG_STATS_DIALOG(obj)                                                                      \
+    (G_TYPE_CHECK_INSTANCE_CAST((obj), TRG_TYPE_STATS_DIALOG, TrgStatsDialog))
+#define TRG_STATS_DIALOG_CLASS(klass)                                                              \
+    (G_TYPE_CHECK_CLASS_CAST((klass), TRG_TYPE_STATS_DIALOG, TrgStatsDialogClass))
+#define TRG_IS_STATS_DIALOG(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), TRG_TYPE_STATS_DIALOG))
+#define TRG_IS_STATS_DIALOG_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass), TRG_TYPE_STATS_DIALOG))
+#define TRG_STATS_DIALOG_GET_CLASS(obj)                                                            \
+    (G_TYPE_INSTANCE_GET_CLASS((obj), TRG_TYPE_STATS_DIALOG, TrgStatsDialogClass))
+typedef struct {
     GtkDialog parent;
 } TrgStatsDialog;
 
@@ -49,8 +47,7 @@ typedef struct {
 
 GType trg_stats_dialog_get_type(void);
 
-TrgStatsDialog *trg_stats_dialog_get_instance(TrgMainWindow * parent,
-                                              TrgClient * client);
+TrgStatsDialog *trg_stats_dialog_get_instance(TrgMainWindow *parent, TrgClient *client);
 
 G_END_DECLS
-#endif                          /* TRG_STATS_DIALOG_H_ */
+#endif /* TRG_STATS_DIALOG_H_ */

--- a/src/trg-status-bar.h
+++ b/src/trg-status-bar.h
@@ -27,17 +27,14 @@
 
 G_BEGIN_DECLS
 #define TRG_TYPE_STATUS_BAR trg_status_bar_get_type()
-#define TRG_STATUS_BAR(obj) \
-  (G_TYPE_CHECK_INSTANCE_CAST ((obj), TRG_TYPE_STATUS_BAR, TrgStatusBar))
-#define TRG_STATUS_BAR_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_CAST ((klass), TRG_TYPE_STATUS_BAR, TrgStatusBarClass))
-#define TRG_IS_STATUS_BAR(obj) \
-  (G_TYPE_CHECK_INSTANCE_TYPE ((obj), TRG_TYPE_STATUS_BAR))
-#define TRG_IS_STATUS_BAR_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_TYPE ((klass), TRG_TYPE_STATUS_BAR))
-#define TRG_STATUS_BAR_GET_CLASS(obj) \
-  (G_TYPE_INSTANCE_GET_CLASS ((obj), TRG_TYPE_STATUS_BAR, TrgStatusBarClass))
-    typedef struct {
+#define TRG_STATUS_BAR(obj) (G_TYPE_CHECK_INSTANCE_CAST((obj), TRG_TYPE_STATUS_BAR, TrgStatusBar))
+#define TRG_STATUS_BAR_CLASS(klass)                                                                \
+    (G_TYPE_CHECK_CLASS_CAST((klass), TRG_TYPE_STATUS_BAR, TrgStatusBarClass))
+#define TRG_IS_STATUS_BAR(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), TRG_TYPE_STATUS_BAR))
+#define TRG_IS_STATUS_BAR_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass), TRG_TYPE_STATUS_BAR))
+#define TRG_STATUS_BAR_GET_CLASS(obj)                                                              \
+    (G_TYPE_INSTANCE_GET_CLASS((obj), TRG_TYPE_STATUS_BAR, TrgStatusBarClass))
+typedef struct {
     GtkHBox parent;
 } TrgStatusBar;
 
@@ -47,22 +44,17 @@ typedef struct {
 
 GType trg_status_bar_get_type(void);
 
-TrgStatusBar *trg_status_bar_new(TrgMainWindow * win, TrgClient * client);
+TrgStatusBar *trg_status_bar_new(TrgMainWindow *win, TrgClient *client);
 
 G_END_DECLS
-    void trg_status_bar_update(TrgStatusBar * sb,
-                               trg_torrent_model_update_stats * stats,
-                               TrgClient * client);
-void trg_status_bar_session_update(TrgStatusBar * sb,
-                                   JsonObject * session);
-void trg_status_bar_connect(TrgStatusBar * sb, JsonObject * session,
-                            TrgClient * client);
-void trg_status_bar_push_connection_msg(TrgStatusBar * sb,
-                                        const gchar * msg);
-void trg_status_bar_reset(TrgStatusBar * sb);
-void trg_status_bar_clear_indicators(TrgStatusBar * sb);
-const gchar *trg_status_bar_get_speed_text(TrgStatusBar * s);
-void trg_status_bar_update_speed(TrgStatusBar * sb,
-                                 trg_torrent_model_update_stats * stats,
-                                 TrgClient * client);
-#endif                          /* TRG_STATUS_BAR_H_ */
+void trg_status_bar_update(TrgStatusBar *sb, trg_torrent_model_update_stats *stats,
+                           TrgClient *client);
+void trg_status_bar_session_update(TrgStatusBar *sb, JsonObject *session);
+void trg_status_bar_connect(TrgStatusBar *sb, JsonObject *session, TrgClient *client);
+void trg_status_bar_push_connection_msg(TrgStatusBar *sb, const gchar *msg);
+void trg_status_bar_reset(TrgStatusBar *sb);
+void trg_status_bar_clear_indicators(TrgStatusBar *sb);
+const gchar *trg_status_bar_get_speed_text(TrgStatusBar *s);
+void trg_status_bar_update_speed(TrgStatusBar *sb, trg_torrent_model_update_stats *stats,
+                                 TrgClient *client);
+#endif /* TRG_STATUS_BAR_H_ */

--- a/src/trg-toolbar.c
+++ b/src/trg-toolbar.c
@@ -22,10 +22,10 @@
 #include <glib/gi18n.h>
 #include <gtk/gtk.h>
 
-#include "trg-prefs.h"
 #include "trg-main-window.h"
-#include "trg-toolbar.h"
 #include "trg-menu-bar.h"
+#include "trg-prefs.h"
+#include "trg-toolbar.h"
 
 enum {
     PROP_0,
@@ -46,8 +46,8 @@ enum {
 };
 
 G_DEFINE_TYPE(TrgToolbar, trg_toolbar, GTK_TYPE_TOOLBAR)
-#define TRG_TOOLBAR_GET_PRIVATE(o) \
-  (G_TYPE_INSTANCE_GET_PRIVATE ((o), TRG_TYPE_TOOLBAR, TrgToolbarPrivate))
+#define TRG_TOOLBAR_GET_PRIVATE(o)                                                                 \
+    (G_TYPE_INSTANCE_GET_PRIVATE((o), TRG_TYPE_TOOLBAR, TrgToolbarPrivate))
 typedef struct _TrgToolbarPrivate TrgToolbarPrivate;
 
 struct _TrgToolbarPrivate {
@@ -65,11 +65,8 @@ struct _TrgToolbarPrivate {
     TrgMainWindow *main_window;
 };
 
-static void
-trg_toolbar_set_property(GObject * object,
-                         guint prop_id,
-                         const GValue * value,
-                         GParamSpec * pspec G_GNUC_UNUSED)
+static void trg_toolbar_set_property(GObject *object, guint prop_id, const GValue *value,
+                                     GParamSpec *pspec G_GNUC_UNUSED)
 {
     TrgToolbarPrivate *priv = TRG_TOOLBAR_GET_PRIVATE(object);
 
@@ -83,9 +80,8 @@ trg_toolbar_set_property(GObject * object,
     }
 }
 
-static void
-trg_toolbar_get_property(GObject * object, guint property_id,
-                         GValue * value, GParamSpec * pspec)
+static void trg_toolbar_get_property(GObject *object, guint property_id, GValue *value,
+                                     GParamSpec *pspec)
 {
     TrgToolbarPrivate *priv = TRG_TOOLBAR_GET_PRIVATE(object);
 
@@ -126,32 +122,20 @@ trg_toolbar_get_property(GObject * object, guint property_id,
     }
 }
 
-static void
-trg_toolbar_install_widget_prop(GObjectClass * class, guint propId,
-                                const gchar * name, const gchar * nick)
+static void trg_toolbar_install_widget_prop(GObjectClass *class, guint propId, const gchar *name,
+                                            const gchar *nick)
 {
-    g_object_class_install_property(class,
-                                    propId,
-                                    g_param_spec_object(name,
-                                                        nick,
-                                                        nick,
-                                                        GTK_TYPE_WIDGET,
-                                                        G_PARAM_READABLE
-                                                        |
-                                                        G_PARAM_STATIC_NAME
-                                                        |
-                                                        G_PARAM_STATIC_NICK
-                                                        |
-                                                        G_PARAM_STATIC_BLURB));
+    g_object_class_install_property(class, propId,
+                                    g_param_spec_object(name, nick, nick, GTK_TYPE_WIDGET,
+                                                        G_PARAM_READABLE | G_PARAM_STATIC_NAME
+                                                            | G_PARAM_STATIC_NICK
+                                                            | G_PARAM_STATIC_BLURB));
 }
 
-static GtkWidget *trg_toolbar_item_new(TrgToolbar * toolbar,
-                                gchar * text,
-                                int *index, gchar * icon,
-                                gboolean sensitive)
+static GtkWidget *trg_toolbar_item_new(TrgToolbar *toolbar, gchar *text, int *index, gchar *icon,
+                                       gboolean sensitive)
 {
-    GtkWidget *img = gtk_image_new_from_icon_name(icon,
-                                                  GTK_ICON_SIZE_LARGE_TOOLBAR);
+    GtkWidget *img = gtk_image_new_from_icon_name(icon, GTK_ICON_SIZE_LARGE_TOOLBAR);
     GtkToolItem *w = gtk_tool_button_new(img, text);
     gtk_widget_set_sensitive(GTK_WIDGET(w), sensitive);
     gtk_tool_item_set_tooltip_text(w, text);
@@ -159,95 +143,69 @@ static GtkWidget *trg_toolbar_item_new(TrgToolbar * toolbar,
     return GTK_WIDGET(w);
 }
 
-static void trg_toolbar_refresh_menu(GtkWidget * w, gpointer data)
+static void trg_toolbar_refresh_menu(GtkWidget *w, gpointer data)
 {
     TrgToolbarPrivate *priv = TRG_TOOLBAR_GET_PRIVATE(data);
-    GtkWidget *old =
-        gtk_menu_tool_button_get_menu(GTK_MENU_TOOL_BUTTON
-                                      (priv->tb_connect));
-    GtkWidget *new =
-        trg_menu_bar_file_connect_menu_new(priv->main_window, priv->prefs);
+    GtkWidget *old = gtk_menu_tool_button_get_menu(GTK_MENU_TOOL_BUTTON(priv->tb_connect));
+    GtkWidget *new = trg_menu_bar_file_connect_menu_new(priv->main_window, priv->prefs);
 
     gtk_widget_destroy(old);
-    gtk_menu_tool_button_set_menu(GTK_MENU_TOOL_BUTTON(priv->tb_connect),
-                                  new);
+    gtk_menu_tool_button_set_menu(GTK_MENU_TOOL_BUTTON(priv->tb_connect), new);
     gtk_widget_show_all(new);
 }
 
-static GObject *trg_toolbar_constructor(GType type,
-                                        guint
-                                        n_construct_properties,
-                                        GObjectConstructParam *
-                                        construct_params)
+static GObject *trg_toolbar_constructor(GType type, guint n_construct_properties,
+                                        GObjectConstructParam *construct_params)
 {
-    GObject *obj =
-        G_OBJECT_CLASS(trg_toolbar_parent_class)->constructor(type,
-                                                              n_construct_properties,
-                                                              construct_params);
+    GObject *obj = G_OBJECT_CLASS(trg_toolbar_parent_class)
+                       ->constructor(type, n_construct_properties, construct_params);
     TrgToolbarPrivate *priv = TRG_TOOLBAR_GET_PRIVATE(obj);
 
     GtkToolItem *separator;
     GtkWidget *menu;
     int position = 0;
 
-    gtk_toolbar_set_icon_size(GTK_TOOLBAR(obj),
-                              GTK_ICON_SIZE_LARGE_TOOLBAR);
+    gtk_toolbar_set_icon_size(GTK_TOOLBAR(obj), GTK_ICON_SIZE_LARGE_TOOLBAR);
     gtk_toolbar_set_style(GTK_TOOLBAR(obj), GTK_TOOLBAR_BOTH_HORIZ);
 
-    GtkWidget *img = gtk_image_new_from_icon_name("trg-gtk-connect",
-                                                  GTK_ICON_SIZE_LARGE_TOOLBAR);
-    priv->tb_connect =
-        GTK_WIDGET(gtk_menu_tool_button_new(img, _("Connect")));
-    gtk_tool_item_set_tooltip_text(GTK_TOOL_ITEM(priv->tb_connect),
-                                   _("Connect"));
-    gtk_tool_item_set_is_important (GTK_TOOL_ITEM (priv->tb_connect), TRUE);
-    menu =
-        trg_menu_bar_file_connect_menu_new(priv->main_window, priv->prefs);
-    gtk_menu_tool_button_set_menu(GTK_MENU_TOOL_BUTTON(priv->tb_connect),
-                                  menu);
-    gtk_toolbar_insert(GTK_TOOLBAR(obj), GTK_TOOL_ITEM(priv->tb_connect),
-                       position++);
+    GtkWidget *img = gtk_image_new_from_icon_name("trg-gtk-connect", GTK_ICON_SIZE_LARGE_TOOLBAR);
+    priv->tb_connect = GTK_WIDGET(gtk_menu_tool_button_new(img, _("Connect")));
+    gtk_tool_item_set_tooltip_text(GTK_TOOL_ITEM(priv->tb_connect), _("Connect"));
+    gtk_tool_item_set_is_important(GTK_TOOL_ITEM(priv->tb_connect), TRUE);
+    menu = trg_menu_bar_file_connect_menu_new(priv->main_window, priv->prefs);
+    gtk_menu_tool_button_set_menu(GTK_MENU_TOOL_BUTTON(priv->tb_connect), menu);
+    gtk_toolbar_insert(GTK_TOOLBAR(obj), GTK_TOOL_ITEM(priv->tb_connect), position++);
     gtk_widget_show_all(menu);
 
-    priv->tb_disconnect =
-        trg_toolbar_item_new(TRG_TOOLBAR(obj), _("Disconnect"), &position,
-                             "trg-gtk-disconnect", FALSE);
-    priv->tb_add =
-        trg_toolbar_item_new(TRG_TOOLBAR(obj), _("Add"), &position,
-                             "list-add", FALSE);
+    priv->tb_disconnect = trg_toolbar_item_new(TRG_TOOLBAR(obj), _("Disconnect"), &position,
+                                               "trg-gtk-disconnect", FALSE);
+    priv->tb_add = trg_toolbar_item_new(TRG_TOOLBAR(obj), _("Add"), &position, "list-add", FALSE);
 
     separator = gtk_separator_tool_item_new();
     gtk_toolbar_insert(GTK_TOOLBAR(obj), separator, position++);
 
-    priv->tb_resume =
-        trg_toolbar_item_new(TRG_TOOLBAR(obj), _("Resume"), &position,
-                             "media-playback-start", FALSE);
-    priv->tb_pause =
-        trg_toolbar_item_new(TRG_TOOLBAR(obj), _("Pause"), &position,
-                             "media-playback-pause", FALSE);
+    priv->tb_resume = trg_toolbar_item_new(TRG_TOOLBAR(obj), _("Resume"), &position,
+                                           "media-playback-start", FALSE);
+    priv->tb_pause = trg_toolbar_item_new(TRG_TOOLBAR(obj), _("Pause"), &position,
+                                          "media-playback-pause", FALSE);
 
-    priv->tb_props =
-        trg_toolbar_item_new(TRG_TOOLBAR(obj), _("Properties"), &position,
-                             "document-properties", FALSE);
+    priv->tb_props = trg_toolbar_item_new(TRG_TOOLBAR(obj), _("Properties"), &position,
+                                          "document-properties", FALSE);
 
-    priv->tb_remove =
-        trg_toolbar_item_new(TRG_TOOLBAR(obj), _("Remove"), &position,
-                             "list-remove", FALSE);
+    priv->tb_remove
+        = trg_toolbar_item_new(TRG_TOOLBAR(obj), _("Remove"), &position, "list-remove", FALSE);
 
-    priv->tb_delete =
-        trg_toolbar_item_new(TRG_TOOLBAR(obj), _("Remove and delete data"),
-                             &position, "edit-delete", FALSE);
+    priv->tb_delete = trg_toolbar_item_new(TRG_TOOLBAR(obj), _("Remove and delete data"), &position,
+                                           "edit-delete", FALSE);
 
     separator = gtk_separator_tool_item_new();
     gtk_toolbar_insert(GTK_TOOLBAR(obj), separator, position++);
 
-    priv->tb_local_prefs =
-        trg_toolbar_item_new(TRG_TOOLBAR(obj), _("Local Preferences"),
-                             &position, "preferences-system", TRUE);
+    priv->tb_local_prefs = trg_toolbar_item_new(TRG_TOOLBAR(obj), _("Local Preferences"), &position,
+                                                "preferences-system", TRUE);
 
-    priv->tb_remote_prefs =
-        trg_toolbar_item_new(TRG_TOOLBAR(obj), _("Remote Preferences"),
-                             &position, "network-workgroup", FALSE);
+    priv->tb_remote_prefs = trg_toolbar_item_new(TRG_TOOLBAR(obj), _("Remote Preferences"),
+                                                 &position, "network-workgroup", FALSE);
 
     g_signal_connect(G_OBJECT(priv->prefs), "pref-profile-changed",
                      G_CALLBACK(trg_toolbar_refresh_menu), obj);
@@ -255,74 +213,51 @@ static GObject *trg_toolbar_constructor(GType type,
     return obj;
 }
 
-static void trg_toolbar_class_init(TrgToolbarClass * klass)
+static void trg_toolbar_class_init(TrgToolbarClass *klass)
 {
     GObjectClass *object_class = G_OBJECT_CLASS(klass);
     object_class->get_property = trg_toolbar_get_property;
     object_class->set_property = trg_toolbar_set_property;
     object_class->constructor = trg_toolbar_constructor;
 
-    g_object_class_install_property(object_class,
-                                    PROP_PREFS,
-                                    g_param_spec_pointer("prefs",
-                                                         "Prefs",
-                                                         "Prefs",
-                                                         G_PARAM_READWRITE
-                                                         |
-                                                         G_PARAM_CONSTRUCT
-                                                         |
-                                                         G_PARAM_STATIC_NAME
-                                                         |
-                                                         G_PARAM_STATIC_NICK
-                                                         |
-                                                         G_PARAM_STATIC_BLURB));
+    g_object_class_install_property(
+        object_class, PROP_PREFS,
+        g_param_spec_pointer("prefs", "Prefs", "Prefs",
+                             G_PARAM_READWRITE | G_PARAM_CONSTRUCT | G_PARAM_STATIC_NAME
+                                 | G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
 
-    g_object_class_install_property(object_class,
-                                    PROP_MAIN_WINDOW,
-                                    g_param_spec_object("mainwindow",
-                                                        "mainwindow",
-                                                        "mainwindow",
-                                                        TRG_TYPE_MAIN_WINDOW,
-                                                        G_PARAM_READWRITE |
-                                                        G_PARAM_CONSTRUCT_ONLY
-                                                        |
-                                                        G_PARAM_STATIC_NAME
-                                                        |
-                                                        G_PARAM_STATIC_NICK
-                                                        |
-                                                        G_PARAM_STATIC_BLURB));
+    g_object_class_install_property(
+        object_class, PROP_MAIN_WINDOW,
+        g_param_spec_object("mainwindow", "mainwindow", "mainwindow", TRG_TYPE_MAIN_WINDOW,
+                            G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME
+                                | G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
 
-    trg_toolbar_install_widget_prop(object_class, PROP_CONNECT_BUTTON,
-                                    "connect-button", "Connect Button");
-    trg_toolbar_install_widget_prop(object_class,
-                                    PROP_DISCONNECT_BUTTON,
-                                    "disconnect-button",
+    trg_toolbar_install_widget_prop(object_class, PROP_CONNECT_BUTTON, "connect-button",
+                                    "Connect Button");
+    trg_toolbar_install_widget_prop(object_class, PROP_DISCONNECT_BUTTON, "disconnect-button",
                                     "Disconnect Button");
-    trg_toolbar_install_widget_prop(object_class, PROP_ADD_BUTTON,
-                                    "add-button", "Add Button");
-    trg_toolbar_install_widget_prop(object_class, PROP_ADD_URL_BUTTON,
-                                    "add-url-button", "Add URL Button");
-    trg_toolbar_install_widget_prop(object_class, PROP_REMOVE_BUTTON,
-                                    "remove-button", "Remove Button");
-    trg_toolbar_install_widget_prop(object_class, PROP_DELETE_BUTTON,
-                                    "delete-button", "Delete Button");
-    trg_toolbar_install_widget_prop(object_class, PROP_RESUME_BUTTON,
-                                    "resume-button", "Resume Button");
-    trg_toolbar_install_widget_prop(object_class, PROP_PAUSE_BUTTON,
-                                    "pause-button", "Pause Button");
-    trg_toolbar_install_widget_prop(object_class, PROP_PROPS_BUTTON,
-                                    "props-button", "Props Button");
-    trg_toolbar_install_widget_prop(object_class, PROP_REMOTE_PREFS_BUTTON,
-                                    "remote-prefs-button",
+    trg_toolbar_install_widget_prop(object_class, PROP_ADD_BUTTON, "add-button", "Add Button");
+    trg_toolbar_install_widget_prop(object_class, PROP_ADD_URL_BUTTON, "add-url-button",
+                                    "Add URL Button");
+    trg_toolbar_install_widget_prop(object_class, PROP_REMOVE_BUTTON, "remove-button",
+                                    "Remove Button");
+    trg_toolbar_install_widget_prop(object_class, PROP_DELETE_BUTTON, "delete-button",
+                                    "Delete Button");
+    trg_toolbar_install_widget_prop(object_class, PROP_RESUME_BUTTON, "resume-button",
+                                    "Resume Button");
+    trg_toolbar_install_widget_prop(object_class, PROP_PAUSE_BUTTON, "pause-button",
+                                    "Pause Button");
+    trg_toolbar_install_widget_prop(object_class, PROP_PROPS_BUTTON, "props-button",
+                                    "Props Button");
+    trg_toolbar_install_widget_prop(object_class, PROP_REMOTE_PREFS_BUTTON, "remote-prefs-button",
                                     "Remote Prefs Button");
-    trg_toolbar_install_widget_prop(object_class, PROP_LOCAL_PREFS_BUTTON,
-                                    "local-prefs-button",
+    trg_toolbar_install_widget_prop(object_class, PROP_LOCAL_PREFS_BUTTON, "local-prefs-button",
                                     "Local Prefs Button");
 
     g_type_class_add_private(klass, sizeof(TrgToolbarPrivate));
 }
 
-void trg_toolbar_connected_change(TrgToolbar * tb, gboolean connected)
+void trg_toolbar_connected_change(TrgToolbar *tb, gboolean connected)
 {
     TrgToolbarPrivate *priv = TRG_TOOLBAR_GET_PRIVATE(tb);
 
@@ -331,8 +266,7 @@ void trg_toolbar_connected_change(TrgToolbar * tb, gboolean connected)
     gtk_widget_set_sensitive(priv->tb_remote_prefs, connected);
 }
 
-void
-trg_toolbar_torrent_actions_sensitive(TrgToolbar * tb, gboolean sensitive)
+void trg_toolbar_torrent_actions_sensitive(TrgToolbar *tb, gboolean sensitive)
 {
     TrgToolbarPrivate *priv = TRG_TOOLBAR_GET_PRIVATE(tb);
 
@@ -343,12 +277,11 @@ trg_toolbar_torrent_actions_sensitive(TrgToolbar * tb, gboolean sensitive)
     gtk_widget_set_sensitive(priv->tb_pause, sensitive);
 }
 
-static void trg_toolbar_init(TrgToolbar * self)
+static void trg_toolbar_init(TrgToolbar *self)
 {
 }
 
-TrgToolbar *trg_toolbar_new(TrgMainWindow * win, TrgPrefs * prefs)
+TrgToolbar *trg_toolbar_new(TrgMainWindow *win, TrgPrefs *prefs)
 {
-    return g_object_new(TRG_TYPE_TOOLBAR,
-                        "prefs", prefs, "mainwindow", win, NULL);
+    return g_object_new(TRG_TYPE_TOOLBAR, "prefs", prefs, "mainwindow", win, NULL);
 }

--- a/src/trg-toolbar.h
+++ b/src/trg-toolbar.h
@@ -20,25 +20,22 @@
 #ifndef TRG_TOOLBAR_H_
 #define TRG_TOOLBAR_H_
 
-#include <gtk/gtk.h>
 #include <glib-object.h>
+#include <gtk/gtk.h>
 
-#include "trg-prefs.h"
 #include "trg-main-window.h"
+#include "trg-prefs.h"
 
 G_BEGIN_DECLS
 #define TRG_TYPE_TOOLBAR trg_toolbar_get_type()
-#define TRG_TOOLBAR(obj) \
-  (G_TYPE_CHECK_INSTANCE_CAST ((obj), TRG_TYPE_TOOLBAR, TrgToolbar))
-#define TRG_TOOLBAR_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_CAST ((klass), TRG_TYPE_TOOLBAR, TrgToolbarClass))
-#define TRG_IS_TOOLBAR(obj) \
-  (G_TYPE_CHECK_INSTANCE_TYPE ((obj), TRG_TYPE_TOOLBAR))
-#define TRG_IS_TOOLBAR_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_TYPE ((klass), TRG_TYPE_TOOLBAR))
-#define TRG_TOOLBAR_GET_CLASS(obj) \
-  (G_TYPE_INSTANCE_GET_CLASS ((obj), TRG_TYPE_TOOLBAR, TrgToolbarClass))
-    typedef struct {
+#define TRG_TOOLBAR(obj) (G_TYPE_CHECK_INSTANCE_CAST((obj), TRG_TYPE_TOOLBAR, TrgToolbar))
+#define TRG_TOOLBAR_CLASS(klass)                                                                   \
+    (G_TYPE_CHECK_CLASS_CAST((klass), TRG_TYPE_TOOLBAR, TrgToolbarClass))
+#define TRG_IS_TOOLBAR(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), TRG_TYPE_TOOLBAR))
+#define TRG_IS_TOOLBAR_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass), TRG_TYPE_TOOLBAR))
+#define TRG_TOOLBAR_GET_CLASS(obj)                                                                 \
+    (G_TYPE_INSTANCE_GET_CLASS((obj), TRG_TYPE_TOOLBAR, TrgToolbarClass))
+typedef struct {
     GtkToolbar parent;
 } TrgToolbar;
 
@@ -48,11 +45,10 @@ typedef struct {
 
 GType trg_toolbar_get_type(void);
 
-TrgToolbar *trg_toolbar_new(TrgMainWindow * win, TrgPrefs * prefs);
+TrgToolbar *trg_toolbar_new(TrgMainWindow *win, TrgPrefs *prefs);
 
 G_END_DECLS
-    void trg_toolbar_torrent_actions_sensitive(TrgToolbar * mb,
-                                               gboolean sensitive);
-void trg_toolbar_connected_change(TrgToolbar * tb, gboolean connected);
+void trg_toolbar_torrent_actions_sensitive(TrgToolbar *mb, gboolean sensitive);
+void trg_toolbar_connected_change(TrgToolbar *tb, gboolean connected);
 
-#endif                          /* TRG_TOOLBAR_H_ */
+#endif /* TRG_TOOLBAR_H_ */

--- a/src/trg-torrent-add-dialog.c
+++ b/src/trg-torrent-add-dialog.c
@@ -25,41 +25,50 @@
 #include "config.h"
 
 #include <glib/gi18n.h>
+#include <glib/gprintf.h>
 #include <gtk/gtk.h>
 #include <json-glib/json-glib.h>
-#include <glib/gprintf.h>
 
 #include "hig.h"
-#include "util.h"
-#include "trg-client.h"
-#include "trg-main-window.h"
-#include "trg-file-parser.h"
-#include "trg-torrent-add-dialog.h"
-#include "trg-files-tree-view-common.h"
-#include "trg-files-model-common.h"
-#include "trg-cell-renderer-size.h"
-#include "trg-cell-renderer-priority.h"
-#include "trg-cell-renderer-file-icon.h"
-#include "trg-cell-renderer-wanted.h"
-#include "trg-destination-combo.h"
-#include "trg-prefs.h"
-#include "requests.h"
-#include "torrent.h"
 #include "json.h"
 #include "protocol-constants.h"
+#include "requests.h"
+#include "torrent.h"
+#include "trg-cell-renderer-file-icon.h"
+#include "trg-cell-renderer-priority.h"
+#include "trg-cell-renderer-size.h"
+#include "trg-cell-renderer-wanted.h"
+#include "trg-client.h"
+#include "trg-destination-combo.h"
+#include "trg-file-parser.h"
+#include "trg-files-model-common.h"
+#include "trg-files-tree-view-common.h"
+#include "trg-main-window.h"
+#include "trg-prefs.h"
+#include "trg-torrent-add-dialog.h"
 #include "upload.h"
+#include "util.h"
 
 enum {
-    PROP_0, PROP_FILENAME, PROP_PARENT, PROP_CLIENT, PROP_UPLOAD
+    PROP_0,
+    PROP_FILENAME,
+    PROP_PARENT,
+    PROP_CLIENT,
+    PROP_UPLOAD
 };
 
 enum {
-    FC_INDEX, FC_LABEL, FC_SIZE, FC_PRIORITY, FC_ENABLED, N_FILE_COLS
+    FC_INDEX,
+    FC_LABEL,
+    FC_SIZE,
+    FC_PRIORITY,
+    FC_ENABLED,
+    N_FILE_COLS
 };
 
 G_DEFINE_TYPE(TrgTorrentAddDialog, trg_torrent_add_dialog, GTK_TYPE_DIALOG)
-#define TRG_TORRENT_ADD_DIALOG_GET_PRIVATE(o) \
-  (G_TYPE_INSTANCE_GET_PRIVATE ((o), TRG_TYPE_TORRENT_ADD_DIALOG, TrgTorrentAddDialogPrivate))
+#define TRG_TORRENT_ADD_DIALOG_GET_PRIVATE(o)                                                      \
+    (G_TYPE_INSTANCE_GET_PRIVATE((o), TRG_TYPE_TORRENT_ADD_DIALOG, TrgTorrentAddDialogPrivate))
 typedef struct _TrgTorrentAddDialogPrivate TrgTorrentAddDialogPrivate;
 
 struct _TrgTorrentAddDialogPrivate {
@@ -77,16 +86,12 @@ struct _TrgTorrentAddDialogPrivate {
     guint n_files;
 };
 
-#define MAGNET_MAX_LINK_WIDTH		75
+#define MAGNET_MAX_LINK_WIDTH 75
 
-static void trg_torrent_add_dialog_set_property(GObject * object,
-                                                guint prop_id,
-                                                const GValue * value,
-                                                GParamSpec *
-                                                pspec G_GNUC_UNUSED)
+static void trg_torrent_add_dialog_set_property(GObject *object, guint prop_id, const GValue *value,
+                                                GParamSpec *pspec G_GNUC_UNUSED)
 {
-    TrgTorrentAddDialogPrivate *priv =
-        TRG_TORRENT_ADD_DIALOG_GET_PRIVATE(object);
+    TrgTorrentAddDialogPrivate *priv = TRG_TORRENT_ADD_DIALOG_GET_PRIVATE(object);
 
     switch (prop_id) {
     case PROP_FILENAME:
@@ -96,22 +101,18 @@ static void trg_torrent_add_dialog_set_property(GObject * object,
         priv->parent = g_value_get_object(value);
         break;
     case PROP_UPLOAD:
-    	priv->upload = g_value_get_pointer(value);
-    	break;
+        priv->upload = g_value_get_pointer(value);
+        break;
     case PROP_CLIENT:
         priv->client = g_value_get_pointer(value);
         break;
     }
 }
 
-static void
-trg_torrent_add_dialog_get_property(GObject * object,
-                                    guint prop_id,
-                                    GValue * value,
-                                    GParamSpec * pspec G_GNUC_UNUSED)
+static void trg_torrent_add_dialog_get_property(GObject *object, guint prop_id, GValue *value,
+                                                GParamSpec *pspec G_GNUC_UNUSED)
 {
-    TrgTorrentAddDialogPrivate *priv =
-        TRG_TORRENT_ADD_DIALOG_GET_PRIVATE(object);
+    TrgTorrentAddDialogPrivate *priv = TRG_TORRENT_ADD_DIALOG_GET_PRIVATE(object);
 
     switch (prop_id) {
     case PROP_FILENAME:
@@ -123,17 +124,14 @@ trg_torrent_add_dialog_get_property(GObject * object,
     }
 }
 
-static gboolean
-add_file_indexes_foreachfunc(GtkTreeModel * model,
-                             GtkTreePath *
-                             path G_GNUC_UNUSED,
-                             GtkTreeIter * iter, gpointer data)
+static gboolean add_file_indexes_foreachfunc(GtkTreeModel *model, GtkTreePath *path G_GNUC_UNUSED,
+                                             GtkTreeIter *iter, gpointer data)
 {
-    trg_upload *upload = (trg_upload *) data;
+    trg_upload *upload = (trg_upload *)data;
     gint priority, index, wanted;
 
-    gtk_tree_model_get(model, iter, FC_PRIORITY, &priority, FC_ENABLED,
-                       &wanted, FC_INDEX, &index, -1);
+    gtk_tree_model_get(model, iter, FC_PRIORITY, &priority, FC_ENABLED, &wanted, FC_INDEX, &index,
+                       -1);
 
     if (gtk_tree_model_iter_has_child(model, iter) || index < 0)
         return FALSE;
@@ -144,34 +142,26 @@ add_file_indexes_foreachfunc(GtkTreeModel * model,
     return FALSE;
 }
 
-static void
-trg_torrent_add_response_cb(GtkDialog * dlg, gint res_id, gpointer data)
+static void trg_torrent_add_response_cb(GtkDialog *dlg, gint res_id, gpointer data)
 {
-    TrgTorrentAddDialogPrivate *priv =
-        TRG_TORRENT_ADD_DIALOG_GET_PRIVATE(dlg);
+    TrgTorrentAddDialogPrivate *priv = TRG_TORRENT_ADD_DIALOG_GET_PRIVATE(dlg);
 
     guint flags = 0x00;
-    if (gtk_toggle_button_get_active
-        (GTK_TOGGLE_BUTTON(priv->paused_check)))
+    if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(priv->paused_check)))
         flags |= TORRENT_ADD_FLAG_PAUSED;
-    if (gtk_toggle_button_get_active
-        (GTK_TOGGLE_BUTTON(priv->delete_check)))
+    if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(priv->delete_check)))
         flags |= TORRENT_ADD_FLAG_DELETE;
 
     if (res_id == GTK_RESPONSE_ACCEPT) {
-        gint priority =
-            gtk_combo_box_get_active(GTK_COMBO_BOX(priv->priority_combo)) -
-            1;
-        gchar *dir =
-            trg_destination_combo_get_dir(TRG_DESTINATION_COMBO
-                                          (priv->dest_combo));
+        gint priority = gtk_combo_box_get_active(GTK_COMBO_BOX(priv->priority_combo)) - 1;
+        gchar *dir = trg_destination_combo_get_dir(TRG_DESTINATION_COMBO(priv->dest_combo));
         trg_upload *upload;
 
         if (priv->upload) {
-        	upload = priv->upload;
+            upload = priv->upload;
         } else {
-        	upload = g_new0(trg_upload, 1);
-			upload->list = priv->filenames;
+            upload = g_new0(trg_upload, 1);
+            upload->list = priv->filenames;
         }
 
         upload->main_window = priv->parent;
@@ -185,13 +175,11 @@ trg_torrent_add_response_cb(GtkDialog * dlg, gint res_id, gpointer data)
         upload->file_priorities = g_new0(gint, priv->n_files);
         upload->file_wanted = g_new0(gint, priv->n_files);
 
-        gtk_tree_model_foreach(GTK_TREE_MODEL(priv->store),
-                                               add_file_indexes_foreachfunc, upload);
+        gtk_tree_model_foreach(GTK_TREE_MODEL(priv->store), add_file_indexes_foreachfunc, upload);
 
         trg_do_upload(upload);
 
-        trg_destination_combo_save_selection(TRG_DESTINATION_COMBO
-                                             (priv->dest_combo));
+        trg_destination_combo_save_selection(TRG_DESTINATION_COMBO(priv->dest_combo));
     } else {
         g_str_slist_free(priv->filenames);
     }
@@ -199,49 +187,40 @@ trg_torrent_add_response_cb(GtkDialog * dlg, gint res_id, gpointer data)
     gtk_widget_destroy(GTK_WIDGET(dlg));
 }
 
-static void set_low(GtkWidget * w G_GNUC_UNUSED, gpointer data)
+static void set_low(GtkWidget *w G_GNUC_UNUSED, gpointer data)
 {
-    trg_files_tree_model_set_priority(GTK_TREE_VIEW(data), FC_PRIORITY,
-                                      TR_PRI_LOW);
+    trg_files_tree_model_set_priority(GTK_TREE_VIEW(data), FC_PRIORITY, TR_PRI_LOW);
 }
 
-static void set_normal(GtkWidget * w G_GNUC_UNUSED, gpointer data)
+static void set_normal(GtkWidget *w G_GNUC_UNUSED, gpointer data)
 {
-    trg_files_tree_model_set_priority(GTK_TREE_VIEW(data), FC_PRIORITY,
-                                      TR_PRI_NORMAL);
+    trg_files_tree_model_set_priority(GTK_TREE_VIEW(data), FC_PRIORITY, TR_PRI_NORMAL);
 }
 
-static void set_high(GtkWidget * w G_GNUC_UNUSED, gpointer data)
+static void set_high(GtkWidget *w G_GNUC_UNUSED, gpointer data)
 {
-    trg_files_tree_model_set_priority(GTK_TREE_VIEW(data), FC_PRIORITY,
-                                      TR_PRI_HIGH);
+    trg_files_tree_model_set_priority(GTK_TREE_VIEW(data), FC_PRIORITY, TR_PRI_HIGH);
 }
 
-static void set_unwanted(GtkWidget * w G_GNUC_UNUSED, gpointer data)
+static void set_unwanted(GtkWidget *w G_GNUC_UNUSED, gpointer data)
 {
     trg_files_model_set_wanted(GTK_TREE_VIEW(data), FC_ENABLED, FALSE);
 }
 
-static void set_wanted(GtkWidget * w G_GNUC_UNUSED, gpointer data)
+static void set_wanted(GtkWidget *w G_GNUC_UNUSED, gpointer data)
 {
     trg_files_model_set_wanted(GTK_TREE_VIEW(data), FC_ENABLED, TRUE);
 }
 
-static gboolean
-onViewButtonPressed(GtkWidget * w, GdkEventButton * event, gpointer gdata)
+static gboolean onViewButtonPressed(GtkWidget *w, GdkEventButton *event, gpointer gdata)
 {
-    return trg_files_tree_view_onViewButtonPressed(w, event, FC_PRIORITY,
-                                                   FC_ENABLED,
-                                                   NULL, /* no rename */
-                                                   G_CALLBACK(set_low),
-                                                   G_CALLBACK(set_normal),
-                                                   G_CALLBACK(set_high),
-                                                   G_CALLBACK(set_wanted),
-                                                   G_CALLBACK
-                                                   (set_unwanted), gdata);
+    return trg_files_tree_view_onViewButtonPressed(
+        w, event, FC_PRIORITY, FC_ENABLED, NULL, /* no rename */
+        G_CALLBACK(set_low), G_CALLBACK(set_normal), G_CALLBACK(set_high), G_CALLBACK(set_wanted),
+        G_CALLBACK(set_unwanted), gdata);
 }
 
-static GtkWidget *gtr_file_list_new(GtkTreeStore ** store)
+static GtkWidget *gtr_file_list_new(GtkTreeStore **store)
 {
     int size;
     int width;
@@ -260,13 +239,11 @@ static GtkWidget *gtr_file_list_new(GtkTreeStore ** store)
     view = gtk_tree_view_new();
     tree_view = GTK_TREE_VIEW(view);
     gtk_container_set_border_width(GTK_CONTAINER(view), GUI_PAD_BIG);
-    g_signal_connect(view, "button-press-event",
-                     G_CALLBACK(onViewButtonPressed), view);
+    g_signal_connect(view, "button-press-event", G_CALLBACK(onViewButtonPressed), view);
 
     pango_context = gtk_widget_create_pango_context(view);
-    pango_font_description =
-        pango_font_description_copy(pango_context_get_font_description
-                                    (pango_context));
+    pango_font_description
+        = pango_font_description_copy(pango_context_get_font_description(pango_context));
     size = pango_font_description_get_size(pango_font_description);
     pango_font_description_set_size(pango_font_description, size * 0.8);
     g_object_unref(G_OBJECT(pango_context));
@@ -278,19 +255,17 @@ static GtkWidget *gtr_file_list_new(GtkTreeStore ** store)
     gtk_tree_view_set_search_column(tree_view, FC_LABEL);
 
     /* add file column */
-    col = GTK_TREE_VIEW_COLUMN(g_object_new(GTK_TYPE_TREE_VIEW_COLUMN,
-                                            "expand", TRUE,
-                                            "title", _("Name"), NULL));
+    col = GTK_TREE_VIEW_COLUMN(
+        g_object_new(GTK_TYPE_TREE_VIEW_COLUMN, "expand", TRUE, "title", _("Name"), NULL));
     gtk_tree_view_column_set_resizable(col, TRUE);
     rend = trg_cell_renderer_file_icon_new();
     gtk_tree_view_column_pack_start(col, rend, FALSE);
-    gtk_tree_view_column_set_attributes(col, rend, "file-name", FC_LABEL,
-                                        "file-id", FC_INDEX, NULL);
+    gtk_tree_view_column_set_attributes(col, rend, "file-name", FC_LABEL, "file-id", FC_INDEX,
+                                        NULL);
 
     /* add text renderer */
     rend = gtk_cell_renderer_text_new();
-    g_object_set(rend, "ellipsize", PANGO_ELLIPSIZE_END, "font-desc",
-                 pango_font_description, NULL);
+    g_object_set(rend, "ellipsize", PANGO_ELLIPSIZE_END, "font-desc", pango_font_description, NULL);
     gtk_tree_view_column_pack_start(col, rend, TRUE);
     gtk_tree_view_column_set_attributes(col, rend, "text", FC_LABEL, NULL);
     gtk_tree_view_column_set_sort_column_id(col, FC_LABEL);
@@ -300,27 +275,22 @@ static GtkWidget *gtr_file_list_new(GtkTreeStore ** store)
 
     title = _("Size");
     rend = trg_cell_renderer_size_new();
-    g_object_set(rend, "alignment", PANGO_ALIGN_RIGHT, "font-desc",
-                 pango_font_description, "xpad", GUI_PAD, "xalign", 1.0f,
-                 "yalign", 0.5f, NULL);
+    g_object_set(rend, "alignment", PANGO_ALIGN_RIGHT, "font-desc", pango_font_description, "xpad",
+                 GUI_PAD, "xalign", 1.0f, "yalign", 0.5f, NULL);
     col = gtk_tree_view_column_new_with_attributes(title, rend, NULL);
     gtk_tree_view_column_set_sizing(col, GTK_TREE_VIEW_COLUMN_GROW_ONLY);
     gtk_tree_view_column_set_sort_column_id(col, FC_SIZE);
-    gtk_tree_view_column_set_attributes(col, rend, "size-value", FC_SIZE,
-                                        NULL);
+    gtk_tree_view_column_set_attributes(col, rend, "size-value", FC_SIZE, NULL);
     gtk_tree_view_append_column(tree_view, col);
 
     /* add "enabled" column */
     title = _("Download");
     pango_layout = gtk_widget_create_pango_layout(view, title);
     pango_layout_get_pixel_size(pango_layout, &width, NULL);
-    width += 30;                /* room for the sort indicator */
+    width += 30; /* room for the sort indicator */
     g_object_unref(G_OBJECT(pango_layout));
     rend = trg_cell_renderer_wanted_new();
-    col =
-        gtk_tree_view_column_new_with_attributes(title, rend,
-                                                 "wanted-value",
-                                                 FC_ENABLED, NULL);
+    col = gtk_tree_view_column_new_with_attributes(title, rend, "wanted-value", FC_ENABLED, NULL);
     gtk_tree_view_column_set_fixed_width(col, width);
     gtk_tree_view_column_set_sizing(col, GTK_TREE_VIEW_COLUMN_FIXED);
     gtk_tree_view_column_set_sort_column_id(col, FC_ENABLED);
@@ -330,33 +300,30 @@ static GtkWidget *gtr_file_list_new(GtkTreeStore ** store)
     title = _("Priority");
     pango_layout = gtk_widget_create_pango_layout(view, title);
     pango_layout_get_pixel_size(pango_layout, &width, NULL);
-    width += 30;                /* room for the sort indicator */
+    width += 30; /* room for the sort indicator */
     g_object_unref(G_OBJECT(pango_layout));
     rend = trg_cell_renderer_priority_new();
-    col = gtk_tree_view_column_new_with_attributes(title, rend,
-                                                   "priority-value",
-                                                   FC_PRIORITY, NULL);
+    col = gtk_tree_view_column_new_with_attributes(title, rend, "priority-value", FC_PRIORITY,
+                                                   NULL);
     gtk_tree_view_column_set_fixed_width(col, width);
     gtk_tree_view_column_set_sizing(col, GTK_TREE_VIEW_COLUMN_FIXED);
     gtk_tree_view_column_set_sort_column_id(col, FC_PRIORITY);
     gtk_tree_view_append_column(tree_view, col);
 
-    *store = gtk_tree_store_new(N_FILE_COLS, G_TYPE_INT,        /* index */
-                                G_TYPE_STRING,  /* label */
-                                G_TYPE_INT64,   /* size */
-                                G_TYPE_INT,     /* priority */
-                                G_TYPE_INT);    /* dl enabled */
+    *store = gtk_tree_store_new(N_FILE_COLS, G_TYPE_INT, /* index */
+                                G_TYPE_STRING, /* label */
+                                G_TYPE_INT64, /* size */
+                                G_TYPE_INT, /* priority */
+                                G_TYPE_INT); /* dl enabled */
 
     gtk_tree_view_set_model(tree_view, GTK_TREE_MODEL(*store));
     g_object_unref(G_OBJECT(*store));
 
     /* create the scrolled window and stick the view in it */
     scroll = gtk_scrolled_window_new(NULL, NULL);
-    gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scroll),
-                                   GTK_POLICY_AUTOMATIC,
+    gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scroll), GTK_POLICY_AUTOMATIC,
                                    GTK_POLICY_AUTOMATIC);
-    gtk_scrolled_window_set_shadow_type(GTK_SCROLLED_WINDOW(scroll),
-                                        GTK_SHADOW_IN);
+    gtk_scrolled_window_set_shadow_type(GTK_SCROLLED_WINDOW(scroll), GTK_SHADOW_IN);
     gtk_container_add(GTK_CONTAINER(scroll), view);
     gtk_widget_set_size_request(scroll, -1, 200);
 
@@ -364,12 +331,12 @@ static GtkWidget *gtr_file_list_new(GtkTreeStore ** store)
     return scroll;
 }
 
-static GtkWidget *gtr_dialog_get_content_area(GtkDialog * dialog)
+static GtkWidget *gtr_dialog_get_content_area(GtkDialog *dialog)
 {
     return gtk_dialog_get_content_area(dialog);
 }
 
-static void gtr_dialog_set_content(GtkDialog * dialog, GtkWidget * content)
+static void gtr_dialog_set_content(GtkDialog *dialog, GtkWidget *content)
 {
     GtkWidget *vbox = gtr_dialog_get_content_area(dialog);
     gtk_box_pack_start(GTK_BOX(vbox), content, TRUE, TRUE, 0);
@@ -378,12 +345,11 @@ static void gtr_dialog_set_content(GtkDialog * dialog, GtkWidget * content)
 
 static GtkWidget *gtr_priority_combo_new(void)
 {
-    return gtr_combo_box_new_enum(_("Low"), TR_PRI_LOW, _("Normal"),
-                                  TR_PRI_NORMAL, _("High"), TR_PRI_HIGH,
-                                  NULL);
+    return gtr_combo_box_new_enum(_("Low"), TR_PRI_LOW, _("Normal"), TR_PRI_NORMAL, _("High"),
+                                  TR_PRI_HIGH, NULL);
 }
 
-static void addTorrentFilters(GtkFileChooser * chooser)
+static void addTorrentFilters(GtkFileChooser *chooser)
 {
     GtkFileFilter *filter;
 
@@ -398,60 +364,49 @@ static void addTorrentFilters(GtkFileChooser * chooser)
     gtk_file_chooser_add_filter(chooser, filter);
 }
 
-static void
-store_add_node(GtkTreeStore * store, GtkTreeIter * parent,
-               trg_files_tree_node * node, guint *n_files)
+static void store_add_node(GtkTreeStore *store, GtkTreeIter *parent, trg_files_tree_node *node,
+                           guint *n_files)
 {
     GtkTreeIter child;
     GList *li;
 
     if (node->name) {
         gtk_tree_store_append(store, &child, parent);
-        gtk_tree_store_set(store, &child, FC_LABEL, node->name, FC_ENABLED,
-                           1, FC_INDEX, node->index,
-                           FC_PRIORITY, TR_PRI_NORMAL,
-                           FC_SIZE, node->length, -1);
+        gtk_tree_store_set(store, &child, FC_LABEL, node->name, FC_ENABLED, 1, FC_INDEX,
+                           node->index, FC_PRIORITY, TR_PRI_NORMAL, FC_SIZE, node->length, -1);
 
         if (!node->children)
             *n_files = *n_files + 1;
     }
 
     for (li = node->children; li; li = g_list_next(li))
-        store_add_node(store, node->name ? &child : NULL,
-                       (trg_files_tree_node *) li->data, n_files);
+        store_add_node(store, node->name ? &child : NULL, (trg_files_tree_node *)li->data, n_files);
 }
 
-static void torrent_not_parsed_warning(GtkWindow * parent)
+static void torrent_not_parsed_warning(GtkWindow *parent)
 {
-    GtkWidget *dialog = gtk_message_dialog_new(parent,
-                                               GTK_DIALOG_DESTROY_WITH_PARENT,
-                                               GTK_MESSAGE_WARNING,
-                                               GTK_BUTTONS_OK,
-                                               _
-                                               ("Unable to parse torrent file. File preferences unavailable, but you can still try uploading it."));
+    GtkWidget *dialog = gtk_message_dialog_new(
+        parent, GTK_DIALOG_DESTROY_WITH_PARENT, GTK_MESSAGE_WARNING, GTK_BUTTONS_OK,
+        _("Unable to parse torrent file. File preferences unavailable, but you can still try "
+          "uploading it."));
     gtk_window_set_transient_for(GTK_WINDOW(dialog), parent);
     gtk_dialog_run(GTK_DIALOG(dialog));
     gtk_widget_destroy(dialog);
 }
 
-static void torrent_not_found_error(GtkWindow * parent, gchar * file)
+static void torrent_not_found_error(GtkWindow *parent, gchar *file)
 {
-    GtkWidget *dialog = gtk_message_dialog_new(parent,
-                                               GTK_DIALOG_DESTROY_WITH_PARENT,
-                                               GTK_MESSAGE_ERROR,
-                                               GTK_BUTTONS_OK,
-                                               _
-                                               ("Unable to open torrent file: %s"),
-                                               file);
+    GtkWidget *dialog
+        = gtk_message_dialog_new(parent, GTK_DIALOG_DESTROY_WITH_PARENT, GTK_MESSAGE_ERROR,
+                                 GTK_BUTTONS_OK, _("Unable to open torrent file: %s"), file);
     gtk_window_set_transient_for(GTK_WINDOW(dialog), parent);
     gtk_dialog_run(GTK_DIALOG(dialog));
     gtk_widget_destroy(dialog);
 }
 
-static void
-trg_torrent_add_dialog_set_upload(TrgTorrentAddDialog *d, trg_upload *upload) {
-    TrgTorrentAddDialogPrivate *priv =
-        TRG_TORRENT_ADD_DIALOG_GET_PRIVATE(d);
+static void trg_torrent_add_dialog_set_upload(TrgTorrentAddDialog *d, trg_upload *upload)
+{
+    TrgTorrentAddDialogPrivate *priv = TRG_TORRENT_ADD_DIALOG_GET_PRIVATE(d);
     GtkButton *chooser = GTK_BUTTON(priv->source_chooser);
     trg_torrent_file *tor_data = NULL;
 
@@ -461,39 +416,34 @@ trg_torrent_add_dialog_set_upload(TrgTorrentAddDialog *d, trg_upload *upload) {
     tor_data = trg_parse_torrent_data(upload->upload_response->raw, upload->upload_response->size);
 
     if (!tor_data) {
-      torrent_not_parsed_warning(GTK_WINDOW(priv->parent));
+        torrent_not_parsed_warning(GTK_WINDOW(priv->parent));
     } else {
-      store_add_node(priv->store, NULL, tor_data->top_node, &priv->n_files);
-      trg_torrent_file_free(tor_data);
+        store_add_node(priv->store, NULL, tor_data->top_node, &priv->n_files);
+        trg_torrent_file_free(tor_data);
     }
 
     gtk_widget_set_sensitive(priv->file_list, tor_data != NULL);
 }
 
-static void
-trg_torrent_add_dialog_set_filenames(TrgTorrentAddDialog * d,
-                                     GSList * filenames)
+static void trg_torrent_add_dialog_set_filenames(TrgTorrentAddDialog *d, GSList *filenames)
 {
-    TrgTorrentAddDialogPrivate *priv =
-        TRG_TORRENT_ADD_DIALOG_GET_PRIVATE(d);
+    TrgTorrentAddDialogPrivate *priv = TRG_TORRENT_ADD_DIALOG_GET_PRIVATE(d);
     GtkButton *chooser = GTK_BUTTON(priv->source_chooser);
     gint nfiles = filenames ? g_slist_length(filenames) : 0;
 
     gtk_tree_store_clear(priv->store);
 
     if (priv->upload) {
-    	trg_upload_free(priv->upload);
-    	priv->upload = NULL;
+        trg_upload_free(priv->upload);
+        priv->upload = NULL;
     }
 
     if (nfiles == 1) {
-        gchar *file_name = (gchar *) filenames->data;
+        gchar *file_name = (gchar *)filenames->data;
         if (is_url(file_name) || is_magnet(file_name)) {
             if (strlen(file_name) > MAGNET_MAX_LINK_WIDTH) {
-                gchar *file_name_trunc =
-                    g_strndup(file_name, MAGNET_MAX_LINK_WIDTH);
-                gchar *file_name_trunc_fmt =
-                    g_strdup_printf("%s ...", file_name_trunc);
+                gchar *file_name_trunc = g_strndup(file_name, MAGNET_MAX_LINK_WIDTH);
+                gchar *file_name_trunc_fmt = g_strdup_printf("%s ...", file_name_trunc);
                 gtk_button_set_label(chooser, file_name_trunc_fmt);
                 g_free(file_name_trunc);
                 g_free(file_name_trunc_fmt);
@@ -525,8 +475,7 @@ trg_torrent_add_dialog_set_filenames(TrgTorrentAddDialog * d,
                     trg_torrent_file_free(tor_data);
                 }
             } else {
-                torrent_not_found_error(GTK_WINDOW(priv->parent),
-                                        file_name);
+                torrent_not_found_error(GTK_WINDOW(priv->parent), file_name);
             }
 
             gtk_widget_set_sensitive(priv->file_list, tor_data != NULL);
@@ -543,31 +492,22 @@ trg_torrent_add_dialog_set_filenames(TrgTorrentAddDialog * d,
     priv->filenames = filenames;
 }
 
-static void
-trg_torrent_add_dialog_generic_save_dir(GtkFileChooser * c,
-                                        TrgPrefs * prefs)
+static void trg_torrent_add_dialog_generic_save_dir(GtkFileChooser *c, TrgPrefs *prefs)
 {
     gchar *cwd = gtk_file_chooser_get_current_folder(c);
 
     if (cwd) {
-        trg_prefs_set_string(prefs, TRG_PREFS_KEY_LAST_TORRENT_DIR, cwd,
-                             TRG_PREFS_GLOBAL);
+        trg_prefs_set_string(prefs, TRG_PREFS_KEY_LAST_TORRENT_DIR, cwd, TRG_PREFS_GLOBAL);
         g_free(cwd);
     }
 }
 
-static GtkWidget *trg_torrent_add_dialog_generic(GtkWindow * parent,
-                                                 TrgPrefs * prefs)
+static GtkWidget *trg_torrent_add_dialog_generic(GtkWindow *parent, TrgPrefs *prefs)
 {
-    GtkWidget *w = gtk_file_chooser_dialog_new(_("Add a Torrent"), parent,
-                                               GTK_FILE_CHOOSER_ACTION_OPEN,
-                                               _("_Cancel"),
-                                               GTK_RESPONSE_CANCEL,
-                                               _("_Add"),
-                                               GTK_RESPONSE_ACCEPT, NULL);
-    gchar *dir =
-        trg_prefs_get_string(prefs, TRG_PREFS_KEY_LAST_TORRENT_DIR,
-                             TRG_PREFS_GLOBAL);
+    GtkWidget *w = gtk_file_chooser_dialog_new(
+        _("Add a Torrent"), parent, GTK_FILE_CHOOSER_ACTION_OPEN, _("_Cancel"), GTK_RESPONSE_CANCEL,
+        _("_Add"), GTK_RESPONSE_ACCEPT, NULL);
+    gchar *dir = trg_prefs_get_string(prefs, TRG_PREFS_KEY_LAST_TORRENT_DIR, TRG_PREFS_GLOBAL);
     if (dir) {
         gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(w), dir);
         g_free(dir);
@@ -578,36 +518,28 @@ static GtkWidget *trg_torrent_add_dialog_generic(GtkWindow * parent,
     return w;
 }
 
-static void
-trg_torrent_add_dialog_source_click_cb(GtkWidget * w, gpointer data)
+static void trg_torrent_add_dialog_source_click_cb(GtkWidget *w, gpointer data)
 {
-    TrgTorrentAddDialogPrivate *priv =
-        TRG_TORRENT_ADD_DIALOG_GET_PRIVATE(data);
-    GtkWidget *d = trg_torrent_add_dialog_generic(GTK_WINDOW(data),
-                                                  trg_client_get_prefs
-                                                  (priv->client));
+    TrgTorrentAddDialogPrivate *priv = TRG_TORRENT_ADD_DIALOG_GET_PRIVATE(data);
+    GtkWidget *d
+        = trg_torrent_add_dialog_generic(GTK_WINDOW(data), trg_client_get_prefs(priv->client));
 
     if (gtk_dialog_run(GTK_DIALOG(d)) == GTK_RESPONSE_ACCEPT) {
         if (priv->filenames)
             g_str_slist_free(priv->filenames);
 
-        priv->filenames =
-            gtk_file_chooser_get_filenames(GTK_FILE_CHOOSER(d));
+        priv->filenames = gtk_file_chooser_get_filenames(GTK_FILE_CHOOSER(d));
 
         trg_torrent_add_dialog_generic_save_dir(GTK_FILE_CHOOSER(d),
-                                                trg_client_get_prefs
-                                                (priv->client));
-        trg_torrent_add_dialog_set_filenames(TRG_TORRENT_ADD_DIALOG(data),
-                                             priv->filenames);
+                                                trg_client_get_prefs(priv->client));
+        trg_torrent_add_dialog_set_filenames(TRG_TORRENT_ADD_DIALOG(data), priv->filenames);
     }
 
     gtk_widget_destroy(GTK_WIDGET(d));
 }
 
-static gboolean
-apply_all_changed_foreachfunc(GtkTreeModel * model,
-                              GtkTreePath * path,
-                              GtkTreeIter * iter, gpointer data)
+static gboolean apply_all_changed_foreachfunc(GtkTreeModel *model, GtkTreePath *path,
+                                              GtkTreeIter *iter, gpointer data)
 {
     GtkComboBox *combo = GTK_COMBO_BOX(data);
     GtkTreeModel *combo_model = gtk_combo_box_get_model(combo);
@@ -617,45 +549,35 @@ apply_all_changed_foreachfunc(GtkTreeModel * model,
         gint value;
         GValue gvalue = { 0 };
         g_value_init(&gvalue, G_TYPE_INT);
-        gtk_tree_model_get(combo_model, &selection_iter, 2, &column, 3,
-                           &value, -1);
+        gtk_tree_model_get(combo_model, &selection_iter, 2, &column, 3, &value, -1);
         g_value_set_int(&gvalue, value);
-        gtk_tree_store_set_value(GTK_TREE_STORE(model), iter, column,
-                                 &gvalue);
+        gtk_tree_store_set_value(GTK_TREE_STORE(model), iter, column, &gvalue);
     }
     return FALSE;
 }
 
-static void
-trg_torrent_add_dialog_apply_all_changed_cb(GtkWidget * w, gpointer data)
+static void trg_torrent_add_dialog_apply_all_changed_cb(GtkWidget *w, gpointer data)
 {
-    TrgTorrentAddDialogPrivate *priv =
-        TRG_TORRENT_ADD_DIALOG_GET_PRIVATE(data);
+    TrgTorrentAddDialogPrivate *priv = TRG_TORRENT_ADD_DIALOG_GET_PRIVATE(data);
     GtkWidget *tv = gtk_bin_get_child(GTK_BIN(priv->file_list));
     GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(tv));
     gtk_tree_model_foreach(model, apply_all_changed_foreachfunc, w);
     gtk_combo_box_set_active(GTK_COMBO_BOX(w), -1);
 }
 
-static GtkWidget
-    * trg_torrent_add_dialog_apply_all_combo_new(TrgTorrentAddDialog *
-                                                 dialog)
+static GtkWidget *trg_torrent_add_dialog_apply_all_combo_new(TrgTorrentAddDialog *dialog)
 {
-    GtkListStore *model =
-        gtk_list_store_new(3, G_TYPE_STRING, G_TYPE_UINT, G_TYPE_INT);
+    GtkListStore *model = gtk_list_store_new(3, G_TYPE_STRING, G_TYPE_UINT, G_TYPE_INT);
     GtkWidget *combo = gtk_combo_box_new();
     GtkTreeIter iter;
     GtkCellRenderer *renderer;
 
     gtk_list_store_append(model, &iter);
-    gtk_list_store_set(model, &iter, 0, _("High Priority"), 1, FC_PRIORITY,
-                       2, TR_PRI_HIGH, -1);
+    gtk_list_store_set(model, &iter, 0, _("High Priority"), 1, FC_PRIORITY, 2, TR_PRI_HIGH, -1);
     gtk_list_store_append(model, &iter);
-    gtk_list_store_set(model, &iter, 0, _("Normal Priority"), 1, FC_PRIORITY,
-                       2, TR_PRI_NORMAL, -1);
+    gtk_list_store_set(model, &iter, 0, _("Normal Priority"), 1, FC_PRIORITY, 2, TR_PRI_NORMAL, -1);
     gtk_list_store_append(model, &iter);
-    gtk_list_store_set(model, &iter, 0, _("Low Priority"), 1, FC_PRIORITY,
-                       2, TR_PRI_LOW, -1);
+    gtk_list_store_set(model, &iter, 0, _("Low Priority"), 1, FC_PRIORITY, 2, TR_PRI_LOW, -1);
     gtk_list_store_append(model, &iter);
     gtk_list_store_set(model, &iter, 0, _("Download"), 1, FC_ENABLED, 2, TRUE, -1);
     gtk_list_store_append(model, &iter);
@@ -666,26 +588,18 @@ static GtkWidget
     gtk_cell_layout_add_attribute(GTK_CELL_LAYOUT(combo), renderer, "text", 0);
 
     gtk_combo_box_set_model(GTK_COMBO_BOX(combo), GTK_TREE_MODEL(model));
-    g_signal_connect(combo, "changed",
-                     G_CALLBACK
-                     (trg_torrent_add_dialog_apply_all_changed_cb),
+    g_signal_connect(combo, "changed", G_CALLBACK(trg_torrent_add_dialog_apply_all_changed_cb),
                      dialog);
 
     return combo;
 }
 
-static GObject *trg_torrent_add_dialog_constructor(GType type,
-                                                   guint
-                                                   n_construct_properties,
-                                                   GObjectConstructParam *
-                                                   construct_params)
+static GObject *trg_torrent_add_dialog_constructor(GType type, guint n_construct_properties,
+                                                   GObjectConstructParam *construct_params)
 {
-    GObject *obj = G_OBJECT_CLASS
-        (trg_torrent_add_dialog_parent_class)->constructor(type,
-                                                           n_construct_properties,
-                                                           construct_params);
-    TrgTorrentAddDialogPrivate *priv =
-        TRG_TORRENT_ADD_DIALOG_GET_PRIVATE(obj);
+    GObject *obj = G_OBJECT_CLASS(trg_torrent_add_dialog_parent_class)
+                       ->constructor(type, n_construct_properties, construct_params);
+    TrgTorrentAddDialogPrivate *priv = TRG_TORRENT_ADD_DIALOG_GET_PRIVATE(obj);
     TrgPrefs *prefs = trg_client_get_prefs(priv->client);
 
     GtkWidget *t, *applyall_combo;
@@ -693,60 +607,48 @@ static GObject *trg_torrent_add_dialog_constructor(GType type,
 
     /* window */
     gtk_window_set_title(GTK_WINDOW(obj), _("Add Torrent"));
-    gtk_window_set_transient_for(GTK_WINDOW(obj),
-                                 GTK_WINDOW(priv->parent));
+    gtk_window_set_transient_for(GTK_WINDOW(obj), GTK_WINDOW(priv->parent));
     gtk_window_set_destroy_with_parent(GTK_WINDOW(obj), TRUE);
 
     /* buttons */
-    gtk_dialog_add_button(GTK_DIALOG(obj), _("_Cancel"),
-                          GTK_RESPONSE_CANCEL);
-    gtk_dialog_add_button(GTK_DIALOG(obj), _("_Open"),
-                          GTK_RESPONSE_ACCEPT);
+    gtk_dialog_add_button(GTK_DIALOG(obj), _("_Cancel"), GTK_RESPONSE_CANCEL);
+    gtk_dialog_add_button(GTK_DIALOG(obj), _("_Open"), GTK_RESPONSE_ACCEPT);
     gtk_dialog_set_default_response(GTK_DIALOG(obj), GTK_RESPONSE_ACCEPT);
-    gtk_widget_grab_focus(gtk_dialog_get_widget_for_response (GTK_DIALOG(obj),
-							      GTK_RESPONSE_ACCEPT));
+    gtk_widget_grab_focus(gtk_dialog_get_widget_for_response(GTK_DIALOG(obj), GTK_RESPONSE_ACCEPT));
 
     /* workspace */
     t = hig_workarea_create();
-    //gtk_container_set_border_width(GTK_CONTAINER(t), GUI_PAD_BIG);
+    // gtk_container_set_border_width(GTK_CONTAINER(t), GUI_PAD_BIG);
 
     priv->file_list = gtr_file_list_new(&priv->store);
     gtk_widget_set_sensitive(priv->file_list, FALSE);
 
-    priv->paused_check =
-        gtk_check_button_new_with_mnemonic(_("Start _paused"));
-    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(priv->paused_check),
-                                 trg_prefs_get_bool(prefs,
-                                                    TRG_PREFS_KEY_START_PAUSED,
-                                                    TRG_PREFS_GLOBAL));
+    priv->paused_check = gtk_check_button_new_with_mnemonic(_("Start _paused"));
+    gtk_toggle_button_set_active(
+        GTK_TOGGLE_BUTTON(priv->paused_check),
+        trg_prefs_get_bool(prefs, TRG_PREFS_KEY_START_PAUSED, TRG_PREFS_GLOBAL));
 
-    priv->delete_check = gtk_check_button_new_with_mnemonic(_
-                                                            ("Delete local .torrent file after adding"));
-    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(priv->delete_check),
-                                 trg_prefs_get_bool(prefs,
-                                                    TRG_PREFS_KEY_DELETE_LOCAL_TORRENT,
-                                                    TRG_PREFS_GLOBAL));
+    priv->delete_check
+        = gtk_check_button_new_with_mnemonic(_("Delete local .torrent file after adding"));
+    gtk_toggle_button_set_active(
+        GTK_TOGGLE_BUTTON(priv->delete_check),
+        trg_prefs_get_bool(prefs, TRG_PREFS_KEY_DELETE_LOCAL_TORRENT, TRG_PREFS_GLOBAL));
 
     priv->priority_combo = gtr_priority_combo_new();
     gtk_combo_box_set_active(GTK_COMBO_BOX(priv->priority_combo), 1);
 
     priv->source_chooser = gtk_button_new();
     hig_workarea_add_row(t, &row, _("_Torrent file:"), priv->source_chooser, NULL);
- 
-    if (priv->filenames)
-		trg_torrent_add_dialog_set_filenames(TRG_TORRENT_ADD_DIALOG(obj),
-											 priv->filenames);
-    else if (priv->upload)
-    	trg_torrent_add_dialog_set_upload(TRG_TORRENT_ADD_DIALOG(obj), priv->upload);
 
+    if (priv->filenames)
+        trg_torrent_add_dialog_set_filenames(TRG_TORRENT_ADD_DIALOG(obj), priv->filenames);
+    else if (priv->upload)
+        trg_torrent_add_dialog_set_upload(TRG_TORRENT_ADD_DIALOG(obj), priv->upload);
 
     g_signal_connect(priv->source_chooser, "clicked",
-                     G_CALLBACK(trg_torrent_add_dialog_source_click_cb),
-                     obj);
+                     G_CALLBACK(trg_torrent_add_dialog_source_click_cb), obj);
 
-    priv->dest_combo =
-        trg_destination_combo_new(priv->client,
-                                  TRG_PREFS_KEY_LAST_ADD_DESTINATION);
+    priv->dest_combo = trg_destination_combo_new(priv->client, TRG_PREFS_KEY_LAST_ADD_DESTINATION);
 
     hig_workarea_add_row(t, &row, _("_Destination folder:"), priv->dest_combo, NULL);
 
@@ -754,8 +656,7 @@ static GObject *trg_torrent_add_dialog_constructor(GType type,
 
     hig_workarea_add_wide_tall_control(t, &row, priv->file_list);
 
-    applyall_combo =
-        trg_torrent_add_dialog_apply_all_combo_new(TRG_TORRENT_ADD_DIALOG(obj));
+    applyall_combo = trg_torrent_add_dialog_apply_all_combo_new(TRG_TORRENT_ADD_DIALOG(obj));
 
     hig_workarea_add_row(t, &row, _("Apply to all:"), applyall_combo, NULL);
 
@@ -766,15 +667,13 @@ static GObject *trg_torrent_add_dialog_constructor(GType type,
 
     gtr_dialog_set_content(GTK_DIALOG(obj), t);
 
-    g_signal_connect(G_OBJECT(obj), "response",
-                     G_CALLBACK(trg_torrent_add_response_cb),
+    g_signal_connect(G_OBJECT(obj), "response", G_CALLBACK(trg_torrent_add_response_cb),
                      priv->parent);
 
     return obj;
 }
 
-static void
-trg_torrent_add_dialog_class_init(TrgTorrentAddDialogClass * klass)
+static void trg_torrent_add_dialog_class_init(TrgTorrentAddDialogClass *klass)
 {
     GObjectClass *object_class = G_OBJECT_CLASS(klass);
 
@@ -784,90 +683,50 @@ trg_torrent_add_dialog_class_init(TrgTorrentAddDialogClass * klass)
     object_class->get_property = trg_torrent_add_dialog_get_property;
     object_class->constructor = trg_torrent_add_dialog_constructor;
 
-    g_object_class_install_property(object_class,
-                                    PROP_FILENAME,
-                                    g_param_spec_pointer("filenames",
-                                                         "filenames",
-                                                         "filenames",
-                                                         G_PARAM_READWRITE
-                                                         |
-                                                         G_PARAM_CONSTRUCT_ONLY
-                                                         |
-                                                         G_PARAM_STATIC_NAME
-                                                         |
-                                                         G_PARAM_STATIC_NICK
-                                                         |
-                                                         G_PARAM_STATIC_BLURB));
+    g_object_class_install_property(
+        object_class, PROP_FILENAME,
+        g_param_spec_pointer("filenames", "filenames", "filenames",
+                             G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME
+                                 | G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
 
-    g_object_class_install_property(object_class,
-                                    PROP_UPLOAD,
-                                    g_param_spec_pointer("upload",
-                                                         "upload",
-                                                         "upload",
-                                                         G_PARAM_READWRITE
-                                                         |
-                                                         G_PARAM_CONSTRUCT_ONLY
-                                                         |
-                                                         G_PARAM_STATIC_NAME
-                                                         |
-                                                         G_PARAM_STATIC_NICK
-                                                         |
-                                                         G_PARAM_STATIC_BLURB));
+    g_object_class_install_property(
+        object_class, PROP_UPLOAD,
+        g_param_spec_pointer("upload", "upload", "upload",
+                             G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME
+                                 | G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
 
-    g_object_class_install_property(object_class,
-                                    PROP_CLIENT,
-                                    g_param_spec_pointer("client",
-                                                         "client",
-                                                         "client",
-                                                         G_PARAM_READWRITE
-                                                         |
-                                                         G_PARAM_CONSTRUCT_ONLY
-                                                         |
-                                                         G_PARAM_STATIC_NAME
-                                                         |
-                                                         G_PARAM_STATIC_NICK
-                                                         |
-                                                         G_PARAM_STATIC_BLURB));
+    g_object_class_install_property(
+        object_class, PROP_CLIENT,
+        g_param_spec_pointer("client", "client", "client",
+                             G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME
+                                 | G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
 
-    g_object_class_install_property(object_class,
-                                    PROP_PARENT,
-                                    g_param_spec_object("parent",
-                                                        "parent",
-                                                        "parent",
-                                                        TRG_TYPE_MAIN_WINDOW,
-                                                        G_PARAM_READWRITE |
-                                                        G_PARAM_CONSTRUCT_ONLY
-                                                        |
-                                                        G_PARAM_STATIC_NAME
-                                                        |
-                                                        G_PARAM_STATIC_NICK
-                                                        |
-                                                        G_PARAM_STATIC_BLURB));
+    g_object_class_install_property(
+        object_class, PROP_PARENT,
+        g_param_spec_object("parent", "parent", "parent", TRG_TYPE_MAIN_WINDOW,
+                            G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME
+                                | G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
 }
 
-static void trg_torrent_add_dialog_init(TrgTorrentAddDialog * self)
+static void trg_torrent_add_dialog_init(TrgTorrentAddDialog *self)
 {
 }
 
-TrgTorrentAddDialog *trg_torrent_add_dialog_new_from_filenames(TrgMainWindow * parent,
-                                                TrgClient * client,
-                                                GSList * filenames)
+TrgTorrentAddDialog *trg_torrent_add_dialog_new_from_filenames(TrgMainWindow *parent,
+                                                               TrgClient *client, GSList *filenames)
 {
-    return g_object_new(TRG_TYPE_TORRENT_ADD_DIALOG, "filenames",
-                        filenames, "parent", parent, "client", client,
-                        NULL);
+    return g_object_new(TRG_TYPE_TORRENT_ADD_DIALOG, "filenames", filenames, "parent", parent,
+                        "client", client, NULL);
 }
 
-TrgTorrentAddDialog *trg_torrent_add_dialog_new_from_upload(TrgMainWindow * parent,
-                                                TrgClient * client,
-                                                trg_upload *upload)
+TrgTorrentAddDialog *trg_torrent_add_dialog_new_from_upload(TrgMainWindow *parent,
+                                                            TrgClient *client, trg_upload *upload)
 {
-    return g_object_new(TRG_TYPE_TORRENT_ADD_DIALOG, "upload",
-                        upload, "parent", parent, "client", client,
-                        NULL);
+    return g_object_new(TRG_TYPE_TORRENT_ADD_DIALOG, "upload", upload, "parent", parent, "client",
+                        client, NULL);
 }
 
-void trg_torrent_add_dialog(TrgMainWindow * win, TrgClient * client)
+void trg_torrent_add_dialog(TrgMainWindow *win, TrgClient *client)
 {
     GtkWidget *w;
     GtkWidget *c;
@@ -876,30 +735,25 @@ void trg_torrent_add_dialog(TrgMainWindow * win, TrgClient * client)
     w = trg_torrent_add_dialog_generic(GTK_WINDOW(win), prefs);
 
     c = gtk_check_button_new_with_mnemonic(_("Show _options dialog"));
-    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(c),
-                                 trg_prefs_get_bool(prefs,
-                                                    TRG_PREFS_KEY_ADD_OPTIONS_DIALOG,
-                                                    TRG_PREFS_GLOBAL));
+    gtk_toggle_button_set_active(
+        GTK_TOGGLE_BUTTON(c),
+        trg_prefs_get_bool(prefs, TRG_PREFS_KEY_ADD_OPTIONS_DIALOG, TRG_PREFS_GLOBAL));
     gtk_file_chooser_set_extra_widget(GTK_FILE_CHOOSER(w), c);
 
     if (gtk_dialog_run(GTK_DIALOG(w)) == GTK_RESPONSE_ACCEPT) {
         GtkFileChooser *chooser = GTK_FILE_CHOOSER(w);
-        GtkToggleButton *tb =
-            GTK_TOGGLE_BUTTON(gtk_file_chooser_get_extra_widget(chooser));
+        GtkToggleButton *tb = GTK_TOGGLE_BUTTON(gtk_file_chooser_get_extra_widget(chooser));
         gboolean showOptions = gtk_toggle_button_get_active(tb);
         GSList *l = gtk_file_chooser_get_filenames(chooser);
 
-        trg_torrent_add_dialog_generic_save_dir(GTK_FILE_CHOOSER(w),
-                                                prefs);
+        trg_torrent_add_dialog_generic_save_dir(GTK_FILE_CHOOSER(w), prefs);
 
         if (showOptions) {
-            TrgTorrentAddDialog *dialog = trg_torrent_add_dialog_new_from_filenames(win,
-                                                                     client,
-                                                                     l);
+            TrgTorrentAddDialog *dialog = trg_torrent_add_dialog_new_from_filenames(win, client, l);
             gtk_widget_show_all(GTK_WIDGET(dialog));
             gtk_window_present(GTK_WINDOW(dialog));
         } else {
-        	trg_upload *upload = g_new0(trg_upload, 1);
+            trg_upload *upload = g_new0(trg_upload, 1);
 
             upload->list = l;
             upload->main_window = win;

--- a/src/trg-torrent-add-dialog.h
+++ b/src/trg-torrent-add-dialog.h
@@ -24,22 +24,22 @@
 #include <gtk/gtk.h>
 
 #include "trg-client.h"
-#include "upload.h"
 #include "trg-main-window.h"
+#include "upload.h"
 
 G_BEGIN_DECLS
 #define TRG_TYPE_TORRENT_ADD_DIALOG trg_torrent_add_dialog_get_type()
-#define TRG_TORRENT_ADD_DIALOG(obj) \
-  (G_TYPE_CHECK_INSTANCE_CAST ((obj), TRG_TYPE_TORRENT_ADD_DIALOG, TrgTorrentAddDialog))
-#define TRG_TORRENT_ADD_DIALOG_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_CAST ((klass), TRG_TYPE_TORRENT_ADD_DIALOG, TrgTorrentAddDialogClass))
-#define TRG_IS_TORRENT_ADD_DIALOG(obj) \
-  (G_TYPE_CHECK_INSTANCE_TYPE ((obj), TRG_TYPE_TORRENT_ADD_DIALOG))
-#define TRG_IS_TORRENT_ADD_DIALOG_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_TYPE ((klass), TRG_TYPE_TORRENT_ADD_DIALOG))
-#define TRG_TORRENT_ADD_DIALOG_GET_CLASS(obj) \
-  (G_TYPE_INSTANCE_GET_CLASS ((obj), TRG_TYPE_TORRENT_ADD_DIALOG, TrgTorrentAddDialogClass))
-    typedef struct {
+#define TRG_TORRENT_ADD_DIALOG(obj)                                                                \
+    (G_TYPE_CHECK_INSTANCE_CAST((obj), TRG_TYPE_TORRENT_ADD_DIALOG, TrgTorrentAddDialog))
+#define TRG_TORRENT_ADD_DIALOG_CLASS(klass)                                                        \
+    (G_TYPE_CHECK_CLASS_CAST((klass), TRG_TYPE_TORRENT_ADD_DIALOG, TrgTorrentAddDialogClass))
+#define TRG_IS_TORRENT_ADD_DIALOG(obj)                                                             \
+    (G_TYPE_CHECK_INSTANCE_TYPE((obj), TRG_TYPE_TORRENT_ADD_DIALOG))
+#define TRG_IS_TORRENT_ADD_DIALOG_CLASS(klass)                                                     \
+    (G_TYPE_CHECK_CLASS_TYPE((klass), TRG_TYPE_TORRENT_ADD_DIALOG))
+#define TRG_TORRENT_ADD_DIALOG_GET_CLASS(obj)                                                      \
+    (G_TYPE_INSTANCE_GET_CLASS((obj), TRG_TYPE_TORRENT_ADD_DIALOG, TrgTorrentAddDialogClass))
+typedef struct {
     GtkDialog parent;
 } TrgTorrentAddDialog;
 
@@ -49,13 +49,12 @@ typedef struct {
 
 GType trg_torrent_add_dialog_get_type(void);
 
-TrgTorrentAddDialog *trg_torrent_add_dialog_new_from_filenames(TrgMainWindow * parent,
-                                                TrgClient * client,
-                                                GSList * filenames);
-TrgTorrentAddDialog *trg_torrent_add_dialog_new_from_upload(TrgMainWindow * parent,
-                                                TrgClient * client,
-                                                trg_upload *upload);
-void trg_torrent_add_dialog(TrgMainWindow * win, TrgClient * client);
+TrgTorrentAddDialog *trg_torrent_add_dialog_new_from_filenames(TrgMainWindow *parent,
+                                                               TrgClient *client,
+                                                               GSList *filenames);
+TrgTorrentAddDialog *trg_torrent_add_dialog_new_from_upload(TrgMainWindow *parent,
+                                                            TrgClient *client, trg_upload *upload);
+void trg_torrent_add_dialog(TrgMainWindow *win, TrgClient *client);
 
 G_END_DECLS
-#endif                          /* TRG_TORRENT_ADD_DIALOG_H_ */
+#endif /* TRG_TORRENT_ADD_DIALOG_H_ */

--- a/src/trg-torrent-add-url-dialog.c
+++ b/src/trg-torrent-add-url-dialog.c
@@ -23,18 +23,17 @@
 #include <gtk/gtk.h>
 #include <json-glib/json-glib.h>
 
+#include "hig.h"
+#include "requests.h"
 #include "trg-client.h"
 #include "trg-main-window.h"
 #include "trg-torrent-add-url-dialog.h"
-#include "hig.h"
-#include "requests.h"
 
-G_DEFINE_TYPE(TrgTorrentAddUrlDialog, trg_torrent_add_url_dialog,
-              GTK_TYPE_DIALOG)
-#define TRG_TORRENT_ADD_URL_DIALOG_GET_PRIVATE(o) \
-  (G_TYPE_INSTANCE_GET_PRIVATE ((o), TRG_TYPE_TORRENT_ADD_URL_DIALOG, TrgTorrentAddUrlDialogPrivate))
-typedef struct _TrgTorrentAddUrlDialogPrivate
- TrgTorrentAddUrlDialogPrivate;
+G_DEFINE_TYPE(TrgTorrentAddUrlDialog, trg_torrent_add_url_dialog, GTK_TYPE_DIALOG)
+#define TRG_TORRENT_ADD_URL_DIALOG_GET_PRIVATE(o)                                                  \
+    (G_TYPE_INSTANCE_GET_PRIVATE((o), TRG_TYPE_TORRENT_ADD_URL_DIALOG,                             \
+                                 TrgTorrentAddUrlDialogPrivate))
+typedef struct _TrgTorrentAddUrlDialogPrivate TrgTorrentAddUrlDialogPrivate;
 
 struct _TrgTorrentAddUrlDialogPrivate {
     TrgClient *client;
@@ -42,71 +41,55 @@ struct _TrgTorrentAddUrlDialogPrivate {
     GtkWidget *urlEntry, *startCheck, *addButton;
 };
 
-static void
-trg_torrent_add_url_dialog_class_init(TrgTorrentAddUrlDialogClass * klass)
+static void trg_torrent_add_url_dialog_class_init(TrgTorrentAddUrlDialogClass *klass)
 {
     g_type_class_add_private(klass, sizeof(TrgTorrentAddUrlDialogPrivate));
 }
 
-static gboolean has_dht_support(TrgTorrentAddUrlDialog * dlg)
+static gboolean has_dht_support(TrgTorrentAddUrlDialog *dlg)
 {
-    TrgTorrentAddUrlDialogPrivate *priv =
-        TRG_TORRENT_ADD_URL_DIALOG_GET_PRIVATE(dlg);
+    TrgTorrentAddUrlDialogPrivate *priv = TRG_TORRENT_ADD_URL_DIALOG_GET_PRIVATE(dlg);
     JsonObject *session = trg_client_get_session(priv->client);
     return session_get_dht_enabled(session);
 }
 
-static void show_dht_not_enabled_warning(TrgTorrentAddUrlDialog * dlg)
+static void show_dht_not_enabled_warning(TrgTorrentAddUrlDialog *dlg)
 {
-    gchar *msg =
-        _
-        ("You are trying to add a magnet torrent, but DHT is disabled. Distributed Hash Table (DHT) should be enabled in remote settings.");
-    GtkWidget *dialog = gtk_message_dialog_new(GTK_WINDOW(dlg),
-                                               GTK_DIALOG_MODAL,
-                                               GTK_MESSAGE_WARNING,
-                                               GTK_BUTTONS_OK,
-                                               "%s", msg);
+    gchar *msg = _("You are trying to add a magnet torrent, but DHT is disabled. Distributed Hash "
+                   "Table (DHT) should be enabled in remote settings.");
+    GtkWidget *dialog = gtk_message_dialog_new(GTK_WINDOW(dlg), GTK_DIALOG_MODAL,
+                                               GTK_MESSAGE_WARNING, GTK_BUTTONS_OK, "%s", msg);
     gtk_window_set_title(GTK_WINDOW(dialog), _("Error"));
     gtk_dialog_run(GTK_DIALOG(dialog));
     gtk_widget_destroy(dialog);
 }
 
-static void
-trg_torrent_add_url_response_cb(TrgTorrentAddUrlDialog * dlg, gint res_id,
-                                gpointer data)
+static void trg_torrent_add_url_response_cb(TrgTorrentAddUrlDialog *dlg, gint res_id, gpointer data)
 {
-    TrgTorrentAddUrlDialogPrivate *priv =
-        TRG_TORRENT_ADD_URL_DIALOG_GET_PRIVATE(dlg);
+    TrgTorrentAddUrlDialogPrivate *priv = TRG_TORRENT_ADD_URL_DIALOG_GET_PRIVATE(dlg);
 
     if (res_id == GTK_RESPONSE_ACCEPT) {
         JsonNode *request;
-        const gchar *entryText =
-            gtk_entry_get_text(GTK_ENTRY(priv->urlEntry));
+        const gchar *entryText = gtk_entry_get_text(GTK_ENTRY(priv->urlEntry));
 
-        if (g_str_has_prefix(entryText, "magnet:")
-            && !has_dht_support(dlg))
+        if (g_str_has_prefix(entryText, "magnet:") && !has_dht_support(dlg))
             show_dht_not_enabled_warning(dlg);
 
-        request =
-            torrent_add_url(entryText,
-                            gtk_toggle_button_get_active
-                            (GTK_TOGGLE_BUTTON(priv->startCheck)));
-        dispatch_async(priv->client, request,
-                       on_generic_interactive_action_response, data);
+        request = torrent_add_url(
+            entryText, gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(priv->startCheck)));
+        dispatch_async(priv->client, request, on_generic_interactive_action_response, data);
     }
 
     gtk_widget_destroy(GTK_WIDGET(dlg));
 }
 
-static void url_entry_changed(GtkWidget * w, gpointer data)
+static void url_entry_changed(GtkWidget *w, gpointer data)
 {
-    TrgTorrentAddUrlDialogPrivate *priv =
-        TRG_TORRENT_ADD_URL_DIALOG_GET_PRIVATE(data);
-    gtk_widget_set_sensitive(priv->addButton,
-                             gtk_entry_get_text_length(GTK_ENTRY(w)) > 0);
+    TrgTorrentAddUrlDialogPrivate *priv = TRG_TORRENT_ADD_URL_DIALOG_GET_PRIVATE(data);
+    gtk_widget_set_sensitive(priv->addButton, gtk_entry_get_text_length(GTK_ENTRY(w)) > 0);
 }
 
-static void url_entry_activate(GtkWidget * w, gpointer data)
+static void url_entry_activate(GtkWidget *w, gpointer data)
 {
     gtk_dialog_response(GTK_DIALOG(data), GTK_RESPONSE_ACCEPT);
 }
@@ -121,10 +104,9 @@ static void clipboard_text_received(GtkClipboard *w, const char *text, void *tex
     }
 }
 
-static void trg_torrent_add_url_dialog_init(TrgTorrentAddUrlDialog * self)
+static void trg_torrent_add_url_dialog_init(TrgTorrentAddUrlDialog *self)
 {
-    TrgTorrentAddUrlDialogPrivate *priv =
-        TRG_TORRENT_ADD_URL_DIALOG_GET_PRIVATE(self);
+    TrgTorrentAddUrlDialogPrivate *priv = TRG_TORRENT_ADD_URL_DIALOG_GET_PRIVATE(self);
     GtkWidget *w, *t, *contentvbox;
     guint row = 0;
 
@@ -140,18 +122,13 @@ static void trg_torrent_add_url_dialog_init(TrgTorrentAddUrlDialog * self)
 
     hig_workarea_add_row(t, &row, _("URL:"), w, NULL);
 
-    priv->startCheck =
-        hig_workarea_add_wide_checkbutton(t, &row, _("Start Paused"),
-                                          FALSE);
+    priv->startCheck = hig_workarea_add_wide_checkbutton(t, &row, _("Start Paused"), FALSE);
 
     gtk_window_set_title(GTK_WINDOW(self), _("Add torrent from URL"));
     gtk_window_set_destroy_with_parent(GTK_WINDOW(self), TRUE);
 
-    gtk_dialog_add_button(GTK_DIALOG(self), _("_Close"),
-                          GTK_RESPONSE_CANCEL);
-    priv->addButton =
-        gtk_dialog_add_button(GTK_DIALOG(self), _("_Add"),
-                              GTK_RESPONSE_ACCEPT);
+    gtk_dialog_add_button(GTK_DIALOG(self), _("_Close"), GTK_RESPONSE_CANCEL);
+    priv->addButton = gtk_dialog_add_button(GTK_DIALOG(self), _("_Add"), GTK_RESPONSE_ACCEPT);
     gtk_widget_set_sensitive(priv->addButton, FALSE);
 
     gtk_container_set_border_width(GTK_CONTAINER(self), GUI_PAD);
@@ -163,20 +140,16 @@ static void trg_torrent_add_url_dialog_init(TrgTorrentAddUrlDialog * self)
     gtk_box_pack_start(GTK_BOX(contentvbox), t, TRUE, TRUE, 0);
 }
 
-TrgTorrentAddUrlDialog *trg_torrent_add_url_dialog_new(TrgMainWindow * win,
-                                                       TrgClient * client)
+TrgTorrentAddUrlDialog *trg_torrent_add_url_dialog_new(TrgMainWindow *win, TrgClient *client)
 {
     GObject *obj = g_object_new(TRG_TYPE_TORRENT_ADD_URL_DIALOG, NULL);
-    TrgTorrentAddUrlDialogPrivate *priv =
-        TRG_TORRENT_ADD_URL_DIALOG_GET_PRIVATE(obj);
+    TrgTorrentAddUrlDialogPrivate *priv = TRG_TORRENT_ADD_URL_DIALOG_GET_PRIVATE(obj);
 
     priv->client = client;
     priv->win = win;
 
     gtk_window_set_transient_for(GTK_WINDOW(obj), GTK_WINDOW(win));
-    g_signal_connect(G_OBJECT(obj),
-                     "response",
-                     G_CALLBACK(trg_torrent_add_url_response_cb), win);
+    g_signal_connect(G_OBJECT(obj), "response", G_CALLBACK(trg_torrent_add_url_response_cb), win);
 
     return TRG_TORRENT_ADD_URL_DIALOG(obj);
 }

--- a/src/trg-torrent-add-url-dialog.h
+++ b/src/trg-torrent-add-url-dialog.h
@@ -28,17 +28,17 @@
 
 G_BEGIN_DECLS
 #define TRG_TYPE_TORRENT_ADD_URL_DIALOG trg_torrent_add_url_dialog_get_type()
-#define TRG_TORRENT_ADD_URL_DIALOG(obj) \
-  (G_TYPE_CHECK_INSTANCE_CAST ((obj), TRG_TYPE_TORRENT_ADD_URL_DIALOG, TrgTorrentAddUrlDialog))
-#define TRG_TORRENT_ADD_URL_DIALOG_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_CAST ((klass), TRG_TYPE_TORRENT_ADD_URL_DIALOG, TrgTorrentAddUrlDialogClass))
-#define TRG_IS_TORRENT_ADD_URL_DIALOG(obj) \
-  (G_TYPE_CHECK_INSTANCE_TYPE ((obj), TRG_TYPE_TORRENT_ADD_URL_DIALOG))
-#define TRG_IS_TORRENT_ADD_URL_DIALOG_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_TYPE ((klass), TRG_TYPE_TORRENT_ADD_URL_DIALOG))
-#define TRG_TORRENT_ADD_URL_DIALOG_GET_CLASS(obj) \
-  (G_TYPE_INSTANCE_GET_CLASS ((obj), TRG_TYPE_TORRENT_ADD_URL_DIALOG, TrgTorrentAddUrlDialogClass))
-    typedef struct {
+#define TRG_TORRENT_ADD_URL_DIALOG(obj)                                                            \
+    (G_TYPE_CHECK_INSTANCE_CAST((obj), TRG_TYPE_TORRENT_ADD_URL_DIALOG, TrgTorrentAddUrlDialog))
+#define TRG_TORRENT_ADD_URL_DIALOG_CLASS(klass)                                                    \
+    (G_TYPE_CHECK_CLASS_CAST((klass), TRG_TYPE_TORRENT_ADD_URL_DIALOG, TrgTorrentAddUrlDialogClass))
+#define TRG_IS_TORRENT_ADD_URL_DIALOG(obj)                                                         \
+    (G_TYPE_CHECK_INSTANCE_TYPE((obj), TRG_TYPE_TORRENT_ADD_URL_DIALOG))
+#define TRG_IS_TORRENT_ADD_URL_DIALOG_CLASS(klass)                                                 \
+    (G_TYPE_CHECK_CLASS_TYPE((klass), TRG_TYPE_TORRENT_ADD_URL_DIALOG))
+#define TRG_TORRENT_ADD_URL_DIALOG_GET_CLASS(obj)                                                  \
+    (G_TYPE_INSTANCE_GET_CLASS((obj), TRG_TYPE_TORRENT_ADD_URL_DIALOG, TrgTorrentAddUrlDialogClass))
+typedef struct {
     GtkDialog parent;
 } TrgTorrentAddUrlDialog;
 
@@ -48,8 +48,7 @@ typedef struct {
 
 GType trg_torrent_add_url_dialog_get_type(void);
 
-TrgTorrentAddUrlDialog *trg_torrent_add_url_dialog_new(TrgMainWindow * win,
-                                                       TrgClient * client);
+TrgTorrentAddUrlDialog *trg_torrent_add_url_dialog_new(TrgMainWindow *win, TrgClient *client);
 
 G_END_DECLS
-#endif                          /* TRG_TORRENT_ADD_URL_DIALOG_H_ */
+#endif /* TRG_TORRENT_ADD_URL_DIALOG_H_ */

--- a/src/trg-torrent-graph.c
+++ b/src/trg-torrent-graph.c
@@ -27,35 +27,34 @@
  * on this widget but with some improvements I didn't do.
  */
 
-
 #include "config.h"
 
 #include "trg-torrent-graph.h"
 
 #if TRG_WITH_GRAPH
 
-#include <math.h>
-#include <glib.h>
+#include "util.h"
 #include <cairo.h>
+#include <glib.h>
 #include <glib/gi18n.h>
 #include <gtk/gtk.h>
-#include "util.h"
+#include <math.h>
 
 /* damn you freebsd */
-#define log2(x) (log(x)/0.69314718055994530942)
+#define log2(x) (log(x) / 0.69314718055994530942)
 
-#define GRAPH_NUM_POINTS 62
-#define GRAPH_MIN_HEIGHT 40
-#define GRAPH_NUM_LINES 2
-#define GRAPH_NUM_DATA_BLOCK_ELEMENTS GRAPH_NUM_POINTS * GRAPH_NUM_LINES
-#define GRAPH_OUT_COLOR "#2D7DB3"
-#define GRAPH_IN_COLOR "#844798"
-#define GRAPH_LINE_WIDTH 3
-#define GRAPH_FRAME_WIDTH 4
+#define GRAPH_NUM_POINTS              62
+#define GRAPH_MIN_HEIGHT              40
+#define GRAPH_NUM_LINES               2
+#define GRAPH_NUM_DATA_BLOCK_ELEMENTS GRAPH_NUM_POINTS *GRAPH_NUM_LINES
+#define GRAPH_OUT_COLOR               "#2D7DB3"
+#define GRAPH_IN_COLOR                "#844798"
+#define GRAPH_LINE_WIDTH              3
+#define GRAPH_FRAME_WIDTH             4
 
 G_DEFINE_TYPE(TrgTorrentGraph, trg_torrent_graph, GTK_TYPE_VBOX)
-#define TRG_TORRENT_GRAPH_GET_PRIVATE(o) \
-  (G_TYPE_INSTANCE_GET_PRIVATE ((o), TRG_TYPE_TORRENT_GRAPH, TrgTorrentGraphPrivate))
+#define TRG_TORRENT_GRAPH_GET_PRIVATE(o)                                                           \
+    (G_TYPE_INSTANCE_GET_PRIVATE((o), TRG_TYPE_TORRENT_GRAPH, TrgTorrentGraphPrivate))
 typedef struct _TrgTorrentGraphPrivate TrgTorrentGraphPrivate;
 
 struct _TrgTorrentGraphPrivate {
@@ -93,9 +92,8 @@ struct _TrgTorrentGraphPrivate {
 
 static int trg_torrent_graph_update(gpointer user_data);
 
-static void
-trg_torrent_graph_get_property(GObject * object, guint property_id,
-                               GValue * value, GParamSpec * pspec)
+static void trg_torrent_graph_get_property(GObject *object, guint property_id, GValue *value,
+                                           GParamSpec *pspec)
 {
     switch (property_id) {
     default:
@@ -104,9 +102,8 @@ trg_torrent_graph_get_property(GObject * object, guint property_id,
     }
 }
 
-static void
-trg_torrent_graph_set_property(GObject * object, guint property_id,
-                               const GValue * value, GParamSpec * pspec)
+static void trg_torrent_graph_set_property(GObject *object, guint property_id, const GValue *value,
+                                           GParamSpec *pspec)
 {
     switch (property_id) {
     default:
@@ -115,7 +112,7 @@ trg_torrent_graph_set_property(GObject * object, guint property_id,
     }
 }
 
-void trg_torrent_graph_draw_background(TrgTorrentGraph * g)
+void trg_torrent_graph_draw_background(TrgTorrentGraph *g)
 {
     TrgTorrentGraphPrivate *priv;
     GtkAllocation allocation;
@@ -132,18 +129,15 @@ void trg_torrent_graph_draw_background(TrgTorrentGraph * g)
     priv = TRG_TORRENT_GRAPH_GET_PRIVATE(g);
 
     num_bars = trg_torrent_graph_get_num_bars(g);
-    priv->graph_dely = (priv->draw_height - 15) / num_bars;     /* round to int to avoid AA blur */
+    priv->graph_dely = (priv->draw_height - 15) / num_bars; /* round to int to avoid AA blur */
     priv->real_draw_height = priv->graph_dely * num_bars;
-    priv->graph_delx =
-        (priv->draw_width - 2.0 - priv->rmargin -
-         priv->indent) / (GRAPH_NUM_POINTS - 3);
-    priv->graph_buffer_offset =
-        (int) (1.5 * priv->graph_delx) + GRAPH_FRAME_WIDTH;
+    priv->graph_delx
+        = (priv->draw_width - 2.0 - priv->rmargin - priv->indent) / (GRAPH_NUM_POINTS - 3);
+    priv->graph_buffer_offset = (int)(1.5 * priv->graph_delx) + GRAPH_FRAME_WIDTH;
 
     gtk_widget_get_allocation(priv->disp, &allocation);
-    priv->background =
-        gdk_pixmap_new(GDK_DRAWABLE(gtk_widget_get_window(priv->disp)),
-                       allocation.width, allocation.height, -1);
+    priv->background = gdk_pixmap_new(GDK_DRAWABLE(gtk_widget_get_window(priv->disp)),
+                                      allocation.width, allocation.height, -1);
     cr = gdk_cairo_create(priv->background);
 
     gdk_cairo_set_source_color(cr, &priv->style->bg[GTK_STATE_NORMAL]);
@@ -151,8 +145,7 @@ void trg_torrent_graph_draw_background(TrgTorrentGraph * g)
     cairo_translate(cr, GRAPH_FRAME_WIDTH, GRAPH_FRAME_WIDTH);
     cairo_set_source_rgb(cr, 1.0, 1.0, 1.0);
     cairo_rectangle(cr, priv->rmargin + priv->indent, 0,
-                    priv->draw_width - priv->rmargin - priv->indent,
-                    priv->real_draw_height);
+                    priv->draw_width - priv->rmargin - priv->indent, priv->real_draw_height);
 
     cairo_fill(cr);
 
@@ -173,7 +166,7 @@ void trg_torrent_graph_draw_background(TrgTorrentGraph * g)
 
         gdk_cairo_set_source_color(cr, &priv->style->fg[GTK_STATE_NORMAL]);
         rate = priv->max - (i * priv->max / num_bars);
-        trg_strlspeed(caption, (gint64) (rate / 1024));
+        trg_strlspeed(caption, (gint64)(rate / 1024));
         cairo_text_extents(cr, caption, &extents);
         cairo_move_to(cr, priv->indent - extents.width + 20, y);
         cairo_show_text(cr, caption);
@@ -188,11 +181,9 @@ void trg_torrent_graph_draw_background(TrgTorrentGraph * g)
     for (i = 0; i < 7; i++) {
         unsigned seconds;
         const char *format;
-        double x =
-            (i) * (priv->draw_width - priv->rmargin - priv->indent) / 6;
+        double x = (i) * (priv->draw_width - priv->rmargin - priv->indent) / 6;
         cairo_set_source_rgba(cr, 0, 0, 0, 0.75);
-        cairo_move_to(cr, (ceil(x) + 0.5) + priv->rmargin + priv->indent,
-                      0.5);
+        cairo_move_to(cr, (ceil(x) + 0.5) + priv->rmargin + priv->indent, 0.5);
         cairo_line_to(cr, (ceil(x) + 0.5) + priv->rmargin + priv->indent,
                       priv->real_draw_height + 4.5);
         cairo_stroke(cr);
@@ -203,9 +194,8 @@ void trg_torrent_graph_draw_background(TrgTorrentGraph * g)
             format = "%u";
         caption = g_strdup_printf(format, seconds);
         cairo_text_extents(cr, caption, &extents);
-        cairo_move_to(cr,
-                      ((ceil(x) + 0.5) + priv->rmargin + priv->indent) -
-                      (extents.width / 2), priv->draw_height);
+        cairo_move_to(cr, ((ceil(x) + 0.5) + priv->rmargin + priv->indent) - (extents.width / 2),
+                      priv->draw_height);
         gdk_cairo_set_source_color(cr, &priv->style->fg[GTK_STATE_NORMAL]);
         cairo_show_text(cr, caption);
         g_free(caption);
@@ -215,26 +205,23 @@ void trg_torrent_graph_draw_background(TrgTorrentGraph * g)
     cairo_destroy(cr);
 }
 
-void trg_torrent_graph_set_nothing(TrgTorrentGraph * g)
+void trg_torrent_graph_set_nothing(TrgTorrentGraph *g)
 {
     TrgTorrentGraphPrivate *priv = TRG_TORRENT_GRAPH_GET_PRIVATE(g);
 
     priv->in = priv->out = 0;
 }
 
-void
-trg_torrent_graph_set_speed(TrgTorrentGraph * g,
-                            trg_torrent_model_update_stats * stats)
+void trg_torrent_graph_set_speed(TrgTorrentGraph *g, trg_torrent_model_update_stats *stats)
 {
     TrgTorrentGraphPrivate *priv = TRG_TORRENT_GRAPH_GET_PRIVATE(g);
 
-    priv->in = (guint64) stats->downRateTotal;
-    priv->out = (guint64) stats->upRateTotal;
+    priv->in = (guint64)stats->downRateTotal;
+    priv->out = (guint64)stats->upRateTotal;
 }
 
-static gboolean
-trg_torrent_graph_configure(GtkWidget * widget,
-                            GdkEventConfigure * event, gpointer data_ptr)
+static gboolean trg_torrent_graph_configure(GtkWidget *widget, GdkEventConfigure *event,
+                                            gpointer data_ptr)
 {
     GtkAllocation allocation;
     TrgTorrentGraph *g = TRG_TORRENT_GRAPH(data_ptr);
@@ -254,9 +241,8 @@ trg_torrent_graph_configure(GtkWidget * widget,
     return TRUE;
 }
 
-static gboolean
-trg_torrent_graph_expose(GtkWidget * widget,
-                         GdkEventExpose * event, gpointer data_ptr)
+static gboolean trg_torrent_graph_expose(GtkWidget *widget, GdkEventExpose *event,
+                                         gpointer data_ptr)
 {
     TrgTorrentGraph *g = TRG_TORRENT_GRAPH(data_ptr);
     TrgTorrentGraphPrivate *priv = TRG_TORRENT_GRAPH_GET_PRIVATE(data_ptr);
@@ -274,51 +260,42 @@ trg_torrent_graph_expose(GtkWidget * widget,
 
     window = gtk_widget_get_window(priv->disp);
     gtk_widget_get_allocation(priv->disp, &allocation);
-    gdk_draw_drawable(window,
-                      priv->gc,
-                      priv->background,
-                      0, 0, 0, 0, allocation.width, allocation.height);
+    gdk_draw_drawable(window, priv->gc, priv->background, 0, 0, 0, 0, allocation.width,
+                      allocation.height);
 
-    sample_width =
-        (float) (priv->draw_width - priv->rmargin -
-                 priv->indent) / (float) GRAPH_NUM_POINTS;
+    sample_width
+        = (float)(priv->draw_width - priv->rmargin - priv->indent) / (float)GRAPH_NUM_POINTS;
     x_offset = priv->draw_width - priv->rmargin + (sample_width * 2);
-    x_offset +=
-        priv->rmargin -
-        ((sample_width / priv->frames_per_unit) * priv->render_counter);
+    x_offset += priv->rmargin - ((sample_width / priv->frames_per_unit) * priv->render_counter);
 
     cr = gdk_cairo_create(window);
 
     cairo_set_line_width(cr, GRAPH_LINE_WIDTH);
     cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
     cairo_set_line_join(cr, CAIRO_LINE_JOIN_ROUND);
-    cairo_rectangle(cr,
-                    priv->rmargin + priv->indent + GRAPH_FRAME_WIDTH + 1,
-                    GRAPH_FRAME_WIDTH - 1,
+    cairo_rectangle(cr, priv->rmargin + priv->indent + GRAPH_FRAME_WIDTH + 1, GRAPH_FRAME_WIDTH - 1,
                     priv->draw_width - priv->rmargin - priv->indent - 1,
                     priv->real_draw_height + GRAPH_FRAME_WIDTH - 1);
     cairo_clip(cr);
 
     for (j = 0; j < GRAPH_NUM_LINES; ++j) {
         GList *li = priv->points;
-        fp = (float *) li->data;
-        cairo_move_to(cr, x_offset,
-                      (1.0f - fp[j]) * priv->real_draw_height);
+        fp = (float *)li->data;
+        cairo_move_to(cr, x_offset, (1.0f - fp[j]) * priv->real_draw_height);
         gdk_cairo_set_source_color(cr, &(priv->colors[j]));
 
         i = 0;
         for (li = g_list_next(li); li != NULL; li = g_list_next(li)) {
             GList *lli = g_list_previous(li);
-            float *lfp = (float *) lli->data;
-            fp = (float *) li->data;
+            float *lfp = (float *)lli->data;
+            fp = (float *)li->data;
 
             i++;
 
             if (fp[j] == -1.0f)
                 continue;
 
-            cairo_curve_to(cr,
-                           x_offset - ((i - 0.5f) * priv->graph_delx),
+            cairo_curve_to(cr, x_offset - ((i - 0.5f) * priv->graph_delx),
                            (1.0f - lfp[j]) * priv->real_draw_height + 3.5f,
                            x_offset - ((i - 0.5f) * priv->graph_delx),
                            (1.0f - fp[j]) * priv->real_draw_height + 3.5f,
@@ -333,14 +310,14 @@ trg_torrent_graph_expose(GtkWidget * widget,
     return TRUE;
 }
 
-void trg_torrent_graph_stop(TrgTorrentGraph * g)
+void trg_torrent_graph_stop(TrgTorrentGraph *g)
 {
     TrgTorrentGraphPrivate *priv = TRG_TORRENT_GRAPH_GET_PRIVATE(g);
 
     priv->draw = FALSE;
 }
 
-static void trg_torrent_graph_dispose(GObject * object)
+static void trg_torrent_graph_dispose(GObject *object)
 {
     TrgTorrentGraph *g = TRG_TORRENT_GRAPH(object);
     TrgTorrentGraphPrivate *priv = TRG_TORRENT_GRAPH_GET_PRIVATE(g);
@@ -354,22 +331,21 @@ static void trg_torrent_graph_dispose(GObject * object)
     G_OBJECT_CLASS(trg_torrent_graph_parent_class)->dispose(object);
 }
 
-void trg_torrent_graph_start(TrgTorrentGraph * g)
+void trg_torrent_graph_start(TrgTorrentGraph *g)
 {
     TrgTorrentGraphPrivate *priv = TRG_TORRENT_GRAPH_GET_PRIVATE(g);
 
     if (!priv->timer_index) {
         trg_torrent_graph_update(g);
 
-        priv->timer_index =
-            g_timeout_add(priv->speed / priv->frames_per_unit,
-                          trg_torrent_graph_update, g);
+        priv->timer_index
+            = g_timeout_add(priv->speed / priv->frames_per_unit, trg_torrent_graph_update, g);
     }
 
     priv->draw = TRUE;
 }
 
-static unsigned get_max_value_element(TrgTorrentGraph * g)
+static unsigned get_max_value_element(TrgTorrentGraph *g)
 {
     TrgTorrentGraphPrivate *priv = TRG_TORRENT_GRAPH_GET_PRIVATE(g);
     unsigned r = 0;
@@ -382,19 +358,18 @@ static unsigned get_max_value_element(TrgTorrentGraph * g)
     return r;
 }
 
-static void trg_torrent_graph_update_net(TrgTorrentGraph * g)
+static void trg_torrent_graph_update_net(TrgTorrentGraph *g)
 {
     TrgTorrentGraphPrivate *priv = TRG_TORRENT_GRAPH_GET_PRIVATE(g);
 
-    unsigned max, new_max, bak_max, pow2, base10, coef10, factor10,
-        num_bars;
+    unsigned max, new_max, bak_max, pow2, base10, coef10, factor10, num_bars;
 
     float scale;
     char speed[32];
     gchar *labelMarkup;
     GList *li;
 
-    float *fp = (float *) (priv->points->data);
+    float *fp = (float *)(priv->points->data);
 
     GList *last = g_list_last(priv->points);
     float *lastData = last->data;
@@ -405,19 +380,17 @@ static void trg_torrent_graph_update_net(TrgTorrentGraph * g)
     fp[0] = 1.0f * priv->out / priv->max;
     fp[1] = 1.0f * priv->in / priv->max;
 
-    trg_strlspeed(speed, (gint64) (priv->out / disk_K));
-    labelMarkup =
-        g_markup_printf_escaped("<span font_size=\"small\" color=\""
-                                GRAPH_OUT_COLOR "\">%s: %s</span>",
-                                _("Total Uploading"), speed);
+    trg_strlspeed(speed, (gint64)(priv->out / disk_K));
+    labelMarkup = g_markup_printf_escaped("<span font_size=\"small\" color=\"" GRAPH_OUT_COLOR
+                                          "\">%s: %s</span>",
+                                          _("Total Uploading"), speed);
     gtk_label_set_markup(GTK_LABEL(priv->label_out), labelMarkup);
     g_free(labelMarkup);
 
-    trg_strlspeed(speed, (gint64) (priv->in / 1024));
-    labelMarkup =
-        g_markup_printf_escaped("<span font_size=\"small\" color=\""
-                                GRAPH_IN_COLOR "\">%s: %s</span>",
-                                _("Total Downloading"), speed);
+    trg_strlspeed(speed, (gint64)(priv->in / 1024));
+    labelMarkup = g_markup_printf_escaped("<span font_size=\"small\" color=\"" GRAPH_IN_COLOR
+                                          "\">%s: %s</span>",
+                                          _("Total Downloading"), speed);
     gtk_label_set_markup(GTK_LABEL(priv->label_in), labelMarkup);
     g_free(labelMarkup);
 
@@ -435,9 +408,9 @@ static void trg_torrent_graph_update_net(TrgTorrentGraph * g)
     new_max = MAX(new_max, 1024U);
     pow2 = floor(log2(new_max));
     base10 = pow2 / 10;
-    coef10 = ceil(new_max / (double) (1UL << (base10 * 10)));
+    coef10 = ceil(new_max / (double)(1UL << (base10 * 10)));
     factor10 = pow(10.0, floor(log10(coef10)));
-    coef10 = ceil(coef10 / (double) (factor10)) * factor10;
+    coef10 = ceil(coef10 / (double)(factor10)) * factor10;
 
     num_bars = trg_torrent_graph_get_num_bars(g);
 
@@ -456,7 +429,7 @@ static void trg_torrent_graph_update_net(TrgTorrentGraph * g)
     scale = 1.0f * priv->max / new_max;
 
     for (li = priv->points; li != NULL; li = g_list_next(li)) {
-        float *fp = (float *) li->data;
+        float *fp = (float *)li->data;
         if (fp[0] >= 0.0f) {
             fp[0] *= scale;
             fp[1] *= scale;
@@ -468,22 +441,16 @@ static void trg_torrent_graph_update_net(TrgTorrentGraph * g)
     trg_torrent_graph_clear_background(g);
 }
 
-static GObject *trg_torrent_graph_constructor(GType type,
-                                              guint
-                                              n_construct_properties,
-                                              GObjectConstructParam *
-                                              construct_params)
+static GObject *trg_torrent_graph_constructor(GType type, guint n_construct_properties,
+                                              GObjectConstructParam *construct_params)
 {
     GObject *object;
     TrgTorrentGraphPrivate *priv;
     GtkWidget *hbox;
     int i;
 
-    object =
-        G_OBJECT_CLASS
-        (trg_torrent_graph_parent_class)->constructor(type,
-                                                      n_construct_properties,
-                                                      construct_params);
+    object = G_OBJECT_CLASS(trg_torrent_graph_parent_class)
+                 ->constructor(type, n_construct_properties, construct_params);
     priv = TRG_TORRENT_GRAPH_GET_PRIVATE(object);
 
     priv->draw_width = 0;
@@ -530,8 +497,8 @@ static GObject *trg_torrent_graph_constructor(GType type,
     gtk_box_set_homogeneous(GTK_BOX(object), FALSE);
 
     priv->disp = gtk_drawing_area_new();
-    g_signal_connect(G_OBJECT(priv->disp), "expose_event",
-                     G_CALLBACK(trg_torrent_graph_expose), object);
+    g_signal_connect(G_OBJECT(priv->disp), "expose_event", G_CALLBACK(trg_torrent_graph_expose),
+                     object);
     g_signal_connect(G_OBJECT(priv->disp), "configure_event",
                      G_CALLBACK(trg_torrent_graph_configure), object);
 
@@ -543,14 +510,13 @@ static GObject *trg_torrent_graph_constructor(GType type,
     for (i = 0; i < GRAPH_NUM_DATA_BLOCK_ELEMENTS; i++) {
         priv->data_block[i] = -1.0f;
         if (i % GRAPH_NUM_LINES == 0)
-            priv->points =
-                g_list_append(priv->points, &priv->data_block[i]);
+            priv->points = g_list_append(priv->points, &priv->data_block[i]);
     }
 
     return object;
 }
 
-static void trg_torrent_graph_class_init(TrgTorrentGraphClass * klass)
+static void trg_torrent_graph_class_init(TrgTorrentGraphClass *klass)
 {
     GObjectClass *object_class = G_OBJECT_CLASS(klass);
 
@@ -562,11 +528,11 @@ static void trg_torrent_graph_class_init(TrgTorrentGraphClass * klass)
     object_class->constructor = trg_torrent_graph_constructor;
 }
 
-static void trg_torrent_graph_init(TrgTorrentGraph * self)
+static void trg_torrent_graph_init(TrgTorrentGraph *self)
 {
 }
 
-TrgTorrentGraph *trg_torrent_graph_new(GtkStyle * style)
+TrgTorrentGraph *trg_torrent_graph_new(GtkStyle *style)
 {
     GObject *obj = g_object_new(TRG_TYPE_TORRENT_GRAPH, NULL);
     TrgTorrentGraphPrivate *priv = TRG_TORRENT_GRAPH_GET_PRIVATE(obj);
@@ -576,14 +542,14 @@ TrgTorrentGraph *trg_torrent_graph_new(GtkStyle * style)
     return TRG_TORRENT_GRAPH(obj);
 }
 
-void trg_torrent_graph_draw(TrgTorrentGraph * g)
+void trg_torrent_graph_draw(TrgTorrentGraph *g)
 {
     TrgTorrentGraphPrivate *priv = TRG_TORRENT_GRAPH_GET_PRIVATE(g);
 
     gtk_widget_queue_draw(priv->disp);
 }
 
-void trg_torrent_graph_clear_background(TrgTorrentGraph * g)
+void trg_torrent_graph_clear_background(TrgTorrentGraph *g)
 {
     TrgTorrentGraphPrivate *priv = TRG_TORRENT_GRAPH_GET_PRIVATE(g);
 
@@ -593,12 +559,10 @@ void trg_torrent_graph_clear_background(TrgTorrentGraph * g)
     }
 }
 
-
 static gboolean trg_torrent_graph_update(gpointer user_data)
 {
     TrgTorrentGraph *g = TRG_TORRENT_GRAPH(user_data);
-    TrgTorrentGraphPrivate *priv =
-        TRG_TORRENT_GRAPH_GET_PRIVATE(user_data);
+    TrgTorrentGraphPrivate *priv = TRG_TORRENT_GRAPH_GET_PRIVATE(user_data);
 
     if (priv->render_counter == priv->frames_per_unit - 1)
         trg_torrent_graph_update_net(g);
@@ -614,12 +578,12 @@ static gboolean trg_torrent_graph_update(gpointer user_data)
     return TRUE;
 }
 
-unsigned trg_torrent_graph_get_num_bars(TrgTorrentGraph * g)
+unsigned trg_torrent_graph_get_num_bars(TrgTorrentGraph *g)
 {
     TrgTorrentGraphPrivate *priv = TRG_TORRENT_GRAPH_GET_PRIVATE(g);
     unsigned n;
 
-    switch ((int) (priv->draw_height / (priv->fontsize + 14))) {
+    switch ((int)(priv->draw_height / (priv->fontsize + 14))) {
     case 0:
     case 1:
         n = 1;

--- a/src/trg-torrent-graph.h
+++ b/src/trg-torrent-graph.h
@@ -5,26 +5,24 @@
 
 #include <gtk/gtk.h>
 
-#define TRG_WITH_GRAPH !GTK_CHECK_VERSION( 3, 0, 0 )
+#define TRG_WITH_GRAPH !GTK_CHECK_VERSION(3, 0, 0)
 
 #if TRG_WITH_GRAPH
 
-#include <glib-object.h>
 #include "trg-torrent-model.h"
+#include <glib-object.h>
 
 G_BEGIN_DECLS
 #define TRG_TYPE_TORRENT_GRAPH trg_torrent_graph_get_type()
-#define TRG_TORRENT_GRAPH(obj) \
-  (G_TYPE_CHECK_INSTANCE_CAST ((obj), TRG_TYPE_TORRENT_GRAPH, TrgTorrentGraph))
-#define TRG_TORRENT_GRAPH_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_CAST ((klass), TRG_TYPE_TORRENT_GRAPH, TrgTorrentGraphClass))
-#define TRG_IS_TORRENT_GRAPH(obj) \
-  (G_TYPE_CHECK_INSTANCE_TYPE ((obj), TRG_TYPE_TORRENT_GRAPH))
-#define TRG_IS_TORRENT_GRAPH_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_TYPE ((klass), TRG_TYPE_TORRENT_GRAPH))
-#define TRG_TORRENT_GRAPH_GET_CLASS(obj) \
-  (G_TYPE_INSTANCE_GET_CLASS ((obj), TRG_TYPE_TORRENT_GRAPH, TrgTorrentGraphClass))
-    typedef struct {
+#define TRG_TORRENT_GRAPH(obj)                                                                     \
+    (G_TYPE_CHECK_INSTANCE_CAST((obj), TRG_TYPE_TORRENT_GRAPH, TrgTorrentGraph))
+#define TRG_TORRENT_GRAPH_CLASS(klass)                                                             \
+    (G_TYPE_CHECK_CLASS_CAST((klass), TRG_TYPE_TORRENT_GRAPH, TrgTorrentGraphClass))
+#define TRG_IS_TORRENT_GRAPH(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), TRG_TYPE_TORRENT_GRAPH))
+#define TRG_IS_TORRENT_GRAPH_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass), TRG_TYPE_TORRENT_GRAPH))
+#define TRG_TORRENT_GRAPH_GET_CLASS(obj)                                                           \
+    (G_TYPE_INSTANCE_GET_CLASS((obj), TRG_TYPE_TORRENT_GRAPH, TrgTorrentGraphClass))
+typedef struct {
     GtkVBox parent;
 } TrgTorrentGraph;
 
@@ -34,24 +32,23 @@ typedef struct {
 
 GType trg_torrent_graph_get_type(void);
 
-TrgTorrentGraph *trg_torrent_graph_new(GtkStyle * style);
+TrgTorrentGraph *trg_torrent_graph_new(GtkStyle *style);
 
-unsigned trg_torrent_graph_get_num_bars(TrgTorrentGraph * g);
+unsigned trg_torrent_graph_get_num_bars(TrgTorrentGraph *g);
 
 void trg_torrent_graph_clear_background();
 
-void trg_torrent_graph_draw(TrgTorrentGraph * g);
+void trg_torrent_graph_draw(TrgTorrentGraph *g);
 
-void trg_torrent_graph_start(TrgTorrentGraph * g);
+void trg_torrent_graph_start(TrgTorrentGraph *g);
 
-void trg_torrent_graph_stop(TrgTorrentGraph * g);
+void trg_torrent_graph_stop(TrgTorrentGraph *g);
 
-void trg_torrent_graph_change_speed(TrgTorrentGraph * g, guint new_speed);
+void trg_torrent_graph_change_speed(TrgTorrentGraph *g, guint new_speed);
 
-void trg_torrent_graph_set_speed(TrgTorrentGraph * g,
-                                 trg_torrent_model_update_stats * stats);
-void trg_torrent_graph_set_nothing(TrgTorrentGraph * g);
+void trg_torrent_graph_set_speed(TrgTorrentGraph *g, trg_torrent_model_update_stats *stats);
+void trg_torrent_graph_set_nothing(TrgTorrentGraph *g);
 
 G_END_DECLS
 #endif
-#endif                          /* _TRG_TORRENT_GRAPH */
+#endif /* _TRG_TORRENT_GRAPH */

--- a/src/trg-torrent-model.c
+++ b/src/trg-torrent-model.c
@@ -19,16 +19,16 @@
 
 #include "config.h"
 
-#include <string.h>
+#include <glib/gi18n.h>
 #include <gtk/gtk.h>
 #include <json-glib/json-glib.h>
-#include <glib/gi18n.h>
+#include <string.h>
 
-#include "torrent.h"
 #include "json.h"
-#include "trg-torrent-model.h"
 #include "protocol-constants.h"
+#include "torrent.h"
 #include "trg-model.h"
+#include "trg-torrent-model.h"
 #include "util.h"
 
 /* An extension of TrgModel (which is an extension of GtkListStore) which
@@ -65,8 +65,8 @@ enum {
 static guint signals[TMODEL_SIGNAL_COUNT] = { 0 };
 
 G_DEFINE_TYPE(TrgTorrentModel, trg_torrent_model, GTK_TYPE_LIST_STORE)
-#define TRG_TORRENT_MODEL_GET_PRIVATE(o) \
-  (G_TYPE_INSTANCE_GET_PRIVATE ((o), TRG_TYPE_TORRENT_MODEL, TrgTorrentModelPrivate))
+#define TRG_TORRENT_MODEL_GET_PRIVATE(o)                                                           \
+    (G_TYPE_INSTANCE_GET_PRIVATE((o), TRG_TYPE_TORRENT_MODEL, TrgTorrentModelPrivate))
 typedef struct _TrgTorrentModelPrivate TrgTorrentModelPrivate;
 
 struct _TrgTorrentModelPrivate {
@@ -75,98 +75,61 @@ struct _TrgTorrentModelPrivate {
     trg_torrent_model_update_stats stats;
 };
 
-static void trg_torrent_model_dispose(GObject * object)
+static void trg_torrent_model_dispose(GObject *object)
 {
     TrgTorrentModelPrivate *priv = TRG_TORRENT_MODEL_GET_PRIVATE(object);
     g_hash_table_destroy(priv->ht);
     G_OBJECT_CLASS(trg_torrent_model_parent_class)->dispose(object);
 }
 
-static void
-update_torrent_iter(TrgTorrentModel * model, TrgClient * tc, gint64 rpcv,
-                    gint64 serial, GtkTreeIter * iter, JsonObject * t,
-                    trg_torrent_model_update_stats * stats,
-                    guint * whatsChanged);
+static void update_torrent_iter(TrgTorrentModel *model, TrgClient *tc, gint64 rpcv, gint64 serial,
+                                GtkTreeIter *iter, JsonObject *t,
+                                trg_torrent_model_update_stats *stats, guint *whatsChanged);
 
-static void trg_torrent_model_class_init(TrgTorrentModelClass * klass)
+static void trg_torrent_model_class_init(TrgTorrentModelClass *klass)
 {
     GObjectClass *object_class = G_OBJECT_CLASS(klass);
 
     g_type_class_add_private(klass, sizeof(TrgTorrentModelPrivate));
     object_class->dispose = trg_torrent_model_dispose;
 
-    signals[TMODEL_TORRENT_COMPLETED] = g_signal_new("torrent-completed",
-                                                     G_TYPE_FROM_CLASS
-                                                     (object_class),
-                                                     G_SIGNAL_RUN_LAST |
-                                                     G_SIGNAL_ACTION,
-                                                     G_STRUCT_OFFSET
-                                                     (TrgTorrentModelClass,
-                                                      torrent_completed),
-                                                     NULL, NULL,
-                                                     g_cclosure_marshal_VOID__POINTER,
-                                                     G_TYPE_NONE, 1,
-                                                     G_TYPE_POINTER);
+    signals[TMODEL_TORRENT_COMPLETED] = g_signal_new(
+        "torrent-completed", G_TYPE_FROM_CLASS(object_class), G_SIGNAL_RUN_LAST | G_SIGNAL_ACTION,
+        G_STRUCT_OFFSET(TrgTorrentModelClass, torrent_completed), NULL, NULL,
+        g_cclosure_marshal_VOID__POINTER, G_TYPE_NONE, 1, G_TYPE_POINTER);
 
-    signals[TMODEL_UPDATE] = g_signal_new("update",
-                                          G_TYPE_FROM_CLASS
-                                          (object_class),
-                                          G_SIGNAL_RUN_LAST |
-                                          G_SIGNAL_ACTION,
-                                          G_STRUCT_OFFSET
-                                          (TrgTorrentModelClass,
-                                           update),
-                                          NULL, NULL,
-                                          g_cclosure_marshal_VOID__VOID,
-                                          G_TYPE_NONE, 0);
+    signals[TMODEL_UPDATE] = g_signal_new("update", G_TYPE_FROM_CLASS(object_class),
+                                          G_SIGNAL_RUN_LAST | G_SIGNAL_ACTION,
+                                          G_STRUCT_OFFSET(TrgTorrentModelClass, update), NULL, NULL,
+                                          g_cclosure_marshal_VOID__VOID, G_TYPE_NONE, 0);
 
-    signals[TMODEL_TORRENT_ADDED] = g_signal_new("torrent-added",
-                                                 G_TYPE_FROM_CLASS
-                                                 (object_class),
-                                                 G_SIGNAL_RUN_LAST |
-                                                 G_SIGNAL_ACTION,
-                                                 G_STRUCT_OFFSET
-                                                 (TrgTorrentModelClass,
-                                                  torrent_added), NULL,
-                                                 NULL,
-                                                 g_cclosure_marshal_VOID__POINTER,
-                                                 G_TYPE_NONE, 1,
-                                                 G_TYPE_POINTER);
+    signals[TMODEL_TORRENT_ADDED] = g_signal_new(
+        "torrent-added", G_TYPE_FROM_CLASS(object_class), G_SIGNAL_RUN_LAST | G_SIGNAL_ACTION,
+        G_STRUCT_OFFSET(TrgTorrentModelClass, torrent_added), NULL, NULL,
+        g_cclosure_marshal_VOID__POINTER, G_TYPE_NONE, 1, G_TYPE_POINTER);
 
-    signals[TMODEL_STATE_CHANGED] = g_signal_new("torrents-state-change",
-                                                 G_TYPE_FROM_CLASS
-                                                 (object_class),
-                                                 G_SIGNAL_RUN_LAST |
-                                                 G_SIGNAL_ACTION,
-                                                 G_STRUCT_OFFSET
-                                                 (TrgTorrentModelClass,
-                                                  torrent_removed), NULL,
-                                                 NULL,
-                                                 g_cclosure_marshal_VOID__UINT,
-                                                 G_TYPE_NONE, 1,
-                                                 G_TYPE_UINT);
+    signals[TMODEL_STATE_CHANGED] = g_signal_new(
+        "torrents-state-change", G_TYPE_FROM_CLASS(object_class),
+        G_SIGNAL_RUN_LAST | G_SIGNAL_ACTION, G_STRUCT_OFFSET(TrgTorrentModelClass, torrent_removed),
+        NULL, NULL, g_cclosure_marshal_VOID__UINT, G_TYPE_NONE, 1, G_TYPE_UINT);
 }
 
-trg_torrent_model_update_stats *trg_torrent_model_get_stats(TrgTorrentModel
-                                                            * model)
+trg_torrent_model_update_stats *trg_torrent_model_get_stats(TrgTorrentModel *model)
 {
     TrgTorrentModelPrivate *priv = TRG_TORRENT_MODEL_GET_PRIVATE(model);
     return &(priv->stats);
 }
 
-static void
-trg_torrent_model_count_peers(TrgTorrentModel * model,
-                              GtkTreeIter * iter, JsonObject * t)
+static void trg_torrent_model_count_peers(TrgTorrentModel *model, GtkTreeIter *iter, JsonObject *t)
 {
-    GList *trackersList =
-        json_array_get_elements(torrent_get_tracker_stats(t));
+    GList *trackersList = json_array_get_elements(torrent_get_tracker_stats(t));
     gint64 seeders = 0;
     gint64 leechers = 0;
     gint64 downloads = 0;
     GList *li;
 
     for (li = trackersList; li; li = g_list_next(li)) {
-        JsonObject *tracker = json_node_get_object((JsonNode *) li->data);
+        JsonObject *tracker = json_node_get_object((JsonNode *)li->data);
 
         seeders += tracker_stats_get_seeder_count(tracker);
         leechers += tracker_stats_get_leecher_count(tracker);
@@ -175,14 +138,13 @@ trg_torrent_model_count_peers(TrgTorrentModel * model,
 
     g_list_free(trackersList);
 
-    gtk_list_store_set(GTK_LIST_STORE(model), iter, TORRENT_COLUMN_SEEDS,
-                       seeders, TORRENT_COLUMN_LEECHERS, leechers,
-                       TORRENT_COLUMN_DOWNLOADS, downloads, -1);
+    gtk_list_store_set(GTK_LIST_STORE(model), iter, TORRENT_COLUMN_SEEDS, seeders,
+                       TORRENT_COLUMN_LEECHERS, leechers, TORRENT_COLUMN_DOWNLOADS, downloads, -1);
 }
 
 static void trg_torrent_model_ref_free(gpointer data)
 {
-    GtkTreeRowReference *rr = (GtkTreeRowReference *) data;
+    GtkTreeRowReference *rr = (GtkTreeRowReference *)data;
     GtkTreeModel *model = gtk_tree_row_reference_get_model(rr);
     GtkTreePath *path = gtk_tree_row_reference_get_path(rr);
     if (path) {
@@ -191,11 +153,9 @@ static void trg_torrent_model_ref_free(gpointer data)
         if (gtk_tree_model_get_iter(model, &iter, path)) {
             gtk_tree_model_get(model, &iter, TORRENT_COLUMN_JSON, &json, -1);
             g_clear_pointer(&json, json_object_unref);
-            g_object_set_data(G_OBJECT(model), PROP_REMOVE_IN_PROGRESS,
-                              GINT_TO_POINTER(TRUE));
+            g_object_set_data(G_OBJECT(model), PROP_REMOVE_IN_PROGRESS, GINT_TO_POINTER(TRUE));
             gtk_list_store_remove(GTK_LIST_STORE(model), &iter);
-            g_object_set_data(G_OBJECT(model), PROP_REMOVE_IN_PROGRESS,
-                              GINT_TO_POINTER(FALSE));
+            g_object_set_data(G_OBJECT(model), PROP_REMOVE_IN_PROGRESS, GINT_TO_POINTER(FALSE));
         }
 
         gtk_tree_path_free(path);
@@ -204,7 +164,7 @@ static void trg_torrent_model_ref_free(gpointer data)
     gtk_tree_row_reference_free(rr);
 }
 
-static void trg_torrent_model_init(TrgTorrentModel * self)
+static void trg_torrent_model_init(TrgTorrentModel *self)
 {
     TrgTorrentModelPrivate *priv = TRG_TORRENT_MODEL_GET_PRIVATE(self);
 
@@ -256,44 +216,33 @@ static void trg_torrent_model_init(TrgTorrentModel * self)
     column_types[TORRENT_COLUMN_LASTACTIVE] = G_TYPE_INT64;
     column_types[TORRENT_COLUMN_FILECOUNT] = G_TYPE_UINT;
 
-    gtk_list_store_set_column_types(GTK_LIST_STORE(self),
-                                    TORRENT_COLUMN_COLUMNS, column_types);
+    gtk_list_store_set_column_types(GTK_LIST_STORE(self), TORRENT_COLUMN_COLUMNS, column_types);
 
-    priv->ht = g_hash_table_new_full(g_int64_hash, g_int64_equal,
-                                     (GDestroyNotify) g_free,
+    priv->ht = g_hash_table_new_full(g_int64_hash, g_int64_equal, (GDestroyNotify)g_free,
                                      trg_torrent_model_ref_free);
 
-    g_object_set_data(G_OBJECT(self), PROP_REMOVE_IN_PROGRESS,
-                      GINT_TO_POINTER(FALSE));
+    g_object_set_data(G_OBJECT(self), PROP_REMOVE_IN_PROGRESS, GINT_TO_POINTER(FALSE));
 
     priv->urlHostRegex = trg_uri_host_regex_new();
 }
 
-gboolean trg_torrent_model_is_remove_in_progress(TrgTorrentModel * model)
+gboolean trg_torrent_model_is_remove_in_progress(TrgTorrentModel *model)
 {
-    return (gboolean) GPOINTER_TO_INT(g_object_get_data
-                                      (G_OBJECT(model),
-                                       PROP_REMOVE_IN_PROGRESS));
+    return (gboolean)GPOINTER_TO_INT(g_object_get_data(G_OBJECT(model), PROP_REMOVE_IN_PROGRESS));
 }
 
-static gboolean
-trg_torrent_model_reload_dir_aliases_foreachfunc(GtkTreeModel * model,
-                                                 GtkTreePath *
-                                                 path G_GNUC_UNUSED,
-                                                 GtkTreeIter * iter,
-                                                 gpointer gdata)
+static gboolean trg_torrent_model_reload_dir_aliases_foreachfunc(GtkTreeModel *model,
+                                                                 GtkTreePath *path G_GNUC_UNUSED,
+                                                                 GtkTreeIter *iter, gpointer gdata)
 {
     gchar *downloadDir, *shortDownloadDir;
 
-    gtk_tree_model_get(model, iter, TORRENT_COLUMN_DOWNLOADDIR,
-                       &downloadDir, -1);
+    gtk_tree_model_get(model, iter, TORRENT_COLUMN_DOWNLOADDIR, &downloadDir, -1);
 
-    shortDownloadDir =
-        shorten_download_dir((TrgClient *) gdata, downloadDir);
+    shortDownloadDir = shorten_download_dir((TrgClient *)gdata, downloadDir);
 
-    gtk_list_store_set(GTK_LIST_STORE(model), iter,
-                       TORRENT_COLUMN_DOWNLOADDIR_SHORT, shortDownloadDir,
-                       -1);
+    gtk_list_store_set(GTK_LIST_STORE(model), iter, TORRENT_COLUMN_DOWNLOADDIR_SHORT,
+                       shortDownloadDir, -1);
 
     g_free(downloadDir);
     g_free(shortDownloadDir);
@@ -301,27 +250,17 @@ trg_torrent_model_reload_dir_aliases_foreachfunc(GtkTreeModel * model,
     return FALSE;
 }
 
-void
-trg_torrent_model_reload_dir_aliases(TrgClient * tc, GtkTreeModel * model)
+void trg_torrent_model_reload_dir_aliases(TrgClient *tc, GtkTreeModel *model)
 {
-    gtk_tree_model_foreach(model,
-                           trg_torrent_model_reload_dir_aliases_foreachfunc,
-                           tc);
-    g_signal_emit(model, signals[TMODEL_STATE_CHANGED], 0,
-                  TORRENT_UPDATE_PATH_CHANGE);
+    gtk_tree_model_foreach(model, trg_torrent_model_reload_dir_aliases_foreachfunc, tc);
+    g_signal_emit(model, signals[TMODEL_STATE_CHANGED], 0, TORRENT_UPDATE_PATH_CHANGE);
 }
 
-static gboolean
-trg_torrent_model_stats_scan_foreachfunc(GtkTreeModel *
-                                         model,
-                                         GtkTreePath *
-                                         path
-                                         G_GNUC_UNUSED,
-                                         GtkTreeIter * iter,
-                                         gpointer gdata)
+static gboolean trg_torrent_model_stats_scan_foreachfunc(GtkTreeModel *model,
+                                                         GtkTreePath *path G_GNUC_UNUSED,
+                                                         GtkTreeIter *iter, gpointer gdata)
 {
-    trg_torrent_model_update_stats *stats =
-        (trg_torrent_model_update_stats *) gdata;
+    trg_torrent_model_update_stats *stats = (trg_torrent_model_update_stats *)gdata;
     guint flags;
 
     gtk_tree_model_get(model, iter, TORRENT_COLUMN_FLAGS, &flags, -1);
@@ -358,19 +297,18 @@ trg_torrent_model_stats_scan_foreachfunc(GtkTreeModel *
     return FALSE;
 }
 
-void trg_torrent_model_remove_all(TrgTorrentModel * model)
+void trg_torrent_model_remove_all(TrgTorrentModel *model)
 {
     TrgTorrentModelPrivate *priv = TRG_TORRENT_MODEL_GET_PRIVATE(model);
     g_hash_table_remove_all(priv->ht);
     gtk_list_store_clear(GTK_LIST_STORE(model));
 }
 
-gchar *shorten_download_dir(TrgClient * tc, const gchar * downloadDir)
+gchar *shorten_download_dir(TrgClient *tc, const gchar *downloadDir)
 {
     TrgPrefs *prefs = trg_client_get_prefs(tc);
-    JsonArray *labels =
-        trg_prefs_get_array(prefs, TRG_PREFS_KEY_DESTINATIONS,
-                            TRG_PREFS_CONNECTION);
+    JsonArray *labels
+        = trg_prefs_get_array(prefs, TRG_PREFS_KEY_DESTINATIONS, TRG_PREFS_CONNECTION);
     JsonObject *session = trg_client_get_session(tc);
     const gchar *defaultDownloadDir = session_get_download_dir(session);
     gchar *shortDownloadDir = NULL;
@@ -380,15 +318,12 @@ gchar *shorten_download_dir(TrgClient * tc, const gchar * downloadDir)
         if (labelsList) {
             GList *li;
             for (li = labelsList; li; li = g_list_next(li)) {
-                JsonObject *labelObj = json_node_get_object((JsonNode *)
-                                                            li->data);
-                const gchar *labelDir =
-                    json_object_get_string_member(labelObj,
-                                                  TRG_PREFS_KEY_DESTINATIONS_SUBKEY_DIR);
+                JsonObject *labelObj = json_node_get_object((JsonNode *)li->data);
+                const gchar *labelDir = json_object_get_string_member(
+                    labelObj, TRG_PREFS_KEY_DESTINATIONS_SUBKEY_DIR);
                 if (!g_strcmp0(downloadDir, labelDir)) {
-                    const gchar *labelLabel =
-                        json_object_get_string_member(labelObj,
-                                                      TRG_PREFS_SUBKEY_LABEL);
+                    const gchar *labelLabel
+                        = json_object_get_string_member(labelObj, TRG_PREFS_SUBKEY_LABEL);
                     shortDownloadDir = g_strdup(labelLabel);
                     break;
                 }
@@ -416,13 +351,9 @@ gchar *shorten_download_dir(TrgClient * tc, const gchar * downloadDir)
     return g_strdup(downloadDir);
 }
 
-static void
-update_torrent_iter(TrgTorrentModel * model,
-                    TrgClient * tc, gint64 rpcv,
-                    gint64 serial, GtkTreeIter * iter,
-                    JsonObject * t,
-                    trg_torrent_model_update_stats *
-                    stats, guint * whatsChanged)
+static void update_torrent_iter(TrgTorrentModel *model, TrgClient *tc, gint64 rpcv, gint64 serial,
+                                GtkTreeIter *iter, JsonObject *t,
+                                trg_torrent_model_update_stats *stats, guint *whatsChanged)
 {
     TrgTorrentModelPrivate *priv = TRG_TORRENT_MODEL_GET_PRIVATE(model);
     GtkListStore *ls = GTK_LIST_STORE(model);
@@ -430,8 +361,7 @@ update_torrent_iter(TrgTorrentModel * model,
     JsonObject *lastJson, *pf;
     JsonArray *trackerStats;
     gchar *statusString, *statusIcon, *downloadDir;
-    gint64 downRate, upRate, haveValid, uploaded, downloaded, id, status,
-        lpd;
+    gint64 downRate, upRate, haveValid, uploaded, downloaded, id, status, lpd;
     guint fileCount;
     gchar *firstTrackerHost = NULL;
     gchar *peerSources = NULL;
@@ -447,191 +377,135 @@ update_torrent_iter(TrgTorrentModel * model,
     downloaded = torrent_get_downloaded(t);
     haveValid = torrent_get_have_valid(t);
 
-    downloadDir = (gchar *) torrent_get_download_dir(t);
+    downloadDir = (gchar *)torrent_get_download_dir(t);
     rm_trailing_slashes(downloadDir);
 
     id = torrent_get_id(t);
     status = torrent_get_status(t);
     fileCount = json_array_get_length(torrent_get_files(t));
-    newFlags =
-        torrent_get_flags(t, rpcv, status, fileCount, downRate, upRate);
+    newFlags = torrent_get_flags(t, rpcv, status, fileCount, downRate, upRate);
     statusString = torrent_get_status_string(rpcv, status, newFlags);
     statusIcon = torrent_get_status_icon(rpcv, newFlags);
     pf = torrent_get_peersfrom(t);
     trackerStats = torrent_get_tracker_stats(t);
 
-    gtk_tree_model_get(GTK_TREE_MODEL(model), iter, TORRENT_COLUMN_FLAGS,
-                       &lastFlags, TORRENT_COLUMN_JSON, &lastJson,
-                       TORRENT_COLUMN_DOWNLOADDIR, &lastDownloadDir, -1);
+    gtk_tree_model_get(GTK_TREE_MODEL(model), iter, TORRENT_COLUMN_FLAGS, &lastFlags,
+                       TORRENT_COLUMN_JSON, &lastJson, TORRENT_COLUMN_DOWNLOADDIR, &lastDownloadDir,
+                       -1);
 
     json_object_ref(t);
 
     if (json_array_get_length(trackerStats) > 0) {
-        JsonObject *firstTracker =
-            json_array_get_object_element(trackerStats,
-                                          0);
-        firstTrackerHost = trg_gregex_get_first(priv->urlHostRegex,
-                                                tracker_stats_get_host
-                                                (firstTracker));
+        JsonObject *firstTracker = json_array_get_object_element(trackerStats, 0);
+        firstTrackerHost
+            = trg_gregex_get_first(priv->urlHostRegex, tracker_stats_get_host(firstTracker));
     }
 
     lpd = peerfrom_get_lpd(pf);
     if (newFlags & TORRENT_FLAG_ACTIVE) {
         if (lpd >= 0) {
-            peerSources =
-                g_strdup_printf("%" G_GINT64_FORMAT " / %" G_GINT64_FORMAT
-                                " / %" G_GINT64_FORMAT " / %"
-                                G_GINT64_FORMAT " / %" G_GINT64_FORMAT
-                                " / %" G_GINT64_FORMAT " / %"
-                                G_GINT64_FORMAT, peerfrom_get_trackers(pf),
-                                peerfrom_get_incoming(pf),
-                                peerfrom_get_ltep(pf),
-                                peerfrom_get_dht(pf), peerfrom_get_pex(pf),
-                                lpd, peerfrom_get_resume(pf));
+            peerSources = g_strdup_printf(
+                "%" G_GINT64_FORMAT " / %" G_GINT64_FORMAT " / %" G_GINT64_FORMAT
+                " / %" G_GINT64_FORMAT " / %" G_GINT64_FORMAT " / %" G_GINT64_FORMAT
+                " / %" G_GINT64_FORMAT,
+                peerfrom_get_trackers(pf), peerfrom_get_incoming(pf), peerfrom_get_ltep(pf),
+                peerfrom_get_dht(pf), peerfrom_get_pex(pf), lpd, peerfrom_get_resume(pf));
         } else {
-            peerSources =
-                g_strdup_printf("%" G_GINT64_FORMAT " / %" G_GINT64_FORMAT
-                                " / %" G_GINT64_FORMAT " / %"
-                                G_GINT64_FORMAT " / %" G_GINT64_FORMAT
-                                " / N/A / %" G_GINT64_FORMAT,
-                                peerfrom_get_trackers(pf),
-                                peerfrom_get_incoming(pf),
-                                peerfrom_get_ltep(pf),
-                                peerfrom_get_dht(pf), peerfrom_get_pex(pf),
-                                peerfrom_get_resume(pf));
+            peerSources = g_strdup_printf(
+                "%" G_GINT64_FORMAT " / %" G_GINT64_FORMAT " / %" G_GINT64_FORMAT
+                " / %" G_GINT64_FORMAT " / %" G_GINT64_FORMAT " / N/A / %" G_GINT64_FORMAT,
+                peerfrom_get_trackers(pf), peerfrom_get_incoming(pf), peerfrom_get_ltep(pf),
+                peerfrom_get_dht(pf), peerfrom_get_pex(pf), peerfrom_get_resume(pf));
         }
     }
 #ifdef TRG_DEBUG
     gtk_list_store_set(ls, iter, TORRENT_COLUMN_ICON, statusIcon, -1);
-    gtk_list_store_set(ls, iter,
-                       TORRENT_COLUMN_NAME, torrent_get_name(t), -1);
-    gtk_list_store_set(ls, iter,
-                       TORRENT_COLUMN_SIZEWHENDONE,
-                       torrent_get_size_when_done(t), -1);
+    gtk_list_store_set(ls, iter, TORRENT_COLUMN_NAME, torrent_get_name(t), -1);
+    gtk_list_store_set(ls, iter, TORRENT_COLUMN_SIZEWHENDONE, torrent_get_size_when_done(t), -1);
     gtk_list_store_set(ls, iter, TORRENT_COLUMN_PERCENTDONE,
-                       (newFlags & TORRENT_FLAG_CHECKING) ?
-                       torrent_get_recheck_progress(t)
-                       : torrent_get_percent_done(t), -1);
+                       (newFlags & TORRENT_FLAG_CHECKING) ? torrent_get_recheck_progress(t)
+                                                          : torrent_get_percent_done(t),
+                       -1);
     gtk_list_store_set(ls, iter, TORRENT_COLUMN_STATUS, statusString, -1);
     gtk_list_store_set(ls, iter, TORRENT_COLUMN_DOWNSPEED, downRate, -1);
     gtk_list_store_set(ls, iter, TORRENT_COLUMN_FLAGS, newFlags, -1);
     gtk_list_store_set(ls, iter, TORRENT_COLUMN_UPSPEED, upRate, -1);
-    gtk_list_store_set(ls, iter, TORRENT_COLUMN_ETA, torrent_get_eta(t),
-                       -1);
+    gtk_list_store_set(ls, iter, TORRENT_COLUMN_ETA, torrent_get_eta(t), -1);
     gtk_list_store_set(ls, iter, TORRENT_COLUMN_UPLOADED, uploaded, -1);
-    gtk_list_store_set(ls, iter, TORRENT_COLUMN_DOWNLOADED, downloaded,
-                       -1);
-    gtk_list_store_set(ls, iter, TORRENT_COLUMN_RATIO, uploaded > 0
-                       && downloaded >
-                       0 ? (double) uploaded / (double) downloaded : 0,
+    gtk_list_store_set(ls, iter, TORRENT_COLUMN_DOWNLOADED, downloaded, -1);
+    gtk_list_store_set(ls, iter, TORRENT_COLUMN_RATIO,
+                       uploaded > 0 && downloaded > 0 ? (double)uploaded / (double)downloaded : 0,
                        -1);
     gtk_list_store_set(ls, iter, TORRENT_COLUMN_ID, id, -1);
     gtk_list_store_set(ls, iter, TORRENT_COLUMN_JSON, t, -1);
     gtk_list_store_set(ls, iter, TORRENT_COLUMN_UPDATESERIAL, serial, -1);
-    gtk_list_store_set(ls, iter,
-                       TORRENT_COLUMN_ADDED, torrent_get_added_date(t),
-                       -1);
-    gtk_list_store_set(ls, iter, TORRENT_COLUMN_DOWNLOADDIR, downloadDir,
-                       -1);
+    gtk_list_store_set(ls, iter, TORRENT_COLUMN_ADDED, torrent_get_added_date(t), -1);
+    gtk_list_store_set(ls, iter, TORRENT_COLUMN_DOWNLOADDIR, downloadDir, -1);
     gtk_list_store_set(ls, iter, TORRENT_COLUMN_PEERS_CONNECTED, torrent_get_peers_connected(t),
                        -1);
-    gtk_list_store_set(ls, iter, TORRENT_COLUMN_ETA, torrent_get_eta(t),
-                       -1);
+    gtk_list_store_set(ls, iter, TORRENT_COLUMN_ETA, torrent_get_eta(t), -1);
     gtk_list_store_set(ls, iter, TORRENT_COLUMN_BANDWIDTH_PRIORITY,
                        torrent_get_bandwidth_priority(t), -1);
-    gtk_list_store_set(ls, iter, TORRENT_COLUMN_TOTALSIZE,
-                       torrent_get_total_size(t), -1);
-    gtk_list_store_set(ls, iter, TORRENT_COLUMN_HAVE_UNCHECKED,
-                       torrent_get_have_unchecked(t), -1);
+    gtk_list_store_set(ls, iter, TORRENT_COLUMN_TOTALSIZE, torrent_get_total_size(t), -1);
+    gtk_list_store_set(ls, iter, TORRENT_COLUMN_HAVE_UNCHECKED, torrent_get_have_unchecked(t), -1);
     gtk_list_store_set(ls, iter, TORRENT_COLUMN_METADATAPERCENTCOMPLETE,
                        torrent_get_metadata_percent_complete(t), -1);
-    gtk_list_store_set(ls, iter, TORRENT_COLUMN_PEERS_TO_US,
-                       torrent_get_peers_sending_to_us(t), -1);
-    gtk_list_store_set(ls, iter, TORRENT_COLUMN_PEERS_FROM_US,
-                       torrent_get_peers_getting_from_us(t), -1);
+    gtk_list_store_set(ls, iter, TORRENT_COLUMN_PEERS_TO_US, torrent_get_peers_sending_to_us(t),
+                       -1);
+    gtk_list_store_set(ls, iter, TORRENT_COLUMN_PEERS_FROM_US, torrent_get_peers_getting_from_us(t),
+                       -1);
     gtk_list_store_set(ls, iter, TORRENT_COLUMN_WEB_SEEDS_TO_US,
                        torrent_get_web_seeds_sending_to_us(t), -1);
-    gtk_list_store_set(ls, iter, TORRENT_COLUMN_SEED_RATIO_LIMIT,
-                       torrent_get_seed_ratio_limit(t), -1);
-    gtk_list_store_set(ls, iter, TORRENT_COLUMN_SEED_RATIO_MODE,
-                       torrent_get_seed_ratio_mode(t), -1);
+    gtk_list_store_set(ls, iter, TORRENT_COLUMN_SEED_RATIO_LIMIT, torrent_get_seed_ratio_limit(t),
+                       -1);
+    gtk_list_store_set(ls, iter, TORRENT_COLUMN_SEED_RATIO_MODE, torrent_get_seed_ratio_mode(t),
+                       -1);
     gtk_list_store_set(ls, iter, TORRENT_COLUMN_FILECOUNT, fileCount, -1);
     gtk_list_store_set(ls, iter, TORRENT_COLUMN_HAVE_VALID, haveValid, -1);
 #else
-    gtk_list_store_set(ls, iter, TORRENT_COLUMN_ICON, statusIcon,
-                       TORRENT_COLUMN_ADDED, torrent_get_added_date(t),
-                       TORRENT_COLUMN_FILECOUNT,
-                       fileCount,
-                       TORRENT_COLUMN_DONE_DATE, torrent_get_done_date(t),
-                       TORRENT_COLUMN_NAME, torrent_get_name(t),
-                       TORRENT_COLUMN_ERROR, torrent_get_error(t),
-                       TORRENT_COLUMN_SIZEWHENDONE,
-                       torrent_get_size_when_done(t),
-                       TORRENT_COLUMN_PERCENTDONE,
-                       (newFlags & TORRENT_FLAG_CHECKING) ?
-                       torrent_get_recheck_progress(t)
-                       : torrent_get_percent_done(t),
-                       TORRENT_COLUMN_METADATAPERCENTCOMPLETE,
-                       torrent_get_metadata_percent_complete(t),
-                       TORRENT_COLUMN_STATUS, statusString,
-                       TORRENT_COLUMN_DOWNSPEED, downRate,
-                       TORRENT_COLUMN_FLAGS, newFlags,
-                       TORRENT_COLUMN_UPSPEED, upRate, TORRENT_COLUMN_ETA,
-                       torrent_get_eta(t), TORRENT_COLUMN_UPLOADED,
-                       uploaded, TORRENT_COLUMN_DOWNLOADED, downloaded,
-                       TORRENT_COLUMN_TOTALSIZE, torrent_get_total_size(t),
-                       TORRENT_COLUMN_HAVE_UNCHECKED,
-                       torrent_get_have_unchecked(t),
-                       TORRENT_COLUMN_HAVE_VALID, haveValid,
-                       TORRENT_COLUMN_FROMPEX, peerfrom_get_pex(pf),
-                       TORRENT_COLUMN_FROMDHT, peerfrom_get_dht(pf),
-                       TORRENT_COLUMN_FROMTRACKERS,
-                       peerfrom_get_trackers(pf), TORRENT_COLUMN_FROMLTEP,
-                       peerfrom_get_ltep(pf), TORRENT_COLUMN_FROMRESUME,
-                       peerfrom_get_resume(pf),
-                       TORRENT_COLUMN_FROMINCOMING,
-                       peerfrom_get_incoming(pf),
-                       TORRENT_COLUMN_PEER_SOURCES, peerSources,
-                       TORRENT_COLUMN_PEERS_CONNECTED,
-                       torrent_get_peers_connected(t),
-                       TORRENT_COLUMN_PEERS_TO_US,
-                       torrent_get_peers_sending_to_us(t),
-                       TORRENT_COLUMN_PEERS_FROM_US,
-                       torrent_get_peers_getting_from_us(t),
-                       TORRENT_COLUMN_WEB_SEEDS_TO_US,
-                       torrent_get_web_seeds_sending_to_us(t),
-                       TORRENT_COLUMN_QUEUE_POSITION,
-                       torrent_get_queue_position(t),
-                       TORRENT_COLUMN_SEED_RATIO_LIMIT,
-                       torrent_get_seed_ratio_limit(t),
-                       TORRENT_COLUMN_SEED_RATIO_MODE,
-                       torrent_get_seed_ratio_mode(t),
-                       TORRENT_COLUMN_LASTACTIVE,
-                       torrent_get_activity_date(t), TORRENT_COLUMN_RATIO,
-                       uploaded > 0
-                       && haveValid >
-                       0 ? (double) uploaded / (double) haveValid : 0,
-                       TORRENT_COLUMN_DOWNLOADDIR, downloadDir,
-                       TORRENT_COLUMN_BANDWIDTH_PRIORITY,
-                       torrent_get_bandwidth_priority(t),
-                       TORRENT_COLUMN_ID, id, TORRENT_COLUMN_JSON, t,
-                       TORRENT_COLUMN_TRACKERHOST,
-                       firstTrackerHost ? firstTrackerHost : "",
-                       TORRENT_COLUMN_UPDATESERIAL, serial, -1);
+    gtk_list_store_set(
+        ls, iter, TORRENT_COLUMN_ICON, statusIcon, TORRENT_COLUMN_ADDED, torrent_get_added_date(t),
+        TORRENT_COLUMN_FILECOUNT, fileCount, TORRENT_COLUMN_DONE_DATE, torrent_get_done_date(t),
+        TORRENT_COLUMN_NAME, torrent_get_name(t), TORRENT_COLUMN_ERROR, torrent_get_error(t),
+        TORRENT_COLUMN_SIZEWHENDONE, torrent_get_size_when_done(t), TORRENT_COLUMN_PERCENTDONE,
+        (newFlags & TORRENT_FLAG_CHECKING) ? torrent_get_recheck_progress(t)
+                                           : torrent_get_percent_done(t),
+        TORRENT_COLUMN_METADATAPERCENTCOMPLETE, torrent_get_metadata_percent_complete(t),
+        TORRENT_COLUMN_STATUS, statusString, TORRENT_COLUMN_DOWNSPEED, downRate,
+        TORRENT_COLUMN_FLAGS, newFlags, TORRENT_COLUMN_UPSPEED, upRate, TORRENT_COLUMN_ETA,
+        torrent_get_eta(t), TORRENT_COLUMN_UPLOADED, uploaded, TORRENT_COLUMN_DOWNLOADED,
+        downloaded, TORRENT_COLUMN_TOTALSIZE, torrent_get_total_size(t),
+        TORRENT_COLUMN_HAVE_UNCHECKED, torrent_get_have_unchecked(t), TORRENT_COLUMN_HAVE_VALID,
+        haveValid, TORRENT_COLUMN_FROMPEX, peerfrom_get_pex(pf), TORRENT_COLUMN_FROMDHT,
+        peerfrom_get_dht(pf), TORRENT_COLUMN_FROMTRACKERS, peerfrom_get_trackers(pf),
+        TORRENT_COLUMN_FROMLTEP, peerfrom_get_ltep(pf), TORRENT_COLUMN_FROMRESUME,
+        peerfrom_get_resume(pf), TORRENT_COLUMN_FROMINCOMING, peerfrom_get_incoming(pf),
+        TORRENT_COLUMN_PEER_SOURCES, peerSources, TORRENT_COLUMN_PEERS_CONNECTED,
+        torrent_get_peers_connected(t), TORRENT_COLUMN_PEERS_TO_US,
+        torrent_get_peers_sending_to_us(t), TORRENT_COLUMN_PEERS_FROM_US,
+        torrent_get_peers_getting_from_us(t), TORRENT_COLUMN_WEB_SEEDS_TO_US,
+        torrent_get_web_seeds_sending_to_us(t), TORRENT_COLUMN_QUEUE_POSITION,
+        torrent_get_queue_position(t), TORRENT_COLUMN_SEED_RATIO_LIMIT,
+        torrent_get_seed_ratio_limit(t), TORRENT_COLUMN_SEED_RATIO_MODE,
+        torrent_get_seed_ratio_mode(t), TORRENT_COLUMN_LASTACTIVE, torrent_get_activity_date(t),
+        TORRENT_COLUMN_RATIO,
+        uploaded > 0 && haveValid > 0 ? (double)uploaded / (double)haveValid : 0,
+        TORRENT_COLUMN_DOWNLOADDIR, downloadDir, TORRENT_COLUMN_BANDWIDTH_PRIORITY,
+        torrent_get_bandwidth_priority(t), TORRENT_COLUMN_ID, id, TORRENT_COLUMN_JSON, t,
+        TORRENT_COLUMN_TRACKERHOST, firstTrackerHost ? firstTrackerHost : "",
+        TORRENT_COLUMN_UPDATESERIAL, serial, -1);
 #endif
 
     if (!lastDownloadDir || g_strcmp0(downloadDir, lastDownloadDir)) {
         gchar *shortDownloadDir = shorten_download_dir(tc, downloadDir);
-        gtk_list_store_set(ls, iter, TORRENT_COLUMN_DOWNLOADDIR_SHORT,
-                           shortDownloadDir, -1);
+        gtk_list_store_set(ls, iter, TORRENT_COLUMN_DOWNLOADDIR_SHORT, shortDownloadDir, -1);
         g_free(shortDownloadDir);
         *whatsChanged |= TORRENT_UPDATE_PATH_CHANGE;
     }
 
     g_clear_pointer(&lastJson, json_object_unref);
 
-    if ((lastFlags & TORRENT_FLAG_DOWNLOADING)
-        && (!(newFlags & TORRENT_FLAG_DOWNLOADING))
+    if ((lastFlags & TORRENT_FLAG_DOWNLOADING) && (!(newFlags & TORRENT_FLAG_DOWNLOADING))
         && (newFlags & TORRENT_FLAG_COMPLETE))
         g_signal_emit(model, signals[TMODEL_TORRENT_COMPLETED], 0, iter);
 
@@ -659,23 +533,20 @@ struct TrgModelRemoveData {
     gint64 currentSerial;
 };
 
-GHashTable *get_torrent_table(TrgTorrentModel * model)
+GHashTable *get_torrent_table(TrgTorrentModel *model)
 {
     TrgTorrentModelPrivate *priv = TRG_TORRENT_MODEL_GET_PRIVATE(model);
     return priv->ht;
 }
 
-static gboolean
-trg_model_find_removed_foreachfunc(GtkTreeModel * model,
-                                   GtkTreePath *
-                                   path G_GNUC_UNUSED,
-                                   GtkTreeIter * iter, gpointer gdata)
+static gboolean trg_model_find_removed_foreachfunc(GtkTreeModel *model,
+                                                   GtkTreePath *path G_GNUC_UNUSED,
+                                                   GtkTreeIter *iter, gpointer gdata)
 {
-    struct TrgModelRemoveData *args = (struct TrgModelRemoveData *) gdata;
+    struct TrgModelRemoveData *args = (struct TrgModelRemoveData *)gdata;
     gint64 rowSerial;
 
-    gtk_tree_model_get(model, iter, TORRENT_COLUMN_UPDATESERIAL,
-                       &rowSerial, -1);
+    gtk_tree_model_get(model, iter, TORRENT_COLUMN_UPDATESERIAL, &rowSerial, -1);
 
     if (rowSerial != args->currentSerial) {
         gint64 *id = g_new(gint64, 1);
@@ -686,28 +557,24 @@ trg_model_find_removed_foreachfunc(GtkTreeModel * model,
     return FALSE;
 }
 
-static GList *trg_torrent_model_find_removed(GtkTreeModel * model,
-                                      gint64 currentSerial)
+static GList *trg_torrent_model_find_removed(GtkTreeModel *model, gint64 currentSerial)
 {
     struct TrgModelRemoveData args;
     args.toRemove = NULL;
     args.currentSerial = currentSerial;
 
-    gtk_tree_model_foreach(GTK_TREE_MODEL(model),
-                           trg_model_find_removed_foreachfunc, &args);
+    gtk_tree_model_foreach(GTK_TREE_MODEL(model), trg_model_find_removed_foreachfunc, &args);
 
     return args.toRemove;
 }
 
-gboolean
-get_torrent_data(GHashTable * table, gint64 id, JsonObject ** t,
-                 GtkTreeIter * out_iter)
+gboolean get_torrent_data(GHashTable *table, gint64 id, JsonObject **t, GtkTreeIter *out_iter)
 {
     gpointer result = g_hash_table_lookup(table, &id);
     gboolean found = FALSE;
 
     if (result) {
-        GtkTreeRowReference *rr = (GtkTreeRowReference *) result;
+        GtkTreeRowReference *rr = (GtkTreeRowReference *)result;
         GtkTreePath *path = gtk_tree_row_reference_get_path(rr);
         GtkTreeIter iter;
         if (path) {
@@ -716,8 +583,7 @@ get_torrent_data(GHashTable * table, gint64 id, JsonObject ** t,
             if (out_iter)
                 *out_iter = iter;
             if (t)
-                gtk_tree_model_get(model, &iter, TORRENT_COLUMN_JSON, t,
-                                   -1);
+                gtk_tree_model_get(model, &iter, TORRENT_COLUMN_JSON, t, -1);
             found = TRUE;
             gtk_tree_path_free(path);
         }
@@ -726,21 +592,15 @@ get_torrent_data(GHashTable * table, gint64 id, JsonObject ** t,
     return found;
 }
 
-static void
-trg_torrent_model_stat_counts_clear(trg_torrent_model_update_stats * stats)
+static void trg_torrent_model_stat_counts_clear(trg_torrent_model_update_stats *stats)
 {
-    stats->count = stats->down = stats->error = stats->paused =
-        stats->seeding = stats->complete = stats->incomplete =
-        stats->active = stats->checking = stats->seed_wait =
-        stats->down_wait = 0;
+    stats->count = stats->down = stats->error = stats->paused = stats->seeding = stats->complete
+        = stats->incomplete = stats->active = stats->checking = stats->seed_wait = stats->down_wait
+        = 0;
 }
 
-trg_torrent_model_update_stats *trg_torrent_model_update(TrgTorrentModel *
-                                                         model,
-                                                         TrgClient * tc,
-                                                         JsonObject *
-                                                         response,
-                                                         gint mode)
+trg_torrent_model_update_stats *trg_torrent_model_update(TrgTorrentModel *model, TrgClient *tc,
+                                                         JsonObject *response, gint mode)
 {
     TrgTorrentModelPrivate *priv = TRG_TORRENT_MODEL_GET_PRIVATE(model);
 
@@ -765,20 +625,17 @@ trg_torrent_model_update_stats *trg_torrent_model_update(TrgTorrentModel *
     priv->stats.upRateTotal = 0;
 
     for (li = torrentList; li; li = g_list_next(li)) {
-        t = json_node_get_object((JsonNode *) li->data);
+        t = json_node_get_object((JsonNode *)li->data);
         id = torrent_get_id(t);
 
-        result =
-            mode == TORRENT_GET_MODE_FIRST ? NULL :
-            g_hash_table_lookup(priv->ht, &id);
+        result = mode == TORRENT_GET_MODE_FIRST ? NULL : g_hash_table_lookup(priv->ht, &id);
 
         if (!result) {
             gint64 *idCopy;
             gtk_list_store_append(GTK_LIST_STORE(model), &iter);
             whatsChanged |= TORRENT_UPDATE_ADDREMOVE;
 
-            update_torrent_iter(model, tc, rpcv, serial,
-                                &iter, t, &(priv->stats), &whatsChanged);
+            update_torrent_iter(model, tc, rpcv, serial, &iter, t, &(priv->stats), &whatsChanged);
 
             path = gtk_tree_model_get_path(GTK_TREE_MODEL(model), &iter);
             rr = gtk_tree_row_reference_new(GTK_TREE_MODEL(model), path);
@@ -788,17 +645,13 @@ trg_torrent_model_update_stats *trg_torrent_model_update(TrgTorrentModel *
             gtk_tree_path_free(path);
 
             if (mode != TORRENT_GET_MODE_FIRST)
-                g_signal_emit(model, signals[TMODEL_TORRENT_ADDED], 0,
-                              &iter);
+                g_signal_emit(model, signals[TMODEL_TORRENT_ADDED], 0, &iter);
         } else {
-            path = gtk_tree_row_reference_get_path((GtkTreeRowReference *)
-                                                   result);
+            path = gtk_tree_row_reference_get_path((GtkTreeRowReference *)result);
             if (path) {
-                if (gtk_tree_model_get_iter(GTK_TREE_MODEL(model), &iter,
-                                            path)) {
-                    update_torrent_iter(model, tc, rpcv,
-                                        serial, &iter,
-                                        t, &(priv->stats), &whatsChanged);
+                if (gtk_tree_model_get_iter(GTK_TREE_MODEL(model), &iter, path)) {
+                    update_torrent_iter(model, tc, rpcv, serial, &iter, t, &(priv->stats),
+                                        &whatsChanged);
                 }
                 gtk_tree_path_free(path);
             }
@@ -808,8 +661,7 @@ trg_torrent_model_update_stats *trg_torrent_model_update(TrgTorrentModel *
     g_list_free(torrentList);
 
     if (mode == TORRENT_GET_MODE_UPDATE) {
-        GList *hitlist =
-            trg_torrent_model_find_removed(GTK_TREE_MODEL(model), serial);
+        GList *hitlist = trg_torrent_model_find_removed(GTK_TREE_MODEL(model), serial);
         if (hitlist) {
             for (li = hitlist; li; li = g_list_next(li)) {
                 g_hash_table_remove(priv->ht, li->data);
@@ -823,7 +675,7 @@ trg_torrent_model_update_stats *trg_torrent_model_update(TrgTorrentModel *
         if (removedTorrents) {
             GList *hitlist = json_array_get_elements(removedTorrents);
             for (li = hitlist; li; li = g_list_next(li)) {
-                id = json_node_get_int((JsonNode *) li->data);
+                id = json_node_get_int((JsonNode *)li->data);
                 g_hash_table_remove(priv->ht, &id);
                 whatsChanged |= TORRENT_UPDATE_ADDREMOVE;
             }
@@ -835,12 +687,10 @@ trg_torrent_model_update_stats *trg_torrent_model_update(TrgTorrentModel *
         if ((whatsChanged & TORRENT_UPDATE_ADDREMOVE)
             || (whatsChanged & TORRENT_UPDATE_STATE_CHANGE)) {
             trg_torrent_model_stat_counts_clear(&priv->stats);
-            gtk_tree_model_foreach(GTK_TREE_MODEL(model),
-                                   trg_torrent_model_stats_scan_foreachfunc,
+            gtk_tree_model_foreach(GTK_TREE_MODEL(model), trg_torrent_model_stats_scan_foreachfunc,
                                    &(priv->stats));
         }
-        g_signal_emit(model, signals[TMODEL_STATE_CHANGED], 0,
-                      whatsChanged);
+        g_signal_emit(model, signals[TMODEL_STATE_CHANGED], 0, whatsChanged);
     }
 
     g_signal_emit(model, signals[TMODEL_UPDATE], 0);

--- a/src/trg-torrent-model.h
+++ b/src/trg-torrent-model.h
@@ -27,29 +27,25 @@
 
 G_BEGIN_DECLS
 #define TRG_TYPE_TORRENT_MODEL trg_torrent_model_get_type()
-#define TRG_TORRENT_MODEL(obj) \
-  (G_TYPE_CHECK_INSTANCE_CAST ((obj), TRG_TYPE_TORRENT_MODEL, TrgTorrentModel))
-#define TRG_TORRENT_MODEL_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_CAST ((klass), TRG_TYPE_TORRENT_MODEL, TrgTorrentModelClass))
-#define TRG_IS_TORRENT_MODEL(obj) \
-  (G_TYPE_CHECK_INSTANCE_TYPE ((obj), TRG_TYPE_TORRENT_MODEL))
-#define TRG_IS_TORRENT_MODEL_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_TYPE ((klass), TRG_TYPE_TORRENT_MODEL))
-#define TRG_TORRENT_MODEL_GET_CLASS(obj) \
-  (G_TYPE_INSTANCE_GET_CLASS ((obj), TRG_TYPE_TORRENT_MODEL, TrgTorrentModelClass))
-    typedef struct {
+#define TRG_TORRENT_MODEL(obj)                                                                     \
+    (G_TYPE_CHECK_INSTANCE_CAST((obj), TRG_TYPE_TORRENT_MODEL, TrgTorrentModel))
+#define TRG_TORRENT_MODEL_CLASS(klass)                                                             \
+    (G_TYPE_CHECK_CLASS_CAST((klass), TRG_TYPE_TORRENT_MODEL, TrgTorrentModelClass))
+#define TRG_IS_TORRENT_MODEL(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), TRG_TYPE_TORRENT_MODEL))
+#define TRG_IS_TORRENT_MODEL_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass), TRG_TYPE_TORRENT_MODEL))
+#define TRG_TORRENT_MODEL_GET_CLASS(obj)                                                           \
+    (G_TYPE_INSTANCE_GET_CLASS((obj), TRG_TYPE_TORRENT_MODEL, TrgTorrentModelClass))
+typedef struct {
     GtkListStore parent;
 } TrgTorrentModel;
 
 typedef struct {
     GtkListStoreClass parent_class;
-    void (*torrent_completed) (TrgTorrentModel * model,
-                               GtkTreeIter * iter, gpointer data);
-    void (*update) (TrgTorrentModel * model, gpointer data);
-    void (*torrent_added) (TrgTorrentModel * model,
-                           GtkTreeIter * iter, gpointer data);
+    void (*torrent_completed)(TrgTorrentModel *model, GtkTreeIter *iter, gpointer data);
+    void (*update)(TrgTorrentModel *model, gpointer data);
+    void (*torrent_added)(TrgTorrentModel *model, GtkTreeIter *iter, gpointer data);
 
-    void (*torrent_removed) (TrgTorrentModel * model, gpointer data);
+    void (*torrent_removed)(TrgTorrentModel *model, gpointer data);
 } TrgTorrentModelClass;
 
 typedef struct {
@@ -68,39 +64,30 @@ typedef struct {
     gint down_wait;
 } trg_torrent_model_update_stats;
 
-#define TORRENT_UPDATE_STATE_CHANGE        (1 << 0)
-#define TORRENT_UPDATE_PATH_CHANGE         (1 << 1)
-#define TORRENT_UPDATE_ADDREMOVE           (1 << 2)
+#define TORRENT_UPDATE_STATE_CHANGE (1 << 0)
+#define TORRENT_UPDATE_PATH_CHANGE  (1 << 1)
+#define TORRENT_UPDATE_ADDREMOVE    (1 << 2)
 
 GType trg_torrent_model_get_type(void);
 
 TrgTorrentModel *trg_torrent_model_new(void);
 
 G_END_DECLS
-    gboolean
-find_existing_peer_item(GtkListStore * model, JsonObject * p,
-                        GtkTreeIter * iter);
+gboolean find_existing_peer_item(GtkListStore *model, JsonObject *p, GtkTreeIter *iter);
 
-trg_torrent_model_update_stats *trg_torrent_model_update(TrgTorrentModel *
-                                                         model,
-                                                         TrgClient * tc,
-                                                         JsonObject *
-                                                         response,
-                                                         gint mode);
-trg_torrent_model_update_stats *trg_torrent_model_get_stats(TrgTorrentModel
-                                                            * model);
+trg_torrent_model_update_stats *trg_torrent_model_update(TrgTorrentModel *model, TrgClient *tc,
+                                                         JsonObject *response, gint mode);
+trg_torrent_model_update_stats *trg_torrent_model_get_stats(TrgTorrentModel *model);
 
-GHashTable *get_torrent_table(TrgTorrentModel * model);
-void trg_torrent_model_remove_all(TrgTorrentModel * model);
+GHashTable *get_torrent_table(TrgTorrentModel *model);
+void trg_torrent_model_remove_all(TrgTorrentModel *model);
 
-gboolean trg_torrent_model_is_remove_in_progress(TrgTorrentModel * model);
+gboolean trg_torrent_model_is_remove_in_progress(TrgTorrentModel *model);
 
-gboolean get_torrent_data(GHashTable * table, gint64 id, JsonObject ** t,
-                          GtkTreeIter * out_iter);
+gboolean get_torrent_data(GHashTable *table, gint64 id, JsonObject **t, GtkTreeIter *out_iter);
 
-gchar *shorten_download_dir(TrgClient * tc, const gchar * downloadDir);
-void trg_torrent_model_reload_dir_aliases(TrgClient * tc,
-                                          GtkTreeModel * model);
+gchar *shorten_download_dir(TrgClient *tc, const gchar *downloadDir);
+void trg_torrent_model_reload_dir_aliases(TrgClient *tc, GtkTreeModel *model);
 
 enum {
     TORRENT_COLUMN_ICON,
@@ -151,4 +138,4 @@ enum {
     TORRENT_COLUMN_COLUMNS
 };
 
-#endif                          /* TRG_TORRENT_MODEL_H_ */
+#endif /* TRG_TORRENT_MODEL_H_ */

--- a/src/trg-torrent-move-dialog.c
+++ b/src/trg-torrent-move-dialog.c
@@ -19,23 +19,22 @@
 
 #include "config.h"
 
-#include <string.h>
 #include <glib/gi18n.h>
 #include <gtk/gtk.h>
 #include <json-glib/json-glib.h>
+#include <string.h>
 
+#include "hig.h"
+#include "requests.h"
+#include "torrent.h"
 #include "trg-client.h"
+#include "trg-destination-combo.h"
 #include "trg-main-window.h"
 #include "trg-torrent-move-dialog.h"
-#include "trg-destination-combo.h"
-#include "hig.h"
-#include "torrent.h"
-#include "requests.h"
 
-G_DEFINE_TYPE(TrgTorrentMoveDialog, trg_torrent_move_dialog,
-              GTK_TYPE_DIALOG)
-#define TRG_TORRENT_MOVE_DIALOG_GET_PRIVATE(o) \
-  (G_TYPE_INSTANCE_GET_PRIVATE ((o), TRG_TYPE_TORRENT_MOVE_DIALOG, TrgTorrentMoveDialogPrivate))
+G_DEFINE_TYPE(TrgTorrentMoveDialog, trg_torrent_move_dialog, GTK_TYPE_DIALOG)
+#define TRG_TORRENT_MOVE_DIALOG_GET_PRIVATE(o)                                                     \
+    (G_TYPE_INSTANCE_GET_PRIVATE((o), TRG_TYPE_TORRENT_MOVE_DIALOG, TrgTorrentMoveDialogPrivate))
 typedef struct _TrgTorrentMoveDialogPrivate TrgTorrentMoveDialogPrivate;
 
 struct _TrgTorrentMoveDialogPrivate {
@@ -53,53 +52,38 @@ enum {
     PROP_TREEVIEW
 };
 
-static void
-trg_torrent_move_response_cb(GtkDialog * dlg, gint res_id, gpointer data)
+static void trg_torrent_move_response_cb(GtkDialog *dlg, gint res_id, gpointer data)
 {
-    TrgTorrentMoveDialogPrivate *priv =
-        TRG_TORRENT_MOVE_DIALOG_GET_PRIVATE(dlg);
+    TrgTorrentMoveDialogPrivate *priv = TRG_TORRENT_MOVE_DIALOG_GET_PRIVATE(dlg);
 
     if (res_id == GTK_RESPONSE_ACCEPT) {
-        gchar *location =
-            trg_destination_combo_get_dir(TRG_DESTINATION_COMBO
-                                          (priv->location_combo));
-        JsonNode *request = torrent_set_location(priv->ids, location,
-                                                 gtk_toggle_button_get_active
-                                                 (GTK_TOGGLE_BUTTON
-                                                  (priv->move_check)));
+        gchar *location
+            = trg_destination_combo_get_dir(TRG_DESTINATION_COMBO(priv->location_combo));
+        JsonNode *request = torrent_set_location(
+            priv->ids, location, gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(priv->move_check)));
         g_free(location);
-        trg_destination_combo_save_selection(TRG_DESTINATION_COMBO
-                                             (priv->location_combo));
-        dispatch_async(priv->client, request,
-                       on_generic_interactive_action_response, data);
+        trg_destination_combo_save_selection(TRG_DESTINATION_COMBO(priv->location_combo));
+        dispatch_async(priv->client, request, on_generic_interactive_action_response, data);
     } else {
         json_array_unref(priv->ids);
     }
     gtk_widget_destroy(GTK_WIDGET(dlg));
 }
 
-static void location_changed(GtkComboBox * w, gpointer data)
+static void location_changed(GtkComboBox *w, gpointer data)
 {
-    TrgTorrentMoveDialogPrivate *priv =
-        TRG_TORRENT_MOVE_DIALOG_GET_PRIVATE(data);
-    gtk_widget_set_sensitive(priv->move_button,
-                             trg_destination_combo_has_text
-                             (TRG_DESTINATION_COMBO
-                              (priv->location_combo)));
+    TrgTorrentMoveDialogPrivate *priv = TRG_TORRENT_MOVE_DIALOG_GET_PRIVATE(data);
+    gtk_widget_set_sensitive(
+        priv->move_button,
+        trg_destination_combo_has_text(TRG_DESTINATION_COMBO(priv->location_combo)));
 }
 
-static GObject *trg_torrent_move_dialog_constructor(GType type,
-                                                    guint
-                                                    n_construct_properties,
-                                                    GObjectConstructParam *
-                                                    construct_params)
+static GObject *trg_torrent_move_dialog_constructor(GType type, guint n_construct_properties,
+                                                    GObjectConstructParam *construct_params)
 {
-    GObject *object = G_OBJECT_CLASS
-        (trg_torrent_move_dialog_parent_class)->constructor(type,
-                                                            n_construct_properties,
-                                                            construct_params);
-    TrgTorrentMoveDialogPrivate *priv =
-        TRG_TORRENT_MOVE_DIALOG_GET_PRIVATE(object);
+    GObject *object = G_OBJECT_CLASS(trg_torrent_move_dialog_parent_class)
+                          ->constructor(type, n_construct_properties, construct_params);
+    TrgTorrentMoveDialogPrivate *priv = TRG_TORRENT_MOVE_DIALOG_GET_PRIVATE(object);
 
     gint count;
     gchar *msg;
@@ -109,44 +93,32 @@ static GObject *trg_torrent_move_dialog_constructor(GType type,
 
     t = hig_workarea_create();
 
-    w = priv->location_combo =
-        trg_destination_combo_new(priv->client,
-                                  TRG_PREFS_KEY_LAST_MOVE_DESTINATION);
-    g_signal_connect(w, "changed",
-                     G_CALLBACK(location_changed), object);
+    w = priv->location_combo
+        = trg_destination_combo_new(priv->client, TRG_PREFS_KEY_LAST_MOVE_DESTINATION);
+    g_signal_connect(w, "changed", G_CALLBACK(location_changed), object);
     hig_workarea_add_row(t, &row, _("Location:"), w, NULL);
 
-    priv->move_check =
-        hig_workarea_add_wide_checkbutton(t, &row, _("Move"), TRUE);
+    priv->move_check = hig_workarea_add_wide_checkbutton(t, &row, _("Move"), TRUE);
 
     gtk_window_set_destroy_with_parent(GTK_WINDOW(object), TRUE);
 
-    gtk_dialog_add_button(GTK_DIALOG(object), _("_Close"),
-                          GTK_RESPONSE_CANCEL);
-    priv->move_button =
-        gtk_dialog_add_button(GTK_DIALOG(object), _("Move"),
-                              GTK_RESPONSE_ACCEPT);
+    gtk_dialog_add_button(GTK_DIALOG(object), _("_Close"), GTK_RESPONSE_CANCEL);
+    priv->move_button = gtk_dialog_add_button(GTK_DIALOG(object), _("Move"), GTK_RESPONSE_ACCEPT);
 
-    gtk_widget_set_sensitive(priv->move_button,
-                             trg_destination_combo_has_text
-                             (TRG_DESTINATION_COMBO
-                              (priv->location_combo)));
+    gtk_widget_set_sensitive(
+        priv->move_button,
+        trg_destination_combo_has_text(TRG_DESTINATION_COMBO(priv->location_combo)));
 
     gtk_container_set_border_width(GTK_CONTAINER(object), GUI_PAD);
 
-    gtk_dialog_set_default_response(GTK_DIALOG(object),
-                                    GTK_RESPONSE_ACCEPT);
+    gtk_dialog_set_default_response(GTK_DIALOG(object), GTK_RESPONSE_ACCEPT);
 
     gtk_container_set_border_width(GTK_CONTAINER(t), GUI_PAD);
 
-    gtk_box_pack_start(GTK_BOX
-                       (gtk_dialog_get_content_area(GTK_DIALOG(object))),
-                       t, TRUE, TRUE, 0);
+    gtk_box_pack_start(GTK_BOX(gtk_dialog_get_content_area(GTK_DIALOG(object))), t, TRUE, TRUE, 0);
 
-    count =
-        gtk_tree_selection_count_selected_rows(gtk_tree_view_get_selection
-                                               (GTK_TREE_VIEW
-                                                (priv->treeview)));
+    count = gtk_tree_selection_count_selected_rows(
+        gtk_tree_view_get_selection(GTK_TREE_VIEW(priv->treeview)));
     priv->ids = build_json_id_array(priv->treeview);
 
     if (count == 1) {
@@ -154,33 +126,28 @@ static GObject *trg_torrent_move_dialog_constructor(GType type,
         const gchar *name;
 
         get_torrent_data(trg_client_get_torrent_table(priv->client),
-                         trg_mw_get_selected_torrent_id(priv->win), &json,
-                         NULL);
+                         trg_mw_get_selected_torrent_id(priv->win), &json, NULL);
         name = torrent_get_name(json);
         msg = g_strdup_printf(_("Move %s"), name);
     } else {
         msg = g_strdup_printf(_("Move %d torrents"), count);
     }
 
-    gtk_window_set_transient_for(GTK_WINDOW(object),
-                                 GTK_WINDOW(priv->win));
+    gtk_window_set_transient_for(GTK_WINDOW(object), GTK_WINDOW(priv->win));
     gtk_window_set_title(GTK_WINDOW(object), msg);
 
-    g_signal_connect(G_OBJECT(object),
-                     "response",
-                     G_CALLBACK(trg_torrent_move_response_cb), priv->win);
+    g_signal_connect(G_OBJECT(object), "response", G_CALLBACK(trg_torrent_move_response_cb),
+                     priv->win);
 
     g_free(msg);
 
     return object;
 }
 
-static void
-trg_torrent_move_dialog_get_property(GObject * object, guint property_id,
-                                     GValue * value, GParamSpec * pspec)
+static void trg_torrent_move_dialog_get_property(GObject *object, guint property_id, GValue *value,
+                                                 GParamSpec *pspec)
 {
-    TrgTorrentMoveDialogPrivate *priv =
-        TRG_TORRENT_MOVE_DIALOG_GET_PRIVATE(object);
+    TrgTorrentMoveDialogPrivate *priv = TRG_TORRENT_MOVE_DIALOG_GET_PRIVATE(object);
     switch (property_id) {
     case PROP_CLIENT:
         g_value_set_pointer(value, priv->client);
@@ -197,13 +164,10 @@ trg_torrent_move_dialog_get_property(GObject * object, guint property_id,
     }
 }
 
-static void
-trg_torrent_move_dialog_set_property(GObject * object, guint property_id,
-                                     const GValue * value,
-                                     GParamSpec * pspec)
+static void trg_torrent_move_dialog_set_property(GObject *object, guint property_id,
+                                                 const GValue *value, GParamSpec *pspec)
 {
-    TrgTorrentMoveDialogPrivate *priv =
-        TRG_TORRENT_MOVE_DIALOG_GET_PRIVATE(object);
+    TrgTorrentMoveDialogPrivate *priv = TRG_TORRENT_MOVE_DIALOG_GET_PRIVATE(object);
     switch (property_id) {
     case PROP_CLIENT:
         priv->client = g_value_get_pointer(value);
@@ -220,8 +184,7 @@ trg_torrent_move_dialog_set_property(GObject * object, guint property_id,
     }
 }
 
-static void
-trg_torrent_move_dialog_class_init(TrgTorrentMoveDialogClass * klass)
+static void trg_torrent_move_dialog_class_init(TrgTorrentMoveDialogClass *klass)
 {
     GObjectClass *object_class = G_OBJECT_CLASS(klass);
 
@@ -231,52 +194,33 @@ trg_torrent_move_dialog_class_init(TrgTorrentMoveDialogClass * klass)
     object_class->set_property = trg_torrent_move_dialog_set_property;
     object_class->constructor = trg_torrent_move_dialog_constructor;
 
-    g_object_class_install_property(object_class,
-                                    PROP_TREEVIEW,
-                                    g_param_spec_object
-                                    ("torrent-tree-view",
-                                     "TrgTorrentTreeView",
-                                     "TrgTorrentTreeView",
-                                     TRG_TYPE_TORRENT_TREE_VIEW,
-                                     G_PARAM_READWRITE |
-                                     G_PARAM_CONSTRUCT_ONLY |
-                                     G_PARAM_STATIC_NAME |
-                                     G_PARAM_STATIC_NICK |
-                                     G_PARAM_STATIC_BLURB));
+    g_object_class_install_property(
+        object_class, PROP_TREEVIEW,
+        g_param_spec_object("torrent-tree-view", "TrgTorrentTreeView", "TrgTorrentTreeView",
+                            TRG_TYPE_TORRENT_TREE_VIEW,
+                            G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME
+                                | G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
 
-    g_object_class_install_property(object_class,
-                                    PROP_PARENT_WINDOW,
-                                    g_param_spec_object
-                                    ("parent-window", "Parent window",
-                                     "Parent window", TRG_TYPE_MAIN_WINDOW,
-                                     G_PARAM_READWRITE |
-                                     G_PARAM_CONSTRUCT_ONLY |
-                                     G_PARAM_STATIC_NAME |
-                                     G_PARAM_STATIC_NICK |
-                                     G_PARAM_STATIC_BLURB));
+    g_object_class_install_property(
+        object_class, PROP_PARENT_WINDOW,
+        g_param_spec_object("parent-window", "Parent window", "Parent window", TRG_TYPE_MAIN_WINDOW,
+                            G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME
+                                | G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
 
-    g_object_class_install_property(object_class,
-                                    PROP_CLIENT,
-                                    g_param_spec_pointer
-                                    ("trg-client", "TClient",
-                                     "Client",
-                                     G_PARAM_READWRITE |
-                                     G_PARAM_CONSTRUCT_ONLY |
-                                     G_PARAM_STATIC_NAME |
-                                     G_PARAM_STATIC_NICK |
-                                     G_PARAM_STATIC_BLURB));
+    g_object_class_install_property(
+        object_class, PROP_CLIENT,
+        g_param_spec_pointer("trg-client", "TClient", "Client",
+                             G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME
+                                 | G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
 }
 
-static void trg_torrent_move_dialog_init(TrgTorrentMoveDialog * self)
+static void trg_torrent_move_dialog_init(TrgTorrentMoveDialog *self)
 {
 }
 
-TrgTorrentMoveDialog *trg_torrent_move_dialog_new(TrgMainWindow * win,
-                                                  TrgClient * client,
-                                                  TrgTorrentTreeView * ttv)
+TrgTorrentMoveDialog *trg_torrent_move_dialog_new(TrgMainWindow *win, TrgClient *client,
+                                                  TrgTorrentTreeView *ttv)
 {
-    return g_object_new(TRG_TYPE_TORRENT_MOVE_DIALOG,
-                        "trg-client", client,
-                        "torrent-tree-view", ttv, "parent-window", win,
-                        NULL);
+    return g_object_new(TRG_TYPE_TORRENT_MOVE_DIALOG, "trg-client", client, "torrent-tree-view",
+                        ttv, "parent-window", win, NULL);
 }

--- a/src/trg-torrent-move-dialog.h
+++ b/src/trg-torrent-move-dialog.h
@@ -28,17 +28,17 @@
 
 G_BEGIN_DECLS
 #define TRG_TYPE_TORRENT_MOVE_DIALOG trg_torrent_move_dialog_get_type()
-#define TRG_TORRENT_MOVE_DIALOG(obj) \
-  (G_TYPE_CHECK_INSTANCE_CAST ((obj), TRG_TYPE_TORRENT_MOVE_DIALOG, TrgTorrentMoveDialog))
-#define TRG_TORRENT_MOVE_DIALOG_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_CAST ((klass), TRG_TYPE_TORRENT_MOVE_DIALOG, TrgTorrentMoveDialogClass))
-#define TRG_IS_TORRENT_MOVE_DIALOG(obj) \
-  (G_TYPE_CHECK_INSTANCE_TYPE ((obj), TRG_TYPE_TORRENT_MOVE_DIALOG))
-#define TRG_IS_TORRENT_MOVE_DIALOG_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_TYPE ((klass), TRG_TYPE_TORRENT_MOVE_DIALOG))
-#define TRG_TORRENT_MOVE_DIALOG_GET_CLASS(obj) \
-  (G_TYPE_INSTANCE_GET_CLASS ((obj), TRG_TYPE_TORRENT_MOVE_DIALOG, TrgTorrentMoveDialogClass))
-    typedef struct {
+#define TRG_TORRENT_MOVE_DIALOG(obj)                                                               \
+    (G_TYPE_CHECK_INSTANCE_CAST((obj), TRG_TYPE_TORRENT_MOVE_DIALOG, TrgTorrentMoveDialog))
+#define TRG_TORRENT_MOVE_DIALOG_CLASS(klass)                                                       \
+    (G_TYPE_CHECK_CLASS_CAST((klass), TRG_TYPE_TORRENT_MOVE_DIALOG, TrgTorrentMoveDialogClass))
+#define TRG_IS_TORRENT_MOVE_DIALOG(obj)                                                            \
+    (G_TYPE_CHECK_INSTANCE_TYPE((obj), TRG_TYPE_TORRENT_MOVE_DIALOG))
+#define TRG_IS_TORRENT_MOVE_DIALOG_CLASS(klass)                                                    \
+    (G_TYPE_CHECK_CLASS_TYPE((klass), TRG_TYPE_TORRENT_MOVE_DIALOG))
+#define TRG_TORRENT_MOVE_DIALOG_GET_CLASS(obj)                                                     \
+    (G_TYPE_INSTANCE_GET_CLASS((obj), TRG_TYPE_TORRENT_MOVE_DIALOG, TrgTorrentMoveDialogClass))
+typedef struct {
     GtkDialog parent;
 } TrgTorrentMoveDialog;
 
@@ -48,10 +48,8 @@ typedef struct {
 
 GType trg_torrent_move_dialog_get_type(void);
 
-TrgTorrentMoveDialog *trg_torrent_move_dialog_new(TrgMainWindow * win,
-                                                  TrgClient * client,
-                                                  TrgTorrentTreeView *
-                                                  ttv);
+TrgTorrentMoveDialog *trg_torrent_move_dialog_new(TrgMainWindow *win, TrgClient *client,
+                                                  TrgTorrentTreeView *ttv);
 
 G_END_DECLS
-#endif                          /* TRG_TORRENT_MOVE_DIALOG_H_ */
+#endif /* TRG_TORRENT_MOVE_DIALOG_H_ */

--- a/src/trg-torrent-props-dialog.h
+++ b/src/trg-torrent-props-dialog.h
@@ -22,22 +22,22 @@
 
 #include <glib-object.h>
 
-#include "trg-torrent-tree-view.h"
 #include "trg-client.h"
+#include "trg-torrent-tree-view.h"
 
 G_BEGIN_DECLS
 #define TRG_TYPE_TORRENT_PROPS_DIALOG trg_torrent_props_dialog_get_type()
-#define TRG_TORRENT_PROPS_DIALOG(obj) \
-  (G_TYPE_CHECK_INSTANCE_CAST ((obj), TRG_TYPE_TORRENT_PROPS_DIALOG, TrgTorrentPropsDialog))
-#define TRG_TORRENT_PROPS_DIALOG_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_CAST ((klass), TRG_TYPE_TORRENT_PROPS_DIALOG, TrgTorrentPropsDialogClass))
-#define TRG_IS_TORRENT_PROPS_DIALOG(obj) \
-  (G_TYPE_CHECK_INSTANCE_TYPE ((obj), TRG_TYPE_TORRENT_PROPS_DIALOG))
-#define TRG_IS_TORRENT_PROPS_DIALOG_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_TYPE ((klass), TRG_TYPE_TORRENT_PROPS_DIALOG))
-#define TRG_TORRENT_PROPS_DIALOG_GET_CLASS(obj) \
-  (G_TYPE_INSTANCE_GET_CLASS ((obj), TRG_TYPE_TORRENT_PROPS_DIALOG, TrgTorrentPropsDialogClass))
-    typedef struct {
+#define TRG_TORRENT_PROPS_DIALOG(obj)                                                              \
+    (G_TYPE_CHECK_INSTANCE_CAST((obj), TRG_TYPE_TORRENT_PROPS_DIALOG, TrgTorrentPropsDialog))
+#define TRG_TORRENT_PROPS_DIALOG_CLASS(klass)                                                      \
+    (G_TYPE_CHECK_CLASS_CAST((klass), TRG_TYPE_TORRENT_PROPS_DIALOG, TrgTorrentPropsDialogClass))
+#define TRG_IS_TORRENT_PROPS_DIALOG(obj)                                                           \
+    (G_TYPE_CHECK_INSTANCE_TYPE((obj), TRG_TYPE_TORRENT_PROPS_DIALOG))
+#define TRG_IS_TORRENT_PROPS_DIALOG_CLASS(klass)                                                   \
+    (G_TYPE_CHECK_CLASS_TYPE((klass), TRG_TYPE_TORRENT_PROPS_DIALOG))
+#define TRG_TORRENT_PROPS_DIALOG_GET_CLASS(obj)                                                    \
+    (G_TYPE_INSTANCE_GET_CLASS((obj), TRG_TYPE_TORRENT_PROPS_DIALOG, TrgTorrentPropsDialogClass))
+typedef struct {
     GtkDialog parent;
 } TrgTorrentPropsDialog;
 
@@ -47,12 +47,9 @@ typedef struct {
 
 GType trg_torrent_props_dialog_get_type(void);
 
-TrgTorrentPropsDialog *trg_torrent_props_dialog_new(GtkWindow * window,
-                                                    TrgTorrentTreeView *
-                                                    treeview,
-                                                    TrgTorrentModel *
-                                                    torrentModel,
-                                                    TrgClient * client);
+TrgTorrentPropsDialog *trg_torrent_props_dialog_new(GtkWindow *window, TrgTorrentTreeView *treeview,
+                                                    TrgTorrentModel *torrentModel,
+                                                    TrgClient *client);
 
 G_END_DECLS
-#endif                          /* TRG_TORRENT_PROPS_DIALOG_H_ */
+#endif /* TRG_TORRENT_PROPS_DIALOG_H_ */

--- a/src/trg-torrent-tree-view.c
+++ b/src/trg-torrent-tree-view.c
@@ -22,172 +22,122 @@
 #include <glib/gi18n.h>
 #include <gtk/gtk.h>
 
-#include "trg-prefs.h"
-#include "trg-tree-view.h"
-#include "trg-torrent-model.h"
 #include "torrent-cell-renderer.h"
+#include "trg-prefs.h"
+#include "trg-torrent-model.h"
 #include "trg-torrent-tree-view.h"
+#include "trg-tree-view.h"
 
-G_DEFINE_TYPE(TrgTorrentTreeView, trg_torrent_tree_view,
-              TRG_TYPE_TREE_VIEW)
-#define GET_PRIVATE(o) \
-  (G_TYPE_INSTANCE_GET_PRIVATE ((o), TRG_TYPE_TORRENT_TREE_VIEW, TrgTorrentTreeViewPrivate))
+G_DEFINE_TYPE(TrgTorrentTreeView, trg_torrent_tree_view, TRG_TYPE_TREE_VIEW)
+#define GET_PRIVATE(o)                                                                             \
+    (G_TYPE_INSTANCE_GET_PRIVATE((o), TRG_TYPE_TORRENT_TREE_VIEW, TrgTorrentTreeViewPrivate))
 typedef struct _TrgTorrentTreeViewPrivate TrgTorrentTreeViewPrivate;
 
 struct _TrgTorrentTreeViewPrivate {
     TrgClient *client;
 };
 
-static void trg_torrent_tree_view_class_init(TrgTorrentTreeViewClass *
-                                             klass G_GNUC_UNUSED)
+static void trg_torrent_tree_view_class_init(TrgTorrentTreeViewClass *klass G_GNUC_UNUSED)
 {
     g_type_class_add_private(klass, sizeof(TrgTorrentTreeViewPrivate));
 }
 
-static void trg_torrent_tree_view_init(TrgTorrentTreeView * tttv)
+static void trg_torrent_tree_view_init(TrgTorrentTreeView *tttv)
 {
     TrgTreeView *ttv = TRG_TREE_VIEW(tttv);
     trg_column_description *desc;
 
-    desc =
-        trg_tree_view_reg_column(ttv, TRG_COLTYPE_ICONTEXT,
-                                 TORRENT_COLUMN_NAME, _("Name"), "name",
-                                 0);
+    desc = trg_tree_view_reg_column(ttv, TRG_COLTYPE_ICONTEXT, TORRENT_COLUMN_NAME, _("Name"),
+                                    "name", 0);
     desc->model_column_extra = TORRENT_COLUMN_ICON;
 
-    trg_tree_view_reg_column(ttv, TRG_COLTYPE_SIZE,
-                             TORRENT_COLUMN_SIZEWHENDONE, _("Size"),
-                             "size", 0);
-    trg_tree_view_reg_column(ttv, TRG_COLTYPE_PROG,
-                             TORRENT_COLUMN_PERCENTDONE, _("Done"), "done",
+    trg_tree_view_reg_column(ttv, TRG_COLTYPE_SIZE, TORRENT_COLUMN_SIZEWHENDONE, _("Size"), "size",
                              0);
-    trg_tree_view_reg_column(ttv, TRG_COLTYPE_TEXT, TORRENT_COLUMN_STATUS,
-                             _("Status"), "status", 0);
-    trg_tree_view_reg_column(ttv, TRG_COLTYPE_NUMGTZERO,
-                             TORRENT_COLUMN_SEEDS, _("Seeds"), "seeds", 0);
-    trg_tree_view_reg_column(ttv, TRG_COLTYPE_NUMGTZERO,
-                             TORRENT_COLUMN_PEERS_TO_US, _("Sending"),
+    trg_tree_view_reg_column(ttv, TRG_COLTYPE_PROG, TORRENT_COLUMN_PERCENTDONE, _("Done"), "done",
+                             0);
+    trg_tree_view_reg_column(ttv, TRG_COLTYPE_TEXT, TORRENT_COLUMN_STATUS, _("Status"), "status",
+                             0);
+    trg_tree_view_reg_column(ttv, TRG_COLTYPE_NUMGTZERO, TORRENT_COLUMN_SEEDS, _("Seeds"), "seeds",
+                             0);
+    trg_tree_view_reg_column(ttv, TRG_COLTYPE_NUMGTZERO, TORRENT_COLUMN_PEERS_TO_US, _("Sending"),
                              "sending", TRG_COLUMN_EXTRA);
-    trg_tree_view_reg_column(ttv, TRG_COLTYPE_NUMGTZERO,
-                             TORRENT_COLUMN_LEECHERS, _("Leechers"),
+    trg_tree_view_reg_column(ttv, TRG_COLTYPE_NUMGTZERO, TORRENT_COLUMN_LEECHERS, _("Leechers"),
                              "leechers", 0);
-    trg_tree_view_reg_column(ttv, TRG_COLTYPE_NUMGTZERO,
-                             TORRENT_COLUMN_DOWNLOADS, _("Downloads"),
+    trg_tree_view_reg_column(ttv, TRG_COLTYPE_NUMGTZERO, TORRENT_COLUMN_DOWNLOADS, _("Downloads"),
                              "downloads", TRG_COLUMN_EXTRA);
-    trg_tree_view_reg_column(ttv, TRG_COLTYPE_NUMGTZERO,
-                             TORRENT_COLUMN_PEERS_FROM_US, _("Receiving"),
-                             "connected-leechers", TRG_COLUMN_EXTRA);
-    trg_tree_view_reg_column(ttv, TRG_COLTYPE_NUMGTZERO,
-                             TORRENT_COLUMN_PEERS_CONNECTED,
+    trg_tree_view_reg_column(ttv, TRG_COLTYPE_NUMGTZERO, TORRENT_COLUMN_PEERS_FROM_US,
+                             _("Receiving"), "connected-leechers", TRG_COLUMN_EXTRA);
+    trg_tree_view_reg_column(ttv, TRG_COLTYPE_NUMGTZERO, TORRENT_COLUMN_PEERS_CONNECTED,
                              _("Connected"), "connected-peers", 0);
-    trg_tree_view_reg_column(ttv, TRG_COLTYPE_NUMGTZERO,
-                             TORRENT_COLUMN_FROMPEX, _("PEX Peers"),
-                             "from-pex",
-                             TRG_COLUMN_EXTRA |
-                             TRG_COLUMN_HIDE_FROM_TOP_MENU);
-    trg_tree_view_reg_column(ttv, TRG_COLTYPE_NUMGTZERO,
-                             TORRENT_COLUMN_FROMDHT, _("DHT Peers"),
-                             "from-dht",
-                             TRG_COLUMN_EXTRA |
-                             TRG_COLUMN_HIDE_FROM_TOP_MENU);
-    trg_tree_view_reg_column(ttv, TRG_COLTYPE_NUMGTZERO,
-                             TORRENT_COLUMN_FROMTRACKERS,
+    trg_tree_view_reg_column(ttv, TRG_COLTYPE_NUMGTZERO, TORRENT_COLUMN_FROMPEX, _("PEX Peers"),
+                             "from-pex", TRG_COLUMN_EXTRA | TRG_COLUMN_HIDE_FROM_TOP_MENU);
+    trg_tree_view_reg_column(ttv, TRG_COLTYPE_NUMGTZERO, TORRENT_COLUMN_FROMDHT, _("DHT Peers"),
+                             "from-dht", TRG_COLUMN_EXTRA | TRG_COLUMN_HIDE_FROM_TOP_MENU);
+    trg_tree_view_reg_column(ttv, TRG_COLTYPE_NUMGTZERO, TORRENT_COLUMN_FROMTRACKERS,
                              _("Tracker Peers"), "from-trackers",
-                             TRG_COLUMN_EXTRA |
-                             TRG_COLUMN_HIDE_FROM_TOP_MENU);
-    trg_tree_view_reg_column(ttv, TRG_COLTYPE_NUMGTZERO,
-                             TORRENT_COLUMN_FROMLTEP, _("LTEP Peers"),
-                             "from-ltep",
-                             TRG_COLUMN_EXTRA |
-                             TRG_COLUMN_HIDE_FROM_TOP_MENU);
-    trg_tree_view_reg_column(ttv, TRG_COLTYPE_NUMGTZERO,
-                             TORRENT_COLUMN_FROMRESUME, _("Resumed Peers"),
-                             "from-resume",
-                             TRG_COLUMN_EXTRA |
-                             TRG_COLUMN_HIDE_FROM_TOP_MENU);
-    trg_tree_view_reg_column(ttv, TRG_COLTYPE_NUMGTZERO,
-                             TORRENT_COLUMN_FROMINCOMING,
+                             TRG_COLUMN_EXTRA | TRG_COLUMN_HIDE_FROM_TOP_MENU);
+    trg_tree_view_reg_column(ttv, TRG_COLTYPE_NUMGTZERO, TORRENT_COLUMN_FROMLTEP, _("LTEP Peers"),
+                             "from-ltep", TRG_COLUMN_EXTRA | TRG_COLUMN_HIDE_FROM_TOP_MENU);
+    trg_tree_view_reg_column(ttv, TRG_COLTYPE_NUMGTZERO, TORRENT_COLUMN_FROMRESUME,
+                             _("Resumed Peers"), "from-resume",
+                             TRG_COLUMN_EXTRA | TRG_COLUMN_HIDE_FROM_TOP_MENU);
+    trg_tree_view_reg_column(ttv, TRG_COLTYPE_NUMGTZERO, TORRENT_COLUMN_FROMINCOMING,
                              _("Incoming Peers"), "from-incoming",
-                             TRG_COLUMN_EXTRA |
-                             TRG_COLUMN_HIDE_FROM_TOP_MENU);
-    trg_tree_view_reg_column(ttv, TRG_COLTYPE_TEXT,
-                             TORRENT_COLUMN_PEER_SOURCES,
+                             TRG_COLUMN_EXTRA | TRG_COLUMN_HIDE_FROM_TOP_MENU);
+    trg_tree_view_reg_column(ttv, TRG_COLTYPE_TEXT, TORRENT_COLUMN_PEER_SOURCES,
                              _("Peers T/I/E/H/X/L/R"), "peer-sources",
-                             TRG_COLUMN_EXTRA |
-                             TRG_COLUMN_HIDE_FROM_TOP_MENU);
-    trg_tree_view_reg_column(ttv, TRG_COLTYPE_SPEED,
-                             TORRENT_COLUMN_DOWNSPEED, _("Down Speed"),
+                             TRG_COLUMN_EXTRA | TRG_COLUMN_HIDE_FROM_TOP_MENU);
+    trg_tree_view_reg_column(ttv, TRG_COLTYPE_SPEED, TORRENT_COLUMN_DOWNSPEED, _("Down Speed"),
                              "down-speed", 0);
-    trg_tree_view_reg_column(ttv, TRG_COLTYPE_SPEED,
-                             TORRENT_COLUMN_UPSPEED, _("Up Speed"),
+    trg_tree_view_reg_column(ttv, TRG_COLTYPE_SPEED, TORRENT_COLUMN_UPSPEED, _("Up Speed"),
                              "up-speed", 0);
-    trg_tree_view_reg_column(ttv, TRG_COLTYPE_ETA, TORRENT_COLUMN_ETA,
-                             _("ETA"), "eta", 0);
-    trg_tree_view_reg_column(ttv, TRG_COLTYPE_SIZE,
-                             TORRENT_COLUMN_UPLOADED, _("Uploaded"),
+    trg_tree_view_reg_column(ttv, TRG_COLTYPE_ETA, TORRENT_COLUMN_ETA, _("ETA"), "eta", 0);
+    trg_tree_view_reg_column(ttv, TRG_COLTYPE_SIZE, TORRENT_COLUMN_UPLOADED, _("Uploaded"),
                              "uploaded", 0);
-    trg_tree_view_reg_column(ttv, TRG_COLTYPE_SIZE,
-                             TORRENT_COLUMN_DOWNLOADED, _("Downloaded"),
+    trg_tree_view_reg_column(ttv, TRG_COLTYPE_SIZE, TORRENT_COLUMN_DOWNLOADED, _("Downloaded"),
                              "downloaded", 0);
-    trg_tree_view_reg_column(ttv, TRG_COLTYPE_RATIO, TORRENT_COLUMN_RATIO,
-                             _("Ratio"), "ratio", 0);
-    trg_tree_view_reg_column(ttv, TRG_COLTYPE_EPOCH, TORRENT_COLUMN_ADDED,
-                             _("Added"), "added", 0);
-    trg_tree_view_reg_column(ttv, TRG_COLTYPE_TEXT,
-                             TORRENT_COLUMN_TRACKERHOST,
-                             _("First Tracker"), "first-tracker",
-                             TRG_COLUMN_EXTRA);
-    trg_tree_view_reg_column(ttv, TRG_COLTYPE_TEXT,
-                             TORRENT_COLUMN_DOWNLOADDIR, _("Location"),
+    trg_tree_view_reg_column(ttv, TRG_COLTYPE_RATIO, TORRENT_COLUMN_RATIO, _("Ratio"), "ratio", 0);
+    trg_tree_view_reg_column(ttv, TRG_COLTYPE_EPOCH, TORRENT_COLUMN_ADDED, _("Added"), "added", 0);
+    trg_tree_view_reg_column(ttv, TRG_COLTYPE_TEXT, TORRENT_COLUMN_TRACKERHOST, _("First Tracker"),
+                             "first-tracker", TRG_COLUMN_EXTRA);
+    trg_tree_view_reg_column(ttv, TRG_COLTYPE_TEXT, TORRENT_COLUMN_DOWNLOADDIR, _("Location"),
                              "download-dir", TRG_COLUMN_EXTRA);
-    trg_tree_view_reg_column(ttv, TRG_COLTYPE_TEXT, TORRENT_COLUMN_ID,
-                             _("ID"), "id", TRG_COLUMN_EXTRA);
-    trg_tree_view_reg_column(ttv, TRG_COLTYPE_PRIO,
-                             TORRENT_COLUMN_BANDWIDTH_PRIORITY,
-                             _("Priority"), "priority", TRG_COLUMN_EXTRA);
-    trg_tree_view_reg_column(ttv, TRG_COLTYPE_NUMGTEQZERO,
-                             TORRENT_COLUMN_QUEUE_POSITION,
-                             _("Queue Position"), "queue-position",
+    trg_tree_view_reg_column(ttv, TRG_COLTYPE_TEXT, TORRENT_COLUMN_ID, _("ID"), "id",
                              TRG_COLUMN_EXTRA);
-    trg_tree_view_reg_column(ttv, TRG_COLTYPE_EPOCH,
-                             TORRENT_COLUMN_DONE_DATE, _("Completed"),
+    trg_tree_view_reg_column(ttv, TRG_COLTYPE_PRIO, TORRENT_COLUMN_BANDWIDTH_PRIORITY,
+                             _("Priority"), "priority", TRG_COLUMN_EXTRA);
+    trg_tree_view_reg_column(ttv, TRG_COLTYPE_NUMGTEQZERO, TORRENT_COLUMN_QUEUE_POSITION,
+                             _("Queue Position"), "queue-position", TRG_COLUMN_EXTRA);
+    trg_tree_view_reg_column(ttv, TRG_COLTYPE_EPOCH, TORRENT_COLUMN_DONE_DATE, _("Completed"),
                              "done-date", TRG_COLUMN_EXTRA);
-    trg_tree_view_reg_column(ttv, TRG_COLTYPE_EPOCH,
-                             TORRENT_COLUMN_LASTACTIVE, _("Last Active"),
+    trg_tree_view_reg_column(ttv, TRG_COLTYPE_EPOCH, TORRENT_COLUMN_LASTACTIVE, _("Last Active"),
                              "last-active", TRG_COLUMN_EXTRA);
 
-    gtk_tree_view_set_search_column(GTK_TREE_VIEW(tttv),
-                                    TORRENT_COLUMN_NAME);
+    gtk_tree_view_set_search_column(GTK_TREE_VIEW(tttv), TORRENT_COLUMN_NAME);
 }
 
-static void
-trg_torrent_model_get_json_id_array_foreach(GtkTreeModel * model,
-                                            GtkTreePath *
-                                            path G_GNUC_UNUSED,
-                                            GtkTreeIter * iter,
-                                            gpointer data)
+static void trg_torrent_model_get_json_id_array_foreach(GtkTreeModel *model,
+                                                        GtkTreePath *path G_GNUC_UNUSED,
+                                                        GtkTreeIter *iter, gpointer data)
 {
-    JsonArray *output = (JsonArray *) data;
+    JsonArray *output = (JsonArray *)data;
     gint64 id;
     gtk_tree_model_get(model, iter, TORRENT_COLUMN_ID, &id, -1);
     json_array_add_int_element(output, id);
 }
 
-JsonArray *build_json_id_array(TrgTorrentTreeView * tv)
+JsonArray *build_json_id_array(TrgTorrentTreeView *tv)
 {
-    GtkTreeSelection *selection =
-        gtk_tree_view_get_selection(GTK_TREE_VIEW(tv));
+    GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(tv));
 
     JsonArray *ids = json_array_new();
-    gtk_tree_selection_selected_foreach(selection,
-                                        (GtkTreeSelectionForeachFunc)
-                                        trg_torrent_model_get_json_id_array_foreach,
-                                        ids);
+    gtk_tree_selection_selected_foreach(
+        selection, (GtkTreeSelectionForeachFunc)trg_torrent_model_get_json_id_array_foreach, ids);
 
     return ids;
 }
 
-static void setup_classic_layout(TrgTorrentTreeView * tv)
+static void setup_classic_layout(TrgTorrentTreeView *tv)
 {
     gtk_tree_view_set_rubber_banding(GTK_TREE_VIEW(tv), TRUE);
     gtk_tree_view_set_headers_clickable(GTK_TREE_VIEW(tv), TRUE);
@@ -195,84 +145,43 @@ static void setup_classic_layout(TrgTorrentTreeView * tv)
     trg_tree_view_setup_columns(TRG_TREE_VIEW(tv));
 }
 
-static void
-trg_torrent_tree_view_renderer_pref_changed(TrgPrefs * p,
-                                            const gchar * updatedKey,
-                                            gpointer data)
+static void trg_torrent_tree_view_renderer_pref_changed(TrgPrefs *p, const gchar *updatedKey,
+                                                        gpointer data)
 {
     if (!g_strcmp0(updatedKey, TRG_PREFS_KEY_STYLE)) {
-        GtkTreeView *tv =
-            torrent_cell_renderer_get_owner(TORRENT_CELL_RENDERER(data));
-        gboolean compact = trg_prefs_get_int(p, TRG_PREFS_KEY_STYLE,
-                                             TRG_PREFS_GLOBAL) ==
-            TRG_STYLE_TR_COMPACT;
-        g_object_set(G_OBJECT(data), "compact", GINT_TO_POINTER(compact),
-                     NULL);
+        GtkTreeView *tv = torrent_cell_renderer_get_owner(TORRENT_CELL_RENDERER(data));
+        gboolean compact
+            = trg_prefs_get_int(p, TRG_PREFS_KEY_STYLE, TRG_PREFS_GLOBAL) == TRG_STYLE_TR_COMPACT;
+        g_object_set(G_OBJECT(data), "compact", GINT_TO_POINTER(compact), NULL);
         g_signal_emit_by_name(tv, "style-updated", NULL, NULL);
     }
 }
 
-static void setup_transmission_layout(TrgTorrentTreeView * tv,
-                                      gint64 style)
+static void setup_transmission_layout(TrgTorrentTreeView *tv, gint64 style)
 {
     TrgTorrentTreeViewPrivate *priv = GET_PRIVATE(tv);
     GtkCellRenderer *renderer = torrent_cell_renderer_new();
     TrgPrefs *prefs = trg_client_get_prefs(priv->client);
 
-    GtkTreeViewColumn *column =
-        gtk_tree_view_column_new_with_attributes("",
-                                                 renderer,
-                                                 "status",
-                                                 TORRENT_COLUMN_FLAGS,
-                                                 "error",
-                                                 TORRENT_COLUMN_ERROR,
-                                                 "fileCount",
-                                                 TORRENT_COLUMN_FILECOUNT,
-                                                 "totalSize",
-                                                 TORRENT_COLUMN_TOTALSIZE,
-                                                 "ratio",
-                                                 TORRENT_COLUMN_RATIO,
-                                                 "downloaded",
-                                                 TORRENT_COLUMN_DOWNLOADED,
-                                                 "haveValid",
-                                                 TORRENT_COLUMN_HAVE_VALID,
-                                                 "sizeWhenDone",
-                                                 TORRENT_COLUMN_SIZEWHENDONE,
-                                                 "uploaded",
-                                                 TORRENT_COLUMN_UPLOADED,
-                                                 "percentComplete",
-                                                 TORRENT_COLUMN_PERCENTDONE,
-                                                 "metadataPercentComplete",
-                                                 TORRENT_COLUMN_METADATAPERCENTCOMPLETE,
-                                                 "upSpeed",
-                                                 TORRENT_COLUMN_UPSPEED,
-                                                 "downSpeed",
-                                                 TORRENT_COLUMN_DOWNSPEED,
-                                                 "peersToUs",
-                                                 TORRENT_COLUMN_PEERS_TO_US,
-                                                 "peersGettingFromUs",
-                                                 TORRENT_COLUMN_PEERS_FROM_US,
-                                                 "webSeedsToUs",
-                                                 TORRENT_COLUMN_WEB_SEEDS_TO_US,
-                                                 "eta", TORRENT_COLUMN_ETA,
-                                                 "json",
-                                                 TORRENT_COLUMN_JSON,
-                                                 "seedRatioMode",
-                                                 TORRENT_COLUMN_SEED_RATIO_MODE,
-                                                 "seedRatioLimit",
-                                                 TORRENT_COLUMN_SEED_RATIO_LIMIT,
-                                                 "connected",
-                                                 TORRENT_COLUMN_PEERS_CONNECTED,
-                                                 NULL);
+    GtkTreeViewColumn *column = gtk_tree_view_column_new_with_attributes(
+        "", renderer, "status", TORRENT_COLUMN_FLAGS, "error", TORRENT_COLUMN_ERROR, "fileCount",
+        TORRENT_COLUMN_FILECOUNT, "totalSize", TORRENT_COLUMN_TOTALSIZE, "ratio",
+        TORRENT_COLUMN_RATIO, "downloaded", TORRENT_COLUMN_DOWNLOADED, "haveValid",
+        TORRENT_COLUMN_HAVE_VALID, "sizeWhenDone", TORRENT_COLUMN_SIZEWHENDONE, "uploaded",
+        TORRENT_COLUMN_UPLOADED, "percentComplete", TORRENT_COLUMN_PERCENTDONE,
+        "metadataPercentComplete", TORRENT_COLUMN_METADATAPERCENTCOMPLETE, "upSpeed",
+        TORRENT_COLUMN_UPSPEED, "downSpeed", TORRENT_COLUMN_DOWNSPEED, "peersToUs",
+        TORRENT_COLUMN_PEERS_TO_US, "peersGettingFromUs", TORRENT_COLUMN_PEERS_FROM_US,
+        "webSeedsToUs", TORRENT_COLUMN_WEB_SEEDS_TO_US, "eta", TORRENT_COLUMN_ETA, "json",
+        TORRENT_COLUMN_JSON, "seedRatioMode", TORRENT_COLUMN_SEED_RATIO_MODE, "seedRatioLimit",
+        TORRENT_COLUMN_SEED_RATIO_LIMIT, "connected", TORRENT_COLUMN_PEERS_CONNECTED, NULL);
 
-    g_object_set(G_OBJECT(renderer), "client", priv->client,
-                 "owner", tv,
-                 "compact", style == TRG_STYLE_TR_COMPACT, NULL);
+    g_object_set(G_OBJECT(renderer), "client", priv->client, "owner", tv, "compact",
+                 style == TRG_STYLE_TR_COMPACT, NULL);
 
     g_signal_connect_object(prefs, "pref-changed",
-                            G_CALLBACK
-                            (trg_torrent_tree_view_renderer_pref_changed),
-                            renderer, G_CONNECT_AFTER);
+                            G_CALLBACK(trg_torrent_tree_view_renderer_pref_changed), renderer,
+                            G_CONNECT_AFTER);
 
     gtk_tree_view_column_set_resizable(column, FALSE);
     gtk_tree_view_column_set_reorderable(column, FALSE);
@@ -285,34 +194,28 @@ static void setup_transmission_layout(TrgTorrentTreeView * tv,
     gtk_tree_view_append_column(GTK_TREE_VIEW(tv), column);
 }
 
-static void
-trg_torrent_tree_view_pref_changed(TrgPrefs * p, const gchar * updatedKey,
-                                   gpointer data)
+static void trg_torrent_tree_view_pref_changed(TrgPrefs *p, const gchar *updatedKey, gpointer data)
 {
     if (!g_strcmp0(updatedKey, TRG_PREFS_KEY_STYLE)) {
         TrgTorrentTreeViewPrivate *priv = GET_PRIVATE(data);
         TrgPrefs *prefs = trg_client_get_prefs(priv->client);
 
         trg_tree_view_remove_all_columns(TRG_TREE_VIEW(data));
-        if (trg_prefs_get_int(p, TRG_PREFS_KEY_STYLE, TRG_PREFS_GLOBAL) ==
-            TRG_STYLE_CLASSIC)
+        if (trg_prefs_get_int(p, TRG_PREFS_KEY_STYLE, TRG_PREFS_GLOBAL) == TRG_STYLE_CLASSIC)
             setup_classic_layout(TRG_TORRENT_TREE_VIEW(data));
         else
-            setup_transmission_layout(TRG_TORRENT_TREE_VIEW(data),
-                                      trg_prefs_get_int(prefs,
-                                                        TRG_PREFS_KEY_STYLE,
-                                                        TRG_PREFS_GLOBAL));
+            setup_transmission_layout(
+                TRG_TORRENT_TREE_VIEW(data),
+                trg_prefs_get_int(prefs, TRG_PREFS_KEY_STYLE, TRG_PREFS_GLOBAL));
     }
 }
 
-TrgTorrentTreeView *trg_torrent_tree_view_new(TrgClient * tc,
-                                              GtkTreeModel * model)
+TrgTorrentTreeView *trg_torrent_tree_view_new(TrgClient *tc, GtkTreeModel *model)
 {
     GObject *obj = g_object_new(TRG_TYPE_TORRENT_TREE_VIEW, NULL);
     TrgTorrentTreeViewPrivate *priv = GET_PRIVATE(obj);
     TrgPrefs *prefs = trg_client_get_prefs(tc);
-    gint64 style =
-        trg_prefs_get_int(prefs, TRG_PREFS_KEY_STYLE, TRG_PREFS_GLOBAL);
+    gint64 style = trg_prefs_get_int(prefs, TRG_PREFS_KEY_STYLE, TRG_PREFS_GLOBAL);
 
     trg_tree_view_set_prefs(TRG_TREE_VIEW(obj), trg_client_get_prefs(tc));
     gtk_tree_view_set_model(GTK_TREE_VIEW(obj), model);
@@ -325,11 +228,9 @@ TrgTorrentTreeView *trg_torrent_tree_view_new(TrgClient * tc,
         setup_transmission_layout(TRG_TORRENT_TREE_VIEW(obj), style);
     }
 
-    g_signal_connect(prefs, "pref-changed",
-                     G_CALLBACK(trg_torrent_tree_view_pref_changed), obj);
+    g_signal_connect(prefs, "pref-changed", G_CALLBACK(trg_torrent_tree_view_pref_changed), obj);
 
-    trg_tree_view_restore_sort(TRG_TREE_VIEW(obj),
-                               TRG_TREE_VIEW_SORTABLE_PARENT);
+    trg_tree_view_restore_sort(TRG_TREE_VIEW(obj), TRG_TREE_VIEW_SORTABLE_PARENT);
 
     return TRG_TORRENT_TREE_VIEW(obj);
 }

--- a/src/trg-torrent-tree-view.h
+++ b/src/trg-torrent-tree-view.h
@@ -24,23 +24,23 @@
 #include <json-glib/json-glib.h>
 
 #include "trg-prefs.h"
+#include "trg-state-selector.h"
 #include "trg-torrent-model.h"
 #include "trg-tree-view.h"
-#include "trg-state-selector.h"
 
 G_BEGIN_DECLS
 #define TRG_TYPE_TORRENT_TREE_VIEW trg_torrent_tree_view_get_type()
-#define TRG_TORRENT_TREE_VIEW(obj) \
-  (G_TYPE_CHECK_INSTANCE_CAST ((obj), TRG_TYPE_TORRENT_TREE_VIEW, TrgTorrentTreeView))
-#define TRG_TORRENT_TREE_VIEW_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_CAST ((klass), TRG_TYPE_TORRENT_TREE_VIEW, TrgTorrentTreeViewClass))
-#define TRG_IS_TORRENT_TREE_VIEW(obj) \
-  (G_TYPE_CHECK_INSTANCE_TYPE ((obj), TRG_TYPE_TORRENT_TREE_VIEW))
-#define TRG_IS_TORRENT_TREE_VIEW_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_TYPE ((klass), TRG_TYPE_TORRENT_TREE_VIEW))
-#define TRG_TORRENT_TREE_VIEW_GET_CLASS(obj) \
-  (G_TYPE_INSTANCE_GET_CLASS ((obj), TRG_TYPE_TORRENT_TREE_VIEW, TrgTorrentTreeViewClass))
-    typedef struct {
+#define TRG_TORRENT_TREE_VIEW(obj)                                                                 \
+    (G_TYPE_CHECK_INSTANCE_CAST((obj), TRG_TYPE_TORRENT_TREE_VIEW, TrgTorrentTreeView))
+#define TRG_TORRENT_TREE_VIEW_CLASS(klass)                                                         \
+    (G_TYPE_CHECK_CLASS_CAST((klass), TRG_TYPE_TORRENT_TREE_VIEW, TrgTorrentTreeViewClass))
+#define TRG_IS_TORRENT_TREE_VIEW(obj)                                                              \
+    (G_TYPE_CHECK_INSTANCE_TYPE((obj), TRG_TYPE_TORRENT_TREE_VIEW))
+#define TRG_IS_TORRENT_TREE_VIEW_CLASS(klass)                                                      \
+    (G_TYPE_CHECK_CLASS_TYPE((klass), TRG_TYPE_TORRENT_TREE_VIEW))
+#define TRG_TORRENT_TREE_VIEW_GET_CLASS(obj)                                                       \
+    (G_TYPE_INSTANCE_GET_CLASS((obj), TRG_TYPE_TORRENT_TREE_VIEW, TrgTorrentTreeViewClass))
+typedef struct {
     TrgTreeView parent;
 } TrgTorrentTreeView;
 
@@ -50,9 +50,8 @@ typedef struct {
 
 GType trg_torrent_tree_view_get_type(void);
 
-TrgTorrentTreeView *trg_torrent_tree_view_new(TrgClient * tc,
-                                              GtkTreeModel * model);
-JsonArray *build_json_id_array(TrgTorrentTreeView * tv);
+TrgTorrentTreeView *trg_torrent_tree_view_new(TrgClient *tc, GtkTreeModel *model);
+JsonArray *build_json_id_array(TrgTorrentTreeView *tv);
 
 G_END_DECLS
-#endif                          /* _TRG_TORRENT_TREE_VIEW_H_ */
+#endif /* _TRG_TORRENT_TREE_VIEW_H_ */

--- a/src/trg-trackers-model.c
+++ b/src/trg-trackers-model.c
@@ -28,8 +28,8 @@
 #include "trg-trackers-model.h"
 
 G_DEFINE_TYPE(TrgTrackersModel, trg_trackers_model, GTK_TYPE_LIST_STORE)
-#define TRG_TRACKERS_MODEL_GET_PRIVATE(o) \
-  (G_TYPE_INSTANCE_GET_PRIVATE ((o), TRG_TYPE_TRACKERS_MODEL, TrgTrackersModelPrivate))
+#define TRG_TRACKERS_MODEL_GET_PRIVATE(o)                                                          \
+    (G_TYPE_INSTANCE_GET_PRIVATE((o), TRG_TYPE_TRACKERS_MODEL, TrgTrackersModelPrivate))
 typedef struct _TrgTrackersModelPrivate TrgTrackersModelPrivate;
 
 struct _TrgTrackersModelPrivate {
@@ -37,21 +37,20 @@ struct _TrgTrackersModelPrivate {
     gint64 accept;
 };
 
-void trg_trackers_model_set_no_selection(TrgTrackersModel * model)
+void trg_trackers_model_set_no_selection(TrgTrackersModel *model)
 {
     TrgTrackersModelPrivate *priv = TRG_TRACKERS_MODEL_GET_PRIVATE(model);
     priv->torrentId = -1;
 }
 
-gint64 trg_trackers_model_get_torrent_id(TrgTrackersModel * model)
+gint64 trg_trackers_model_get_torrent_id(TrgTrackersModel *model)
 {
     TrgTrackersModelPrivate *priv = TRG_TRACKERS_MODEL_GET_PRIVATE(model);
     return priv->torrentId;
 }
 
-void
-trg_trackers_model_update(TrgTrackersModel * model,
-                          gint64 updateSerial, JsonObject * t, gint mode)
+void trg_trackers_model_update(TrgTrackersModel *model, gint64 updateSerial, JsonObject *t,
+                               gint mode)
 {
     TrgTrackersModelPrivate *priv = TRG_TRACKERS_MODEL_GET_PRIVATE(model);
 
@@ -73,99 +72,73 @@ trg_trackers_model_update(TrgTrackersModel * model,
     trackers = json_array_get_elements(torrent_get_tracker_stats(t));
 
     for (li = trackers; li; li = g_list_next(li)) {
-        tracker = json_node_get_object((JsonNode *) li->data);
+        tracker = json_node_get_object((JsonNode *)li->data);
         trackerId = tracker_stats_get_id(tracker);
         announce = tracker_stats_get_announce(tracker);
         scrape = tracker_stats_get_scrape(tracker);
 
         if (mode == TORRENT_GET_MODE_FIRST
-            || find_existing_model_item(GTK_TREE_MODEL(model),
-                                        TRACKERCOL_ID, trackerId,
-                                        &trackIter) == FALSE)
+            || find_existing_model_item(GTK_TREE_MODEL(model), TRACKERCOL_ID, trackerId, &trackIter)
+                == FALSE)
             gtk_list_store_append(GTK_LIST_STORE(model), &trackIter);
 
 #ifdef DEBUG
-        gtk_list_store_set(GTK_LIST_STORE(model), &trackIter,
-                           TRACKERCOL_ICON, "network-workgroup", -1);
-        gtk_list_store_set(GTK_LIST_STORE(model), &trackIter,
-                           TRACKERCOL_TIER,
+        gtk_list_store_set(GTK_LIST_STORE(model), &trackIter, TRACKERCOL_ICON, "network-workgroup",
+                           -1);
+        gtk_list_store_set(GTK_LIST_STORE(model), &trackIter, TRACKERCOL_TIER,
                            tracker_stats_get_tier(tracker), -1);
-        gtk_list_store_set(GTK_LIST_STORE(model), &trackIter,
-                           TRACKERCOL_ANNOUNCE, announce, -1);
-        gtk_list_store_set(GTK_LIST_STORE(model), &trackIter,
-                           TRACKERCOL_SCRAPE, scrape, -1);
-        gtk_list_store_set(GTK_LIST_STORE(model), &trackIter,
-                           TRACKERCOL_ID, trackerId, -1);
-        gtk_list_store_set(GTK_LIST_STORE(model), &trackIter,
-                           TRACKERCOL_UPDATESERIAL, updateSerial, -1);
-        gtk_list_store_set(GTK_LIST_STORE(model), &trackIter,
-                           TRACKERCOL_LAST_ANNOUNCE_RESULT,
+        gtk_list_store_set(GTK_LIST_STORE(model), &trackIter, TRACKERCOL_ANNOUNCE, announce, -1);
+        gtk_list_store_set(GTK_LIST_STORE(model), &trackIter, TRACKERCOL_SCRAPE, scrape, -1);
+        gtk_list_store_set(GTK_LIST_STORE(model), &trackIter, TRACKERCOL_ID, trackerId, -1);
+        gtk_list_store_set(GTK_LIST_STORE(model), &trackIter, TRACKERCOL_UPDATESERIAL, updateSerial,
+                           -1);
+        gtk_list_store_set(GTK_LIST_STORE(model), &trackIter, TRACKERCOL_LAST_ANNOUNCE_RESULT,
                            tracker_stats_get_announce_result(tracker), -1);
-        gtk_list_store_set(GTK_LIST_STORE(model), &trackIter,
-                           TRACKERCOL_LAST_ANNOUNCE_TIME,
-                           tracker_stats_get_last_announce_time(tracker),
-                           -1);
-        gtk_list_store_set(GTK_LIST_STORE(model), &trackIter,
-                           TRACKERCOL_LAST_SCRAPE_TIME,
-                           tracker_stats_get_last_scrape_time(tracker),
-                           -1);
-        gtk_list_store_set(GTK_LIST_STORE(model), &trackIter,
-                           TRACKERCOL_HOST,
+        gtk_list_store_set(GTK_LIST_STORE(model), &trackIter, TRACKERCOL_LAST_ANNOUNCE_TIME,
+                           tracker_stats_get_last_announce_time(tracker), -1);
+        gtk_list_store_set(GTK_LIST_STORE(model), &trackIter, TRACKERCOL_LAST_SCRAPE_TIME,
+                           tracker_stats_get_last_scrape_time(tracker), -1);
+        gtk_list_store_set(GTK_LIST_STORE(model), &trackIter, TRACKERCOL_HOST,
                            tracker_stats_get_host(tracker), -1);
-        gtk_list_store_set(GTK_LIST_STORE(model), &trackIter,
-                           TRACKERCOL_LAST_ANNOUNCE_PEER_COUNT,
-                           tracker_stats_get_last_announce_peer_count
-                           (tracker), -1);
-        gtk_list_store_set(GTK_LIST_STORE(model), &trackIter,
-                           TRACKERCOL_LEECHERCOUNT,
+        gtk_list_store_set(GTK_LIST_STORE(model), &trackIter, TRACKERCOL_LAST_ANNOUNCE_PEER_COUNT,
+                           tracker_stats_get_last_announce_peer_count(tracker), -1);
+        gtk_list_store_set(GTK_LIST_STORE(model), &trackIter, TRACKERCOL_LEECHERCOUNT,
                            tracker_stats_get_leecher_count(tracker), -1);
-        gtk_list_store_set(GTK_LIST_STORE(model), &trackIter,
-                           TRACKERCOL_SEEDERCOUNT,
+        gtk_list_store_set(GTK_LIST_STORE(model), &trackIter, TRACKERCOL_SEEDERCOUNT,
                            tracker_stats_get_seeder_count(tracker), -1);
 #else
-        gtk_list_store_set(GTK_LIST_STORE(model), &trackIter,
-                           TRACKERCOL_ICON, "network-workgroup",
-                           TRACKERCOL_ID, trackerId,
-                           TRACKERCOL_UPDATESERIAL, updateSerial,
-                           TRACKERCOL_TIER,
-                           tracker_stats_get_tier(tracker),
-                           TRACKERCOL_ANNOUNCE, announce,
-                           TRACKERCOL_SCRAPE, scrape, TRACKERCOL_HOST,
-                           tracker_stats_get_host(tracker),
-                           TRACKERCOL_LAST_ANNOUNCE_RESULT,
-                           tracker_stats_get_announce_result(tracker),
-                           TRACKERCOL_LAST_ANNOUNCE_TIME,
-                           tracker_stats_get_last_announce_time(tracker),
-                           TRACKERCOL_LAST_SCRAPE_TIME,
-                           tracker_stats_get_last_scrape_time(tracker),
-                           TRACKERCOL_LAST_ANNOUNCE_PEER_COUNT,
-                           tracker_stats_get_last_announce_peer_count
-                           (tracker), TRACKERCOL_LEECHERCOUNT,
-                           tracker_stats_get_leecher_count(tracker),
-                           TRACKERCOL_SEEDERCOUNT,
-                           tracker_stats_get_seeder_count(tracker), -1);
+        gtk_list_store_set(
+            GTK_LIST_STORE(model), &trackIter, TRACKERCOL_ICON, "network-workgroup", TRACKERCOL_ID,
+            trackerId, TRACKERCOL_UPDATESERIAL, updateSerial, TRACKERCOL_TIER,
+            tracker_stats_get_tier(tracker), TRACKERCOL_ANNOUNCE, announce, TRACKERCOL_SCRAPE,
+            scrape, TRACKERCOL_HOST, tracker_stats_get_host(tracker),
+            TRACKERCOL_LAST_ANNOUNCE_RESULT, tracker_stats_get_announce_result(tracker),
+            TRACKERCOL_LAST_ANNOUNCE_TIME, tracker_stats_get_last_announce_time(tracker),
+            TRACKERCOL_LAST_SCRAPE_TIME, tracker_stats_get_last_scrape_time(tracker),
+            TRACKERCOL_LAST_ANNOUNCE_PEER_COUNT,
+            tracker_stats_get_last_announce_peer_count(tracker), TRACKERCOL_LEECHERCOUNT,
+            tracker_stats_get_leecher_count(tracker), TRACKERCOL_SEEDERCOUNT,
+            tracker_stats_get_seeder_count(tracker), -1);
 #endif
     }
 
     g_list_free(trackers);
 
-    trg_model_remove_removed(GTK_LIST_STORE(model),
-                             TRACKERCOL_UPDATESERIAL, updateSerial);
+    trg_model_remove_removed(GTK_LIST_STORE(model), TRACKERCOL_UPDATESERIAL, updateSerial);
 }
 
-static void trg_trackers_model_class_init(TrgTrackersModelClass * klass)
+static void trg_trackers_model_class_init(TrgTrackersModelClass *klass)
 {
     g_type_class_add_private(klass, sizeof(TrgTrackersModelPrivate));
 }
 
-void
-trg_trackers_model_set_accept(TrgTrackersModel * model, gboolean accept)
+void trg_trackers_model_set_accept(TrgTrackersModel *model, gboolean accept)
 {
     TrgTrackersModelPrivate *priv = TRG_TRACKERS_MODEL_GET_PRIVATE(model);
     priv->accept = accept;
 }
 
-static void trg_trackers_model_init(TrgTrackersModel * self)
+static void trg_trackers_model_init(TrgTrackersModel *self)
 {
     TrgTrackersModelPrivate *priv = TRG_TRACKERS_MODEL_GET_PRIVATE(self);
 
@@ -188,8 +161,7 @@ static void trg_trackers_model_init(TrgTrackersModel * self)
     priv->accept = TRUE;
     priv->torrentId = -1;
 
-    gtk_list_store_set_column_types(GTK_LIST_STORE(self),
-                                    TRACKERCOL_COLUMNS, column_types);
+    gtk_list_store_set_column_types(GTK_LIST_STORE(self), TRACKERCOL_COLUMNS, column_types);
 }
 
 TrgTrackersModel *trg_trackers_model_new(void)

--- a/src/trg-trackers-model.h
+++ b/src/trg-trackers-model.h
@@ -25,17 +25,16 @@
 
 G_BEGIN_DECLS
 #define TRG_TYPE_TRACKERS_MODEL trg_trackers_model_get_type()
-#define TRG_TRACKERS_MODEL(obj) \
-  (G_TYPE_CHECK_INSTANCE_CAST ((obj), TRG_TYPE_TRACKERS_MODEL, TrgTrackersModel))
-#define TRG_TRACKERS_MODEL_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_CAST ((klass), TRG_TYPE_TRACKERS_MODEL, TrgTrackersModelClass))
-#define TRG_IS_TRACKERS_MODEL(obj) \
-  (G_TYPE_CHECK_INSTANCE_TYPE ((obj), TRG_TYPE_TRACKERS_MODEL))
-#define TRG_IS_TRACKERS_MODEL_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_TYPE ((klass), TRG_TYPE_TRACKERS_MODEL))
-#define TRG_TRACKERS_MODEL_GET_CLASS(obj) \
-  (G_TYPE_INSTANCE_GET_CLASS ((obj), TRG_TYPE_TRACKERS_MODEL, TrgTrackersModelClass))
-    typedef struct {
+#define TRG_TRACKERS_MODEL(obj)                                                                    \
+    (G_TYPE_CHECK_INSTANCE_CAST((obj), TRG_TYPE_TRACKERS_MODEL, TrgTrackersModel))
+#define TRG_TRACKERS_MODEL_CLASS(klass)                                                            \
+    (G_TYPE_CHECK_CLASS_CAST((klass), TRG_TYPE_TRACKERS_MODEL, TrgTrackersModelClass))
+#define TRG_IS_TRACKERS_MODEL(obj) (G_TYPE_CHECK_INSTANCE_TYPE((obj), TRG_TYPE_TRACKERS_MODEL))
+#define TRG_IS_TRACKERS_MODEL_CLASS(klass)                                                         \
+    (G_TYPE_CHECK_CLASS_TYPE((klass), TRG_TYPE_TRACKERS_MODEL))
+#define TRG_TRACKERS_MODEL_GET_CLASS(obj)                                                          \
+    (G_TYPE_INSTANCE_GET_CLASS((obj), TRG_TYPE_TRACKERS_MODEL, TrgTrackersModelClass))
+typedef struct {
     GtkListStore parent;
 } TrgTrackersModel;
 
@@ -48,13 +47,11 @@ GType trg_trackers_model_get_type(void);
 TrgTrackersModel *trg_trackers_model_new(void);
 
 G_END_DECLS
-    void trg_trackers_model_update(TrgTrackersModel * model,
-                                   gint64 updateSerial, JsonObject * t,
-                                   gint mode);
-void trg_trackers_model_set_accept(TrgTrackersModel * model,
-                                   gboolean accept);
-gint64 trg_trackers_model_get_torrent_id(TrgTrackersModel * model);
-void trg_trackers_model_set_no_selection(TrgTrackersModel * model);
+void trg_trackers_model_update(TrgTrackersModel *model, gint64 updateSerial, JsonObject *t,
+                               gint mode);
+void trg_trackers_model_set_accept(TrgTrackersModel *model, gboolean accept);
+gint64 trg_trackers_model_get_torrent_id(TrgTrackersModel *model);
+void trg_trackers_model_set_no_selection(TrgTrackersModel *model);
 
 typedef enum {
     /* we won't (announce,scrape) this torrent to this tracker because
@@ -93,4 +90,4 @@ enum {
     TRACKERCOL_COLUMNS
 };
 
-#endif                          /* TRG_TRACKERS_MODEL_H_ */
+#endif /* TRG_TRACKERS_MODEL_H_ */

--- a/src/trg-trackers-tree-view.h
+++ b/src/trg-trackers-tree-view.h
@@ -23,24 +23,24 @@
 #include <glib-object.h>
 #include <gtk/gtk.h>
 
-#include "trg-trackers-model.h"
-#include "trg-tree-view.h"
 #include "trg-client.h"
 #include "trg-main-window.h"
+#include "trg-trackers-model.h"
+#include "trg-tree-view.h"
 
 G_BEGIN_DECLS
 #define TRG_TYPE_TRACKERS_TREE_VIEW trg_trackers_tree_view_get_type()
-#define TRG_TRACKERS_TREE_VIEW(obj) \
-  (G_TYPE_CHECK_INSTANCE_CAST ((obj), TRG_TYPE_TRACKERS_TREE_VIEW, TrgTrackersTreeView))
-#define TRG_TRACKERS_TREE_VIEW_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_CAST ((klass), TRG_TYPE_TRACKERS_TREE_VIEW, TrgTrackersTreeViewClass))
-#define TRG_IS_TRACKERS_TREE_VIEW(obj) \
-  (G_TYPE_CHECK_INSTANCE_TYPE ((obj), TRG_TYPE_TRACKERS_TREE_VIEW))
-#define TRG_IS_TRACKERS_TREE_VIEW_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_TYPE ((klass), TRG_TYPE_TRACKERS_TREE_VIEW))
-#define TRG_TRACKERS_TREE_VIEW_GET_CLASS(obj) \
-  (G_TYPE_INSTANCE_GET_CLASS ((obj), TRG_TYPE_TRACKERS_TREE_VIEW, TrgTrackersTreeViewClass))
-    typedef struct {
+#define TRG_TRACKERS_TREE_VIEW(obj)                                                                \
+    (G_TYPE_CHECK_INSTANCE_CAST((obj), TRG_TYPE_TRACKERS_TREE_VIEW, TrgTrackersTreeView))
+#define TRG_TRACKERS_TREE_VIEW_CLASS(klass)                                                        \
+    (G_TYPE_CHECK_CLASS_CAST((klass), TRG_TYPE_TRACKERS_TREE_VIEW, TrgTrackersTreeViewClass))
+#define TRG_IS_TRACKERS_TREE_VIEW(obj)                                                             \
+    (G_TYPE_CHECK_INSTANCE_TYPE((obj), TRG_TYPE_TRACKERS_TREE_VIEW))
+#define TRG_IS_TRACKERS_TREE_VIEW_CLASS(klass)                                                     \
+    (G_TYPE_CHECK_CLASS_TYPE((klass), TRG_TYPE_TRACKERS_TREE_VIEW))
+#define TRG_TRACKERS_TREE_VIEW_GET_CLASS(obj)                                                      \
+    (G_TYPE_INSTANCE_GET_CLASS((obj), TRG_TYPE_TRACKERS_TREE_VIEW, TrgTrackersTreeViewClass))
+typedef struct {
     TrgTreeView parent;
 } TrgTrackersTreeView;
 
@@ -50,12 +50,9 @@ typedef struct {
 
 GType trg_trackers_tree_view_get_type(void);
 
-TrgTrackersTreeView *trg_trackers_tree_view_new(TrgTrackersModel * model,
-                                                TrgClient * client,
-                                                TrgMainWindow * win,
-                                                const gchar * configId);
-void trg_trackers_tree_view_new_connection(TrgTrackersTreeView * tv,
-                                           TrgClient * tc);
+TrgTrackersTreeView *trg_trackers_tree_view_new(TrgTrackersModel *model, TrgClient *client,
+                                                TrgMainWindow *win, const gchar *configId);
+void trg_trackers_tree_view_new_connection(TrgTrackersTreeView *tv, TrgClient *tc);
 
 G_END_DECLS
-#endif                          /* TRG_TRACKERS_TREE_VIEW_H_ */
+#endif /* TRG_TRACKERS_TREE_VIEW_H_ */

--- a/src/trg-tree-view.c
+++ b/src/trg-tree-view.c
@@ -19,22 +19,22 @@
 
 #include "config.h"
 
-#include <stdlib.h>
+#include <glib/gi18n.h>
 #include <gtk/gtk.h>
 #include <json-glib/json-glib.h>
-#include <glib/gi18n.h>
+#include <stdlib.h>
 
+#include "trg-cell-renderer-epoch.h"
+#include "trg-cell-renderer-eta.h"
+#include "trg-cell-renderer-file-icon.h"
+#include "trg-cell-renderer-numgteqthan.h"
+#include "trg-cell-renderer-priority.h"
+#include "trg-cell-renderer-ratio.h"
+#include "trg-cell-renderer-size.h"
+#include "trg-cell-renderer-speed.h"
+#include "trg-cell-renderer-wanted.h"
 #include "trg-prefs.h"
 #include "trg-tree-view.h"
-#include "trg-cell-renderer-speed.h"
-#include "trg-cell-renderer-size.h"
-#include "trg-cell-renderer-ratio.h"
-#include "trg-cell-renderer-wanted.h"
-#include "trg-cell-renderer-eta.h"
-#include "trg-cell-renderer-epoch.h"
-#include "trg-cell-renderer-priority.h"
-#include "trg-cell-renderer-numgteqthan.h"
-#include "trg-cell-renderer-file-icon.h"
 
 /* A subclass of GtkTreeView which allows the user to change column visibility
  * by right clicking on any column for a menu to hide the clicked column, or
@@ -48,18 +48,21 @@
  */
 
 enum {
-    PROP_0, PROP_PREFS, PROP_CONFIGID
+    PROP_0,
+    PROP_PREFS,
+    PROP_CONFIGID
 };
 
 enum {
-	SIGNAL_COLUMN_ADDED, SIGNAL_COUNT
+    SIGNAL_COLUMN_ADDED,
+    SIGNAL_COUNT
 };
 
 static guint signals[SIGNAL_COUNT] = { 0 };
 
 G_DEFINE_TYPE(TrgTreeView, trg_tree_view, GTK_TYPE_TREE_VIEW)
-#define TRG_TREE_VIEW_GET_PRIVATE(o) \
-  (G_TYPE_INSTANCE_GET_PRIVATE ((o), TRG_TYPE_TREE_VIEW, TrgTreeViewPrivate))
+#define TRG_TREE_VIEW_GET_PRIVATE(o)                                                               \
+    (G_TYPE_INSTANCE_GET_PRIVATE((o), TRG_TYPE_TREE_VIEW, TrgTreeViewPrivate))
 typedef struct _TrgTreeViewPrivate TrgTreeViewPrivate;
 
 struct _TrgTreeViewPrivate {
@@ -70,13 +73,13 @@ struct _TrgTreeViewPrivate {
 
 #define GDATA_KEY_COLUMN_DESC "column-desc"
 
-gboolean trg_tree_view_is_column_showing(TrgTreeView * tv, gint index)
+gboolean trg_tree_view_is_column_showing(TrgTreeView *tv, gint index)
 {
     TrgTreeViewPrivate *priv = TRG_TREE_VIEW_GET_PRIVATE(tv);
 
     GList *li;
     for (li = priv->columns; li; li = g_list_next(li)) {
-        trg_column_description *cd = (trg_column_description *) li->data;
+        trg_column_description *cd = (trg_column_description *)li->data;
         if (cd->model_column == index) {
             if (cd->flags & TRG_COLUMN_SHOWING)
                 return TRUE;
@@ -88,8 +91,7 @@ gboolean trg_tree_view_is_column_showing(TrgTreeView * tv, gint index)
     return FALSE;
 }
 
-static void
-trg_column_description_free(trg_column_description * desc)
+static void trg_column_description_free(trg_column_description *desc)
 {
     if (desc) {
         g_free(desc->header);
@@ -98,16 +100,14 @@ trg_column_description_free(trg_column_description * desc)
     }
 }
 
-static void
-trg_tree_view_get_property(GObject * object, guint property_id,
-                           GValue * value, GParamSpec * pspec)
+static void trg_tree_view_get_property(GObject *object, guint property_id, GValue *value,
+                                       GParamSpec *pspec)
 {
     G_OBJECT_WARN_INVALID_PROPERTY_ID(object, property_id, pspec);
 }
 
-static void
-trg_tree_view_set_property(GObject * object, guint property_id,
-                           const GValue * value, GParamSpec * pspec)
+static void trg_tree_view_set_property(GObject *object, guint property_id, const GValue *value,
+                                       GParamSpec *pspec)
 {
     TrgTreeViewPrivate *priv = TRG_TREE_VIEW_GET_PRIVATE(object);
     switch (property_id) {
@@ -124,26 +124,21 @@ trg_tree_view_set_property(GObject * object, guint property_id,
     }
 }
 
-static GObject *trg_tree_view_constructor(GType type,
-                                          guint n_construct_properties,
-                                          GObjectConstructParam *
-                                          construct_params)
+static GObject *trg_tree_view_constructor(GType type, guint n_construct_properties,
+                                          GObjectConstructParam *construct_params)
 {
-    GObject *obj = G_OBJECT_CLASS
-        (trg_tree_view_parent_class)->constructor(type,
-                                                  n_construct_properties,
-                                                  construct_params);
+    GObject *obj = G_OBJECT_CLASS(trg_tree_view_parent_class)
+                       ->constructor(type, n_construct_properties, construct_params);
 
     return obj;
 }
 
-static JsonObject *trg_prefs_get_tree_view_props(TrgTreeView * tv)
+static JsonObject *trg_prefs_get_tree_view_props(TrgTreeView *tv)
 {
     TrgTreeViewPrivate *priv = TRG_TREE_VIEW_GET_PRIVATE(tv);
     JsonObject *root = trg_prefs_get_root(priv->prefs);
-    const gchar *className = priv->configId
-        && strlen(priv->configId) >
-        0 ? priv->configId : G_OBJECT_TYPE_NAME(tv);
+    const gchar *className
+        = priv->configId && strlen(priv->configId) > 0 ? priv->configId : G_OBJECT_TYPE_NAME(tv);
     JsonObject *obj;
     JsonObject *tvProps = NULL;
 
@@ -151,8 +146,7 @@ static JsonObject *trg_prefs_get_tree_view_props(TrgTreeView * tv)
         obj = json_object_new();
         json_object_set_object_member(root, TRG_PREFS_KEY_TREE_VIEWS, obj);
     } else {
-        obj =
-            json_object_get_object_member(root, TRG_PREFS_KEY_TREE_VIEWS);
+        obj = json_object_get_object_member(root, TRG_PREFS_KEY_TREE_VIEWS);
     }
 
     if (!json_object_has_member(obj, className)) {
@@ -165,17 +159,11 @@ static JsonObject *trg_prefs_get_tree_view_props(TrgTreeView * tv)
     return tvProps;
 }
 
-static void trg_tree_view_add_column_after(TrgTreeView * tv,
-                                           trg_column_description * desc,
-                                           gint64 width,
-                                           GtkTreeViewColumn * after_col);
+static void trg_tree_view_add_column_after(TrgTreeView *tv, trg_column_description *desc,
+                                           gint64 width, GtkTreeViewColumn *after_col);
 
-trg_column_description *trg_tree_view_reg_column(TrgTreeView * tv,
-                                                 gint type,
-                                                 gint model_column,
-                                                 const gchar * header,
-                                                 const gchar * id,
-                                                 guint flags)
+trg_column_description *trg_tree_view_reg_column(TrgTreeView *tv, gint type, gint model_column,
+                                                 const gchar *header, const gchar *id, guint flags)
 {
     TrgTreeViewPrivate *priv = TRG_TREE_VIEW_GET_PRIVATE(tv);
     trg_column_description *desc = g_new0(trg_column_description, 1);
@@ -191,15 +179,14 @@ trg_column_description *trg_tree_view_reg_column(TrgTreeView * tv,
     return desc;
 }
 
-static trg_column_description *trg_tree_view_find_column(TrgTreeView * tv,
-                                                         const gchar * id)
+static trg_column_description *trg_tree_view_find_column(TrgTreeView *tv, const gchar *id)
 {
     TrgTreeViewPrivate *priv = TRG_TREE_VIEW_GET_PRIVATE(tv);
     GList *li;
     trg_column_description *desc;
 
     for (li = priv->columns; li; li = g_list_next(li)) {
-        desc = (trg_column_description *) li->data;
+        desc = (trg_column_description *)li->data;
         if (!g_strcmp0(desc->id, id))
             return desc;
     }
@@ -207,76 +194,61 @@ static trg_column_description *trg_tree_view_find_column(TrgTreeView * tv,
     return NULL;
 }
 
-static void
-trg_tree_view_hide_column(GtkWidget * w, GtkTreeViewColumn * col)
+static void trg_tree_view_hide_column(GtkWidget *w, GtkTreeViewColumn *col)
 {
-    trg_column_description *desc = g_object_get_data(G_OBJECT(col),
-                                                     GDATA_KEY_COLUMN_DESC);
+    trg_column_description *desc = g_object_get_data(G_OBJECT(col), GDATA_KEY_COLUMN_DESC);
     GtkWidget *tv = gtk_tree_view_column_get_tree_view(col);
     desc->flags &= ~TRG_COLUMN_SHOWING;
     gtk_tree_view_remove_column(GTK_TREE_VIEW(tv), col);
 }
 
-static void
-trg_tree_view_add_column(TrgTreeView * tv,
-                         trg_column_description * desc, gint64 width)
+static void trg_tree_view_add_column(TrgTreeView *tv, trg_column_description *desc, gint64 width)
 {
     trg_tree_view_add_column_after(tv, desc, width, NULL);
 }
 
-static void
-trg_tree_view_user_add_column_cb(GtkWidget * w,
-                                 trg_column_description * desc)
+static void trg_tree_view_user_add_column_cb(GtkWidget *w, trg_column_description *desc)
 {
     GtkTreeViewColumn *col = g_object_get_data(G_OBJECT(w), "parent-col");
-    TrgTreeView *tv =
-        TRG_TREE_VIEW(gtk_tree_view_column_get_tree_view(col));
+    TrgTreeView *tv = TRG_TREE_VIEW(gtk_tree_view_column_get_tree_view(col));
 
     trg_tree_view_add_column_after(tv, desc, -1, col);
 
     g_signal_emit(tv, signals[SIGNAL_COLUMN_ADDED], 0, desc->id);
 }
 
-static void trg_tree_view_sort_menu_item_toggled(GtkCheckMenuItem * w,
-                                                 gpointer data)
+static void trg_tree_view_sort_menu_item_toggled(GtkCheckMenuItem *w, gpointer data)
 {
     GtkTreeSortable *model = GTK_TREE_SORTABLE(data);
-    trg_column_description *desc =
-        (trg_column_description *) g_object_get_data(G_OBJECT(w),
-                                                     GDATA_KEY_COLUMN_DESC);
+    trg_column_description *desc
+        = (trg_column_description *)g_object_get_data(G_OBJECT(w), GDATA_KEY_COLUMN_DESC);
 
     if (gtk_check_menu_item_get_active(w)) {
         GtkSortType sortType;
         gtk_tree_sortable_get_sort_column_id(model, NULL, &sortType);
-        gtk_tree_sortable_set_sort_column_id(model, desc->model_column,
-                                             sortType);
+        gtk_tree_sortable_set_sort_column_id(model, desc->model_column, sortType);
     }
 }
 
-static void trg_tree_view_sort_menu_type_toggled(GtkCheckMenuItem * w,
-                                                 gpointer data)
+static void trg_tree_view_sort_menu_type_toggled(GtkCheckMenuItem *w, gpointer data)
 {
     GtkTreeSortable *model = GTK_TREE_SORTABLE(data);
 
     if (gtk_check_menu_item_get_active(w)) {
         gint sortColumn;
-        gint sortType =
-            GPOINTER_TO_INT(g_object_get_data(G_OBJECT(w), "sort-type"));
+        gint sortType = GPOINTER_TO_INT(g_object_get_data(G_OBJECT(w), "sort-type"));
         gtk_tree_sortable_get_sort_column_id(model, &sortColumn, NULL);
         gtk_tree_sortable_set_sort_column_id(model, sortColumn, sortType);
     }
 }
 
-
-GtkWidget *trg_tree_view_sort_menu(TrgTreeView * tv, const gchar * label)
+GtkWidget *trg_tree_view_sort_menu(TrgTreeView *tv, const gchar *label)
 {
     TrgTreeViewPrivate *priv = TRG_TREE_VIEW_GET_PRIVATE(tv);
     GtkWidget *item = gtk_menu_item_new_with_mnemonic(label);
-    GtkTreeModel *treeViewModel =
-        gtk_tree_view_get_model(GTK_TREE_VIEW(tv));
-    GtkTreeSortable *sortableModel =
-        GTK_TREE_SORTABLE(gtk_tree_model_filter_get_model
-                          (GTK_TREE_MODEL_FILTER(treeViewModel)));
+    GtkTreeModel *treeViewModel = gtk_tree_view_get_model(GTK_TREE_VIEW(tv));
+    GtkTreeSortable *sortableModel
+        = GTK_TREE_SORTABLE(gtk_tree_model_filter_get_model(GTK_TREE_MODEL_FILTER(treeViewModel)));
     GtkWidget *menu = gtk_menu_new();
     GtkWidget *b;
     GList *li;
@@ -287,44 +259,32 @@ GtkWidget *trg_tree_view_sort_menu(TrgTreeView * tv, const gchar * label)
     gtk_tree_sortable_get_sort_column_id(sortableModel, &sort, &sortType);
 
     b = gtk_radio_menu_item_new_with_label(group, _("Ascending"));
-    gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(b),
-                                   sortType == GTK_SORT_ASCENDING);
-    g_object_set_data(G_OBJECT(b), "sort-type",
-                      GINT_TO_POINTER(GTK_SORT_ASCENDING));
-    g_signal_connect(b, "toggled",
-                     G_CALLBACK(trg_tree_view_sort_menu_type_toggled),
-                     sortableModel);
+    gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(b), sortType == GTK_SORT_ASCENDING);
+    g_object_set_data(G_OBJECT(b), "sort-type", GINT_TO_POINTER(GTK_SORT_ASCENDING));
+    g_signal_connect(b, "toggled", G_CALLBACK(trg_tree_view_sort_menu_type_toggled), sortableModel);
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), b);
     group = gtk_radio_menu_item_get_group(GTK_RADIO_MENU_ITEM(b));
     b = gtk_radio_menu_item_new_with_label(group, _("Descending"));
-    gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(b),
-                                   sortType == GTK_SORT_DESCENDING);
-    g_object_set_data(G_OBJECT(b), "sort-type",
-                      GINT_TO_POINTER(GTK_SORT_DESCENDING));
-    g_signal_connect(b, "toggled",
-                     G_CALLBACK(trg_tree_view_sort_menu_type_toggled),
-                     sortableModel);
+    gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(b), sortType == GTK_SORT_DESCENDING);
+    g_object_set_data(G_OBJECT(b), "sort-type", GINT_TO_POINTER(GTK_SORT_DESCENDING));
+    g_signal_connect(b, "toggled", G_CALLBACK(trg_tree_view_sort_menu_type_toggled), sortableModel);
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), b);
 
     group = NULL;
 
-    gtk_menu_shell_append(GTK_MENU_SHELL(menu),
-                          gtk_separator_menu_item_new());
+    gtk_menu_shell_append(GTK_MENU_SHELL(menu), gtk_separator_menu_item_new());
 
     for (li = priv->columns; li; li = g_list_next(li)) {
-        trg_column_description *desc = (trg_column_description *) li->data;
+        trg_column_description *desc = (trg_column_description *)li->data;
         if (!(desc->flags & TRG_COLUMN_HIDE_FROM_TOP_MENU)) {
             b = gtk_radio_menu_item_new_with_label(group, desc->header);
             group = gtk_radio_menu_item_get_group(GTK_RADIO_MENU_ITEM(b));
 
             if (desc->model_column == sort)
-                gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(b),
-                                               TRUE);
+                gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(b), TRUE);
 
             g_object_set_data(G_OBJECT(b), GDATA_KEY_COLUMN_DESC, desc);
-            g_signal_connect(b, "toggled",
-                             G_CALLBACK
-                             (trg_tree_view_sort_menu_item_toggled),
+            g_signal_connect(b, "toggled", G_CALLBACK(trg_tree_view_sort_menu_item_toggled),
                              sortableModel);
 
             gtk_menu_shell_append(GTK_MENU_SHELL(menu), b);
@@ -336,9 +296,7 @@ GtkWidget *trg_tree_view_sort_menu(TrgTreeView * tv, const gchar * label)
     return item;
 }
 
-static void
-view_popup_menu(GtkButton * button, GdkEventButton * event,
-                GtkTreeViewColumn * column)
+static void view_popup_menu(GtkButton *button, GdkEventButton *event, GtkTreeViewColumn *column)
 {
     GtkWidget *tv = gtk_tree_view_column_get_tree_view(column);
     TrgTreeViewPrivate *priv = TRG_TREE_VIEW_GET_PRIVATE(tv);
@@ -352,30 +310,27 @@ view_popup_menu(GtkButton * button, GdkEventButton * event,
     desc = g_object_get_data(G_OBJECT(column), GDATA_KEY_COLUMN_DESC);
 
     for (li = priv->columns; li; li = g_list_next(li)) {
-        trg_column_description *desc = (trg_column_description *) li->data;
+        trg_column_description *desc = (trg_column_description *)li->data;
         if (!(desc->flags & TRG_COLUMN_SHOWING)) {
             menuitem = gtk_check_menu_item_new_with_label(desc->header);
             g_object_set_data(G_OBJECT(menuitem), "parent-col", column);
-            g_signal_connect(menuitem, "activate",
-                             G_CALLBACK(trg_tree_view_user_add_column_cb),
+            g_signal_connect(menuitem, "activate", G_CALLBACK(trg_tree_view_user_add_column_cb),
                              desc);
             gtk_menu_shell_append(GTK_MENU_SHELL(menu), menuitem);
         } else {
-        	n_showing++;
+            n_showing++;
         }
     }
 
     menuitem = gtk_check_menu_item_new_with_label(desc->header);
     gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(menuitem), TRUE);
-    g_signal_connect(menuitem, "activate",
-                     G_CALLBACK(trg_tree_view_hide_column), column);
-    gtk_widget_set_sensitive(menuitem,
-                             !(desc->flags & TRG_COLUMN_UNREMOVABLE) && n_showing > 1);
+    g_signal_connect(menuitem, "activate", G_CALLBACK(trg_tree_view_hide_column), column);
+    gtk_widget_set_sensitive(menuitem, !(desc->flags & TRG_COLUMN_UNREMOVABLE) && n_showing > 1);
     gtk_menu_shell_prepend(GTK_MENU_SHELL(menu), menuitem);
 
     gtk_widget_show_all(menu);
 
-    gtk_menu_popup_at_pointer(GTK_MENU(menu), (GdkEvent*)event);
+    gtk_menu_popup_at_pointer(GTK_MENU(menu), (GdkEvent *)event);
 }
 
 /* This used to get the column as an argument binded when the signal was
@@ -383,20 +338,19 @@ view_popup_menu(GtkButton * button, GdkEventButton * event,
  * circumstances. So bind the column description instead and search for the
  * column by its title.
  */
-static gboolean
-col_onButtonPressed(GtkButton * button,
-                    GdkEventButton * event, trg_column_description *desc)
+static gboolean col_onButtonPressed(GtkButton *button, GdkEventButton *event,
+                                    trg_column_description *desc)
 {
     if (event->type == GDK_BUTTON_PRESS && event->button == 3) {
-    	GtkTreeView *gtv = GTK_TREE_VIEW(gtk_widget_get_parent(GTK_WIDGET(button)));
+        GtkTreeView *gtv = GTK_TREE_VIEW(gtk_widget_get_parent(GTK_WIDGET(button)));
         GList *cols = gtk_tree_view_get_columns(gtv);
         GList *li;
         for (li = cols; li; li = g_list_next(li)) {
-        	GtkTreeViewColumn *col = GTK_TREE_VIEW_COLUMN(li->data);
-        	if (!g_strcmp0(desc->header, gtk_tree_view_column_get_title(col))) {
-        		view_popup_menu(button, event, col);
-        		break;
-        	}
+            GtkTreeViewColumn *col = GTK_TREE_VIEW_COLUMN(li->data);
+            if (!g_strcmp0(desc->header, gtk_tree_view_column_get_title(col))) {
+                view_popup_menu(button, event, col);
+                break;
+            }
         }
         g_list_free(cols);
 
@@ -406,53 +360,43 @@ col_onButtonPressed(GtkButton * button,
     return FALSE;
 }
 
-static GtkTreeViewColumn
-    * trg_tree_view_icontext_column_new(trg_column_description * desc,
-                                        gchar * renderer_property)
+static GtkTreeViewColumn *trg_tree_view_icontext_column_new(trg_column_description *desc,
+                                                            gchar *renderer_property)
 {
     GtkTreeViewColumn *column = gtk_tree_view_column_new();
     GtkCellRenderer *renderer = gtk_cell_renderer_pixbuf_new();
 
     gtk_tree_view_column_set_title(column, desc->header);
     gtk_tree_view_column_pack_start(column, renderer, FALSE);
-    gtk_tree_view_column_set_attributes(column, renderer,
-                                        renderer_property,
+    gtk_tree_view_column_set_attributes(column, renderer, renderer_property,
                                         desc->model_column_extra, NULL);
 
     renderer = gtk_cell_renderer_text_new();
     gtk_tree_view_column_pack_start(column, renderer, TRUE);
-    gtk_tree_view_column_set_attributes(column, renderer, "text",
-                                        desc->model_column, NULL);
+    gtk_tree_view_column_set_attributes(column, renderer, "text", desc->model_column, NULL);
 
     return column;
 }
 
-static GtkTreeViewColumn
-    * trg_tree_view_fileicontext_column_new(trg_column_description * desc)
+static GtkTreeViewColumn *trg_tree_view_fileicontext_column_new(trg_column_description *desc)
 {
     GtkTreeViewColumn *column = gtk_tree_view_column_new();
     GtkCellRenderer *renderer = trg_cell_renderer_file_icon_new();
 
     gtk_tree_view_column_set_title(column, desc->header);
     gtk_tree_view_column_pack_start(column, renderer, FALSE);
-    gtk_tree_view_column_set_attributes(column, renderer,
-                                        "file-id",
-                                        desc->model_column_extra,
-                                        "file-name", desc->model_column,
-                                        NULL);
+    gtk_tree_view_column_set_attributes(column, renderer, "file-id", desc->model_column_extra,
+                                        "file-name", desc->model_column, NULL);
 
     renderer = gtk_cell_renderer_text_new();
     gtk_tree_view_column_pack_start(column, renderer, TRUE);
-    gtk_tree_view_column_set_attributes(column, renderer, "text",
-                                        desc->model_column, NULL);
+    gtk_tree_view_column_set_attributes(column, renderer, "text", desc->model_column, NULL);
 
     return column;
 }
 
-static void
-trg_tree_view_add_column_after(TrgTreeView * tv,
-                               trg_column_description * desc,
-                               gint64 width, GtkTreeViewColumn * after_col)
+static void trg_tree_view_add_column_after(TrgTreeView *tv, trg_column_description *desc,
+                                           gint64 width, GtkTreeViewColumn *after_col)
 {
     GtkCellRenderer *renderer;
     GtkTreeViewColumn *column = NULL;
@@ -460,69 +404,40 @@ trg_tree_view_add_column_after(TrgTreeView * tv,
 
     switch (desc->type) {
     case TRG_COLTYPE_TEXT:
-        renderer =
-            desc->customRenderer ? desc->customRenderer :
-            gtk_cell_renderer_text_new();
-        column = gtk_tree_view_column_new_with_attributes(desc->header,
-                                                          renderer, "text",
-                                                          desc->
-                                                          model_column,
-                                                          NULL);
+        renderer = desc->customRenderer ? desc->customRenderer : gtk_cell_renderer_text_new();
+        column = gtk_tree_view_column_new_with_attributes(desc->header, renderer, "text",
+                                                          desc->model_column, NULL);
 
         break;
     case TRG_COLTYPE_SPEED:
         renderer = trg_cell_renderer_speed_new();
-        column = gtk_tree_view_column_new_with_attributes(desc->header,
-                                                          renderer,
-                                                          "speed-value",
-                                                          desc->
-                                                          model_column,
-                                                          NULL);
+        column = gtk_tree_view_column_new_with_attributes(desc->header, renderer, "speed-value",
+                                                          desc->model_column, NULL);
         break;
     case TRG_COLTYPE_EPOCH:
         renderer = trg_cell_renderer_epoch_new();
-        column = gtk_tree_view_column_new_with_attributes(desc->header,
-                                                          renderer,
-                                                          "epoch-value",
-                                                          desc->
-                                                          model_column,
-                                                          NULL);
+        column = gtk_tree_view_column_new_with_attributes(desc->header, renderer, "epoch-value",
+                                                          desc->model_column, NULL);
         break;
     case TRG_COLTYPE_ETA:
         renderer = trg_cell_renderer_eta_new();
-        column = gtk_tree_view_column_new_with_attributes(desc->header,
-                                                          renderer,
-                                                          "eta-value",
-                                                          desc->
-                                                          model_column,
-                                                          NULL);
+        column = gtk_tree_view_column_new_with_attributes(desc->header, renderer, "eta-value",
+                                                          desc->model_column, NULL);
         break;
     case TRG_COLTYPE_SIZE:
         renderer = trg_cell_renderer_size_new();
-        column = gtk_tree_view_column_new_with_attributes(desc->header,
-                                                          renderer,
-                                                          "size-value",
-                                                          desc->
-                                                          model_column,
-                                                          NULL);
+        column = gtk_tree_view_column_new_with_attributes(desc->header, renderer, "size-value",
+                                                          desc->model_column, NULL);
         break;
     case TRG_COLTYPE_PROG:
         renderer = gtk_cell_renderer_progress_new();
-        column = gtk_tree_view_column_new_with_attributes(desc->header,
-                                                          renderer,
-                                                          "value",
-                                                          desc->
-                                                          model_column,
-                                                          NULL);
+        column = gtk_tree_view_column_new_with_attributes(desc->header, renderer, "value",
+                                                          desc->model_column, NULL);
         break;
     case TRG_COLTYPE_RATIO:
         renderer = trg_cell_renderer_ratio_new();
-        column = gtk_tree_view_column_new_with_attributes(desc->header,
-                                                          renderer,
-                                                          "ratio-value",
-                                                          desc->
-                                                          model_column,
-                                                          NULL);
+        column = gtk_tree_view_column_new_with_attributes(desc->header, renderer, "ratio-value",
+                                                          desc->model_column, NULL);
         break;
     case TRG_COLTYPE_WANTED:
         column = gtk_tree_view_column_new();
@@ -531,9 +446,8 @@ trg_tree_view_add_column_after(TrgTreeView * tv,
            0.0); */
         gtk_tree_view_column_set_title(column, desc->header);
         gtk_tree_view_column_pack_start(column, renderer, TRUE);
-        gtk_tree_view_column_set_attributes(column, renderer,
-                                            "wanted-value",
-                                            desc->model_column, NULL);
+        gtk_tree_view_column_set_attributes(column, renderer, "wanted-value", desc->model_column,
+                                            NULL);
         break;
     case TRG_COLTYPE_ICONTEXT:
         column = trg_tree_view_icontext_column_new(desc, "icon-name");
@@ -543,37 +457,25 @@ trg_tree_view_add_column_after(TrgTreeView * tv,
         break;
     case TRG_COLTYPE_PRIO:
         renderer = trg_cell_renderer_priority_new();
-        column = gtk_tree_view_column_new_with_attributes(desc->header,
-                                                          renderer,
-                                                          "priority-value",
-                                                          desc->
-                                                          model_column,
-                                                          NULL);
+        column = gtk_tree_view_column_new_with_attributes(desc->header, renderer, "priority-value",
+                                                          desc->model_column, NULL);
         break;
     case TRG_COLTYPE_NUMGTZERO:
         renderer = trg_cell_renderer_numgteqthan_new(1);
-        column = gtk_tree_view_column_new_with_attributes(desc->header,
-                                                          renderer,
-                                                          "value",
-                                                          desc->
-                                                          model_column,
-                                                          NULL);
+        column = gtk_tree_view_column_new_with_attributes(desc->header, renderer, "value",
+                                                          desc->model_column, NULL);
         break;
     case TRG_COLTYPE_NUMGTEQZERO:
         renderer = trg_cell_renderer_numgteqthan_new(0);
-        column = gtk_tree_view_column_new_with_attributes(desc->header,
-                                                          renderer,
-                                                          "value",
-                                                          desc->
-                                                          model_column,
-                                                          NULL);
+        column = gtk_tree_view_column_new_with_attributes(desc->header, renderer, "value",
+                                                          desc->model_column, NULL);
         break;
     default:
         g_critical("unknown TrgTreeView column");
         return;
     }
 
-    //gtk_tree_view_column_set_min_width(column, 0);
+    // gtk_tree_view_column_set_min_width(column, 0);
     gtk_tree_view_column_set_resizable(column, TRUE);
     gtk_tree_view_column_set_reorderable(column, TRUE);
     gtk_tree_view_column_set_sort_column_id(column, desc->model_column);
@@ -583,7 +485,7 @@ trg_tree_view_add_column_after(TrgTreeView * tv,
                                     GTK_TREE_VIEW_COLUMN_FIXED);*/
 
     if (width > 0) {
-        //gtk_tree_view_column_set_fixed_width(column, width);
+        // gtk_tree_view_column_set_fixed_width(column, width);
     }
 
     g_object_set_data(G_OBJECT(column), GDATA_KEY_COLUMN_DESC, desc);
@@ -591,14 +493,11 @@ trg_tree_view_add_column_after(TrgTreeView * tv,
     gtk_tree_view_append_column(GTK_TREE_VIEW(tv), column);
 
     if (after_col)
-        gtk_tree_view_move_column_after(GTK_TREE_VIEW(tv), column,
-                                        after_col);
+        gtk_tree_view_move_column_after(GTK_TREE_VIEW(tv), column, after_col);
 
     column_button = GTK_BUTTON(gtk_tree_view_column_get_button(column));
 
-    g_signal_connect(column_button,
-                     "button-press-event", G_CALLBACK(col_onButtonPressed),
-                     desc);
+    g_signal_connect(column_button, "button-press-event", G_CALLBACK(col_onButtonPressed), desc);
 
     if (desc->out)
         *(desc->out) = column;
@@ -606,7 +505,7 @@ trg_tree_view_add_column_after(TrgTreeView * tv,
     desc->flags |= TRG_COLUMN_SHOWING;
 }
 
-void trg_tree_view_remove_all_columns(TrgTreeView * tv)
+void trg_tree_view_remove_all_columns(TrgTreeView *tv)
 {
     GtkTreeView *gtv = GTK_TREE_VIEW(tv);
     GList *cols = gtk_tree_view_get_columns(gtv);
@@ -617,7 +516,7 @@ void trg_tree_view_remove_all_columns(TrgTreeView * tv)
     g_list_free(cols);
 }
 
-void trg_tree_view_persist(TrgTreeView * tv, guint flags)
+void trg_tree_view_persist(TrgTreeView *tv, guint flags)
 {
     JsonObject *props = trg_prefs_get_tree_view_props(tv);
     GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(tv));
@@ -627,14 +526,11 @@ void trg_tree_view_persist(TrgTreeView * tv, guint flags)
     GtkSortType sort_type;
 
     if (flags & TRG_TREE_VIEW_PERSIST_SORT) {
-        gtk_tree_sortable_get_sort_column_id(GTK_TREE_SORTABLE
-                                             ((flags &
-                                               TRG_TREE_VIEW_SORTABLE_PARENT)
-                                              ?
-                                              gtk_tree_model_filter_get_model
-                                              (GTK_TREE_MODEL_FILTER
-                                               (model)) : model),
-                                             &sort_column_id, &sort_type);
+        gtk_tree_sortable_get_sort_column_id(
+            GTK_TREE_SORTABLE((flags & TRG_TREE_VIEW_SORTABLE_PARENT)
+                                  ? gtk_tree_model_filter_get_model(GTK_TREE_MODEL_FILTER(model))
+                                  : model),
+            &sort_column_id, &sort_type);
 
         if (json_object_has_member(props, TRG_PREFS_KEY_TV_SORT_COL))
             json_object_remove_member(props, TRG_PREFS_KEY_TV_SORT_COL);
@@ -642,10 +538,8 @@ void trg_tree_view_persist(TrgTreeView * tv, guint flags)
         if (json_object_has_member(props, TRG_PREFS_KEY_TV_SORT_TYPE))
             json_object_remove_member(props, TRG_PREFS_KEY_TV_SORT_TYPE);
 
-        json_object_set_int_member(props, TRG_PREFS_KEY_TV_SORT_COL,
-                                   (gint64) sort_column_id);
-        json_object_set_int_member(props, TRG_PREFS_KEY_TV_SORT_TYPE,
-                                   (gint64) sort_type);
+        json_object_set_int_member(props, TRG_PREFS_KEY_TV_SORT_COL, (gint64)sort_column_id);
+        json_object_set_int_member(props, TRG_PREFS_KEY_TV_SORT_TYPE, (gint64)sort_type);
     }
 
     if (flags & TRG_TREE_VIEW_PERSIST_LAYOUT) {
@@ -655,62 +549,51 @@ void trg_tree_view_persist(TrgTreeView * tv, guint flags)
             json_object_remove_member(props, TRG_PREFS_KEY_TV_WIDTHS);
 
         widths = json_array_new();
-        json_object_set_array_member(props, TRG_PREFS_KEY_TV_WIDTHS,
-                                     widths);
+        json_object_set_array_member(props, TRG_PREFS_KEY_TV_WIDTHS, widths);
 
         if (json_object_has_member(props, TRG_PREFS_KEY_TV_COLUMNS))
             json_object_remove_member(props, TRG_PREFS_KEY_TV_COLUMNS);
 
         columns = json_array_new();
-        json_object_set_array_member(props, TRG_PREFS_KEY_TV_COLUMNS,
-                                     columns);
+        json_object_set_array_member(props, TRG_PREFS_KEY_TV_COLUMNS, columns);
 
         for (li = cols; li; li = g_list_next(li)) {
-            GtkTreeViewColumn *col = (GtkTreeViewColumn *) li->data;
-            trg_column_description *desc =
-                g_object_get_data(G_OBJECT(li->data),
-                                  GDATA_KEY_COLUMN_DESC);
+            GtkTreeViewColumn *col = (GtkTreeViewColumn *)li->data;
+            trg_column_description *desc
+                = g_object_get_data(G_OBJECT(li->data), GDATA_KEY_COLUMN_DESC);
 
             json_array_add_string_element(columns, desc->id);
-            json_array_add_int_element(widths,
-                                       gtk_tree_view_column_get_width
-                                       (col));
+            json_array_add_int_element(widths, gtk_tree_view_column_get_width(col));
         }
 
         g_list_free(cols);
     }
 }
 
-void trg_tree_view_restore_sort(TrgTreeView * tv, guint flags)
+void trg_tree_view_restore_sort(TrgTreeView *tv, guint flags)
 {
     JsonObject *props = trg_prefs_get_tree_view_props(tv);
     GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(tv));
 
     if (json_object_has_member(props, TRG_PREFS_KEY_TV_SORT_COL)
         && json_object_has_member(props, TRG_PREFS_KEY_TV_SORT_TYPE)) {
-        gint64 sort_col = json_object_get_int_member(props,
-                                                     TRG_PREFS_KEY_TV_SORT_COL);
-        gint64 sort_type = json_object_get_int_member(props,
-                                                      TRG_PREFS_KEY_TV_SORT_TYPE);
-        gtk_tree_sortable_set_sort_column_id(GTK_TREE_SORTABLE
-                                             ((flags &
-                                               TRG_TREE_VIEW_SORTABLE_PARENT)
-                                              ?
-                                              gtk_tree_model_filter_get_model
-                                              (GTK_TREE_MODEL_FILTER
-                                               (model)) : model), sort_col,
-                                             (GtkSortType) sort_type);
-
+        gint64 sort_col = json_object_get_int_member(props, TRG_PREFS_KEY_TV_SORT_COL);
+        gint64 sort_type = json_object_get_int_member(props, TRG_PREFS_KEY_TV_SORT_TYPE);
+        gtk_tree_sortable_set_sort_column_id(
+            GTK_TREE_SORTABLE((flags & TRG_TREE_VIEW_SORTABLE_PARENT)
+                                  ? gtk_tree_model_filter_get_model(GTK_TREE_MODEL_FILTER(model))
+                                  : model),
+            sort_col, (GtkSortType)sort_type);
     }
 }
 
-void trg_tree_view_set_prefs(TrgTreeView * tv, TrgPrefs * prefs)
+void trg_tree_view_set_prefs(TrgTreeView *tv, TrgPrefs *prefs)
 {
     TrgTreeViewPrivate *priv = TRG_TREE_VIEW_GET_PRIVATE(tv);
     priv->prefs = prefs;
 }
 
-void trg_tree_view_setup_columns(TrgTreeView * tv)
+void trg_tree_view_setup_columns(TrgTreeView *tv)
 {
     TrgTreeViewPrivate *priv = TRG_TREE_VIEW_GET_PRIVATE(tv);
     JsonObject *props = trg_prefs_get_tree_view_props(tv);
@@ -720,31 +603,22 @@ void trg_tree_view_setup_columns(TrgTreeView * tv)
         || !json_object_has_member(props, TRG_PREFS_KEY_TV_WIDTHS)) {
         GList *li;
         for (li = priv->columns; li; li = g_list_next(li)) {
-            trg_column_description *desc =
-                (trg_column_description *) li->data;
+            trg_column_description *desc = (trg_column_description *)li->data;
             if (desc && !(desc->flags & TRG_COLUMN_EXTRA))
                 trg_tree_view_add_column(tv, desc, -1);
         }
         return;
     }
 
-    columns =
-        json_array_get_elements(json_object_get_array_member
-                                (props, TRG_PREFS_KEY_TV_COLUMNS));
-    widths =
-        json_array_get_elements(json_object_get_array_member
-                                (props, TRG_PREFS_KEY_TV_WIDTHS));
+    columns
+        = json_array_get_elements(json_object_get_array_member(props, TRG_PREFS_KEY_TV_COLUMNS));
+    widths = json_array_get_elements(json_object_get_array_member(props, TRG_PREFS_KEY_TV_WIDTHS));
 
-    for (cli = columns, wli = widths; cli && wli;
-         cli = g_list_next(cli), wli = g_list_next(wli)) {
-        trg_column_description *desc = trg_tree_view_find_column(tv,
-                                                                 json_node_get_string
-                                                                 ((JsonNode
-                                                                   *)
-                                                                  cli->
-                                                                  data));
+    for (cli = columns, wli = widths; cli && wli; cli = g_list_next(cli), wli = g_list_next(wli)) {
+        trg_column_description *desc
+            = trg_tree_view_find_column(tv, json_node_get_string((JsonNode *)cli->data));
         if (desc) {
-            gint64 width = json_node_get_int((JsonNode *) wli->data);
+            gint64 width = json_node_get_int((JsonNode *)wli->data);
             trg_tree_view_add_column(tv, desc, width);
         }
     }
@@ -753,7 +627,7 @@ void trg_tree_view_setup_columns(TrgTreeView * tv)
     g_list_free(widths);
 }
 
-GList *trg_tree_view_get_selected_refs_list(GtkTreeView * tv)
+GList *trg_tree_view_get_selected_refs_list(GtkTreeView *tv)
 {
     GtkTreeModel *model = gtk_tree_view_get_model(tv);
     GtkTreeSelection *selection = gtk_tree_view_get_selection(tv);
@@ -762,7 +636,7 @@ GList *trg_tree_view_get_selected_refs_list(GtkTreeView * tv)
 
     selectionList = gtk_tree_selection_get_selected_rows(selection, NULL);
     for (li = selectionList; li != NULL; li = g_list_next(li)) {
-        GtkTreePath *path = (GtkTreePath *) li->data;
+        GtkTreePath *path = (GtkTreePath *)li->data;
         GtkTreeRowReference *ref = gtk_tree_row_reference_new(model, path);
         gtk_tree_path_free(path);
         refList = g_list_append(refList, ref);
@@ -772,22 +646,22 @@ GList *trg_tree_view_get_selected_refs_list(GtkTreeView * tv)
     return refList;
 }
 
-static void trg_tree_view_dispose(GObject * object)
+static void trg_tree_view_dispose(GObject *object)
 {
     G_OBJECT_CLASS(trg_tree_view_parent_class)->dispose(object);
 }
 
-static void trg_tree_view_finalize(GObject * object)
+static void trg_tree_view_finalize(GObject *object)
 {
     TrgTreeViewPrivate *priv = TRG_TREE_VIEW_GET_PRIVATE(object);
 
-    g_list_free_full(priv->columns, (GDestroyNotify) trg_column_description_free);
+    g_list_free_full(priv->columns, (GDestroyNotify)trg_column_description_free);
     g_free(priv->configId);
 
     G_OBJECT_CLASS(trg_tree_view_parent_class)->finalize(object);
 }
 
-static void trg_tree_view_class_init(TrgTreeViewClass * klass)
+static void trg_tree_view_class_init(TrgTreeViewClass *klass)
 {
     GObjectClass *object_class = G_OBJECT_CLASS(klass);
 
@@ -799,51 +673,29 @@ static void trg_tree_view_class_init(TrgTreeViewClass * klass)
     object_class->dispose = trg_tree_view_dispose;
     object_class->finalize = trg_tree_view_finalize;
 
-    g_object_class_install_property(object_class,
-                                    PROP_PREFS,
-                                    g_param_spec_object("prefs",
-                                                        "Trg Prefs",
-                                                        "Trg Prefs",
-                                                        TRG_TYPE_PREFS,
-                                                        G_PARAM_READWRITE |
-                                                        G_PARAM_CONSTRUCT_ONLY
-                                                        |
-                                                        G_PARAM_STATIC_NAME
-                                                        |
-                                                        G_PARAM_STATIC_NICK
-                                                        |
-                                                        G_PARAM_STATIC_BLURB));
+    g_object_class_install_property(
+        object_class, PROP_PREFS,
+        g_param_spec_object("prefs", "Trg Prefs", "Trg Prefs", TRG_TYPE_PREFS,
+                            G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME
+                                | G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
 
-    g_object_class_install_property(object_class,
-                                    PROP_CONFIGID,
-                                    g_param_spec_string
-                                    ("config-id",
-                                     "config-id",
-                                     "config-id",
-                                     NULL,
-                                     G_PARAM_READWRITE |
-                                     G_PARAM_CONSTRUCT_ONLY |
-                                     G_PARAM_STATIC_NAME |
-                                     G_PARAM_STATIC_NICK |
-                                     G_PARAM_STATIC_BLURB));
+    g_object_class_install_property(
+        object_class, PROP_CONFIGID,
+        g_param_spec_string("config-id", "config-id", "config-id", NULL,
+                            G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME
+                                | G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
 
-    signals[SIGNAL_COLUMN_ADDED] =
-        g_signal_new("column-added",
-                     G_TYPE_FROM_CLASS(object_class),
-                     G_SIGNAL_RUN_LAST | G_SIGNAL_ACTION,
-                     G_STRUCT_OFFSET(TrgTreeViewClass,
-                                     column_added), NULL,
-                     NULL, g_cclosure_marshal_VOID__STRING,
-                     G_TYPE_NONE, 1, G_TYPE_STRING);
-
+    signals[SIGNAL_COLUMN_ADDED] = g_signal_new(
+        "column-added", G_TYPE_FROM_CLASS(object_class), G_SIGNAL_RUN_LAST | G_SIGNAL_ACTION,
+        G_STRUCT_OFFSET(TrgTreeViewClass, column_added), NULL, NULL,
+        g_cclosure_marshal_VOID__STRING, G_TYPE_NONE, 1, G_TYPE_STRING);
 }
 
-static void trg_tree_view_init(TrgTreeView * tv)
+static void trg_tree_view_init(TrgTreeView *tv)
 {
     gtk_tree_view_set_rubber_banding(GTK_TREE_VIEW(tv), TRUE);
     gtk_tree_view_set_headers_clickable(GTK_TREE_VIEW(tv), TRUE);
-    gtk_tree_selection_set_mode(gtk_tree_view_get_selection
-                                (GTK_TREE_VIEW(tv)),
+    gtk_tree_selection_set_mode(gtk_tree_view_get_selection(GTK_TREE_VIEW(tv)),
                                 GTK_SELECTION_MULTIPLE);
 
     gtk_widget_set_sensitive(GTK_WIDGET(tv), FALSE);

--- a/src/trg-tree-view.h
+++ b/src/trg-tree-view.h
@@ -26,30 +26,27 @@
 
 G_BEGIN_DECLS
 #define TRG_TYPE_TREE_VIEW trg_tree_view_get_type()
-#define TRG_TREE_VIEW(obj) \
-  (G_TYPE_CHECK_INSTANCE_CAST ((obj), TRG_TYPE_TREE_VIEW, TrgTreeView))
-#define TRG_TREE_VIEW_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_CAST ((klass), TRG_TYPE_TREE_VIEW, TrgTreeViewClass))
-#define TRG_IS_TREE_VIEW(obj) \
-  (G_TYPE_CHECK_INSTANCE_TYPE ((obj), TRG_TYPE_TREE_VIEW))
-#define TRG_IS_TREE_VIEW_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_TYPE ((klass), TRG_TYPE_TREE_VIEW))
-#define TRG_TREE_VIEW_GET_CLASS(obj) \
-  (G_TYPE_INSTANCE_GET_CLASS ((obj), TRG_TYPE_TREE_VIEW, TrgTreeViewClass))
-    typedef struct {
+#define TRG_TREE_VIEW(obj) (G_TYPE_CHECK_INSTANCE_CAST((obj), TRG_TYPE_TREE_VIEW, TrgTreeView))
+#define TRG_TREE_VIEW_CLASS(klass)                                                                 \
+    (G_TYPE_CHECK_CLASS_CAST((klass), TRG_TYPE_TREE_VIEW, TrgTreeViewClass))
+#define TRG_IS_TREE_VIEW(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), TRG_TYPE_TREE_VIEW))
+#define TRG_IS_TREE_VIEW_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass), TRG_TYPE_TREE_VIEW))
+#define TRG_TREE_VIEW_GET_CLASS(obj)                                                               \
+    (G_TYPE_INSTANCE_GET_CLASS((obj), TRG_TYPE_TREE_VIEW, TrgTreeViewClass))
+typedef struct {
     GtkTreeView parent;
 } TrgTreeView;
 
 typedef struct {
     GtkTreeViewClass parent_class;
-    void (*column_added) (TrgTreeView * tv, const gchar *id);
+    void (*column_added)(TrgTreeView *tv, const gchar *id);
 } TrgTreeViewClass;
 
 GType trg_tree_view_get_type(void);
 
 GtkWidget *trg_tree_view_new(void);
 
-G_END_DECLS GList *trg_tree_view_get_selected_refs_list(GtkTreeView * tv);
+G_END_DECLS GList *trg_tree_view_get_selected_refs_list(GtkTreeView *tv);
 
 typedef enum {
     TRG_COLTYPE_ICONTEXT,
@@ -78,28 +75,24 @@ typedef struct {
     GtkTreeViewColumn **out;
 } trg_column_description;
 
-#define TRG_COLUMN_DEFAULT             0x00
-#define TRG_COLUMN_SHOWING             (1 << 0) /* 0x01 */
-#define TRG_COLUMN_UNREMOVABLE         (1 << 1) /* 0x02 */
-#define TRG_COLUMN_EXTRA               (1 << 2) /* 0x04 */
-#define TRG_COLUMN_HIDE_FROM_TOP_MENU  (1 << 3) /* 0x08 */
+#define TRG_COLUMN_DEFAULT            0x00
+#define TRG_COLUMN_SHOWING            (1 << 0) /* 0x01 */
+#define TRG_COLUMN_UNREMOVABLE        (1 << 1) /* 0x02 */
+#define TRG_COLUMN_EXTRA              (1 << 2) /* 0x04 */
+#define TRG_COLUMN_HIDE_FROM_TOP_MENU (1 << 3) /* 0x08 */
 
-#define TRG_TREE_VIEW_PERSIST_SORT	   (1 << 0)
-#define TRG_TREE_VIEW_PERSIST_LAYOUT   (1 << 1)
-#define TRG_TREE_VIEW_SORTABLE_PARENT  (1 << 2)
+#define TRG_TREE_VIEW_PERSIST_SORT    (1 << 0)
+#define TRG_TREE_VIEW_PERSIST_LAYOUT  (1 << 1)
+#define TRG_TREE_VIEW_SORTABLE_PARENT (1 << 2)
 
-trg_column_description *trg_tree_view_reg_column(TrgTreeView * tv,
-                                                 gint type,
-                                                 gint model_column,
-                                                 const gchar * header,
-                                                 const gchar * id,
-                                                 guint flags);
-void trg_tree_view_setup_columns(TrgTreeView * tv);
-void trg_tree_view_set_prefs(TrgTreeView * tv, TrgPrefs * prefs);
-void trg_tree_view_persist(TrgTreeView * tv, guint flags);
-void trg_tree_view_remove_all_columns(TrgTreeView * tv);
-void trg_tree_view_restore_sort(TrgTreeView * tv, guint flags);
-GtkWidget *trg_tree_view_sort_menu(TrgTreeView * tv, const gchar * label);
-gboolean trg_tree_view_is_column_showing(TrgTreeView * tv, gint index);
+trg_column_description *trg_tree_view_reg_column(TrgTreeView *tv, gint type, gint model_column,
+                                                 const gchar *header, const gchar *id, guint flags);
+void trg_tree_view_setup_columns(TrgTreeView *tv);
+void trg_tree_view_set_prefs(TrgTreeView *tv, TrgPrefs *prefs);
+void trg_tree_view_persist(TrgTreeView *tv, guint flags);
+void trg_tree_view_remove_all_columns(TrgTreeView *tv);
+void trg_tree_view_restore_sort(TrgTreeView *tv, guint flags);
+GtkWidget *trg_tree_view_sort_menu(TrgTreeView *tv, const gchar *label);
+gboolean trg_tree_view_is_column_showing(TrgTreeView *tv, gint index);
 
-#endif                          /* _TRG_TREE_VIEW_H_ */
+#endif /* _TRG_TREE_VIEW_H_ */

--- a/src/upload.c
+++ b/src/upload.c
@@ -1,105 +1,108 @@
 #include "config.h"
 
+#include "json.h"
 #include "protocol-constants.h"
 #include "requests.h"
 #include "trg-client.h"
-#include "util.h"
 #include "trg-main-window.h"
-#include "json.h"
 #include "upload.h"
+#include "util.h"
 
 static gboolean upload_complete_callback(gpointer data);
 static void next_upload(trg_upload *upload);
 
-static void
-add_set_common_args(JsonObject * args, gint priority, gchar * dir)
+static void add_set_common_args(JsonObject *args, gint priority, gchar *dir)
 {
     json_object_set_string_member(args, FIELD_FILE_DOWNLOAD_DIR, dir);
-    json_object_set_int_member(args, FIELD_BANDWIDTH_PRIORITY,
-                               (gint64) priority);
+    json_object_set_int_member(args, FIELD_BANDWIDTH_PRIORITY, (gint64)priority);
 }
 
-void trg_upload_free(trg_upload *upload) {
-	g_str_slist_free(upload->list);
-	g_free(upload->dir);
-	g_free(upload->uid);
-	g_free(upload->file_wanted);
-	g_free(upload->file_priorities);
-	trg_response_free(upload->upload_response);
-	g_free(upload);
-}
-
-static void add_priorities(JsonObject *args, gint* priorities, gint n_files)
+void trg_upload_free(trg_upload *upload)
 {
-	gint i;
-	for (i = 0; i < n_files; i++) {
-		gint priority = priorities[i];
-	    if (priority == TR_PRI_LOW)
-	        add_file_id_to_array(args, FIELD_FILES_PRIORITY_LOW, i);
-	    else if (priority == TR_PRI_HIGH)
-	        add_file_id_to_array(args, FIELD_FILES_PRIORITY_HIGH, i);
-	    else
-	        add_file_id_to_array(args, FIELD_FILES_PRIORITY_NORMAL, i);
-	}
+    g_str_slist_free(upload->list);
+    g_free(upload->dir);
+    g_free(upload->uid);
+    g_free(upload->file_wanted);
+    g_free(upload->file_priorities);
+    trg_response_free(upload->upload_response);
+    g_free(upload);
 }
 
-static void add_wanteds(JsonObject *args, gint* wanteds, gint n_files) {
-	gint i;
-	for (i = 0; i < n_files; i++) {
-		if (wanteds[i])
-			add_file_id_to_array(args, FIELD_FILES_WANTED, i);
-		else
-			add_file_id_to_array(args, FIELD_FILES_UNWANTED, i);
-	}
+static void add_priorities(JsonObject *args, gint *priorities, gint n_files)
+{
+    gint i;
+    for (i = 0; i < n_files; i++) {
+        gint priority = priorities[i];
+        if (priority == TR_PRI_LOW)
+            add_file_id_to_array(args, FIELD_FILES_PRIORITY_LOW, i);
+        else if (priority == TR_PRI_HIGH)
+            add_file_id_to_array(args, FIELD_FILES_PRIORITY_HIGH, i);
+        else
+            add_file_id_to_array(args, FIELD_FILES_PRIORITY_NORMAL, i);
+    }
 }
 
-static void next_upload(trg_upload *upload) {
-	JsonNode *req = NULL;
-
-	if (upload->upload_response && upload->progress_index < 1)
-		req = torrent_add_from_response(upload->upload_response, upload->flags);
-	else if (upload->list && upload->progress_index < g_slist_length(upload->list))
-		req = torrent_add_from_file((gchar*)g_slist_nth_data(upload->list, upload->progress_index), upload->flags);
-
-	if (req) {
-		JsonObject *args = node_get_arguments(req);
-
-		if (upload->extra_args)
-			add_set_common_args(args, upload->priority, upload->dir);
-
-		if (upload->file_wanted)
-			add_wanteds(args, upload->file_wanted, upload->n_files);
-
-		if (upload->file_priorities)
-			add_priorities(args, upload->file_priorities, upload->n_files);
-
-		upload->progress_index++;
-		dispatch_async(upload->client, req, upload_complete_callback, upload);
-	} else {
-		trg_upload_free(upload);
-	}
+static void add_wanteds(JsonObject *args, gint *wanteds, gint n_files)
+{
+    gint i;
+    for (i = 0; i < n_files; i++) {
+        if (wanteds[i])
+            add_file_id_to_array(args, FIELD_FILES_WANTED, i);
+        else
+            add_file_id_to_array(args, FIELD_FILES_UNWANTED, i);
+    }
 }
 
-static gboolean upload_complete_callback(gpointer data) {
-	trg_response *response = (trg_response*)data;
-	trg_upload *upload = (trg_upload*)response->cb_data;
+static void next_upload(trg_upload *upload)
+{
+    JsonNode *req = NULL;
 
-	if (upload->callback)
-		upload->callback(data);
+    if (upload->upload_response && upload->progress_index < 1)
+        req = torrent_add_from_response(upload->upload_response, upload->flags);
+    else if (upload->list && upload->progress_index < g_slist_length(upload->list))
+        req = torrent_add_from_file((gchar *)g_slist_nth_data(upload->list, upload->progress_index),
+                                    upload->flags);
 
-	/* the callback we're delegating to will destroy the response */
+    if (req) {
+        JsonObject *args = node_get_arguments(req);
 
-	if (upload->main_window)
-		on_generic_interactive_action(upload->main_window, response);
-	else
-		trg_response_free(response);
+        if (upload->extra_args)
+            add_set_common_args(args, upload->priority, upload->dir);
 
-	next_upload(upload);
+        if (upload->file_wanted)
+            add_wanteds(args, upload->file_wanted, upload->n_files);
 
-	return FALSE;
+        if (upload->file_priorities)
+            add_priorities(args, upload->file_priorities, upload->n_files);
+
+        upload->progress_index++;
+        dispatch_async(upload->client, req, upload_complete_callback, upload);
+    } else {
+        trg_upload_free(upload);
+    }
+}
+
+static gboolean upload_complete_callback(gpointer data)
+{
+    trg_response *response = (trg_response *)data;
+    trg_upload *upload = (trg_upload *)response->cb_data;
+
+    if (upload->callback)
+        upload->callback(data);
+
+    /* the callback we're delegating to will destroy the response */
+
+    if (upload->main_window)
+        on_generic_interactive_action(upload->main_window, response);
+    else
+        trg_response_free(response);
+
+    next_upload(upload);
+
+    return FALSE;
 }
 
 void trg_do_upload(trg_upload *upload)
 {
-	next_upload(upload);
+    next_upload(upload);
 }

--- a/src/upload.h
+++ b/src/upload.h
@@ -15,8 +15,8 @@ typedef struct {
     guint flags;
     gchar *dir;
     gint priority;
-    gint* file_priorities;
-    gint* file_wanted;
+    gint *file_priorities;
+    gint *file_wanted;
     guint n_files;
     gboolean extra_args;
     guint progress_index;

--- a/src/util.c
+++ b/src/util.c
@@ -22,17 +22,17 @@
 #include "config.h"
 
 #include <limits.h>
-#include <stdlib.h>
 #include <math.h>
+#include <stdlib.h>
 #include <string.h>
 
-#include <glib/gi18n.h>
-#include <glib-object.h>
 #include <curl/curl.h>
-#include <json-glib/json-glib.h>
+#include <glib-object.h>
 #include <glib.h>
+#include <glib/gi18n.h>
 #include <glib/gprintf.h>
 #include <gtk/gtk.h>
+#include <json-glib/json-glib.h>
 
 #include "util.h"
 
@@ -61,13 +61,15 @@ struct formatter_units {
     struct formatter_unit units[4];
 };
 
-enum { TR_FMT_KB, TR_FMT_MB, TR_FMT_GB, TR_FMT_TB };
+enum {
+    TR_FMT_KB,
+    TR_FMT_MB,
+    TR_FMT_GB,
+    TR_FMT_TB
+};
 
-static void
-formatter_init(struct formatter_units *units,
-               unsigned int kilo,
-               const char *kb, const char *mb,
-               const char *gb, const char *tb)
+static void formatter_init(struct formatter_units *units, unsigned int kilo, const char *kb,
+                           const char *mb, const char *gb, const char *tb)
 {
     guint64 value = kilo;
     units->units[TR_FMT_KB].name = g_strdup(kb);
@@ -86,8 +88,8 @@ formatter_init(struct formatter_units *units,
     units->units[TR_FMT_TB].value = value;
 }
 
-static char *formatter_get_size_str(const struct formatter_units *u,
-                                    char *buf, gint64 bytes, size_t buflen)
+static char *formatter_get_size_str(const struct formatter_units *u, char *buf, gint64 bytes,
+                                    size_t buflen)
 {
     int precision;
     double value;
@@ -103,7 +105,7 @@ static char *formatter_get_size_str(const struct formatter_units *u,
     else
         unit = &u->units[3];
 
-    value = (double) bytes / unit->value;
+    value = (double)bytes / unit->value;
     units = unit->name;
     if (unit->value == 1)
         precision = 0;
@@ -117,10 +119,8 @@ static char *formatter_get_size_str(const struct formatter_units *u,
 
 static struct formatter_units size_units;
 
-void
-tr_formatter_size_init(unsigned int kilo,
-                       const char *kb, const char *mb,
-                       const char *gb, const char *tb)
+void tr_formatter_size_init(unsigned int kilo, const char *kb, const char *mb, const char *gb,
+                            const char *tb)
 {
     formatter_init(&size_units, kilo, kb, mb, gb, tb);
 }
@@ -134,10 +134,8 @@ static struct formatter_units speed_units;
 
 unsigned int tr_speed_K = 0u;
 
-void
-tr_formatter_speed_init(unsigned int kilo,
-                        const char *kb, const char *mb,
-                        const char *gb, const char *tb)
+void tr_formatter_speed_init(unsigned int kilo, const char *kb, const char *mb, const char *gb,
+                             const char *tb)
 {
     tr_speed_K = kilo;
     formatter_init(&speed_units, kilo, kb, mb, gb, tb);
@@ -148,21 +146,17 @@ char *tr_formatter_speed_KBps(char *buf, double KBps, size_t buflen)
     const double K = speed_units.units[TR_FMT_KB].value;
     double speed = KBps;
 
-    if (speed <= 999.95)        /* 0.0 KB to 999.9 KB */
-        g_snprintf(buf, buflen, "%d %s", (int) speed,
-                    speed_units.units[TR_FMT_KB].name);
+    if (speed <= 999.95) /* 0.0 KB to 999.9 KB */
+        g_snprintf(buf, buflen, "%d %s", (int)speed, speed_units.units[TR_FMT_KB].name);
     else {
         speed /= K;
-        if (speed <= 99.995)    /* 0.98 MB to 99.99 MB */
-            g_snprintf(buf, buflen, "%.2f %s", speed,
-                        speed_units.units[TR_FMT_MB].name);
-        else if (speed <= 999.95)       /* 100.0 MB to 999.9 MB */
-            g_snprintf(buf, buflen, "%.1f %s", speed,
-                        speed_units.units[TR_FMT_MB].name);
+        if (speed <= 99.995) /* 0.98 MB to 99.99 MB */
+            g_snprintf(buf, buflen, "%.2f %s", speed, speed_units.units[TR_FMT_MB].name);
+        else if (speed <= 999.95) /* 100.0 MB to 999.9 MB */
+            g_snprintf(buf, buflen, "%.1f %s", speed, speed_units.units[TR_FMT_MB].name);
         else {
             speed /= K;
-            g_snprintf(buf, buflen, "%.1f %s", speed,
-                        speed_units.units[TR_FMT_GB].name);
+            g_snprintf(buf, buflen, "%.1f %s", speed, speed_units.units[TR_FMT_GB].name);
         }
     }
 
@@ -171,14 +165,15 @@ char *tr_formatter_speed_KBps(char *buf, double KBps, size_t buflen)
 
 /* URL checkers. */
 
-gboolean is_magnet(const gchar * string)
+gboolean is_magnet(const gchar *string)
 {
     return g_str_has_prefix(string, "magnet:");
 }
 
-gboolean is_url(const gchar * string)
+gboolean is_url(const gchar *string)
 {
-    /* return g_regex_match_simple ("^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?", string, 0, 0); */
+    /* return g_regex_match_simple ("^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?",
+     * string, 0, 0); */
     return g_regex_match_simple("^http[s]?://", string, 0, 0);
 }
 
@@ -186,7 +181,7 @@ gboolean is_url(const gchar * string)
  * Glib-ish Utility functions.
  */
 
-gchar *trg_base64encode(const gchar * filename)
+gchar *trg_base64encode(const gchar *filename)
 {
     GError *error = NULL;
     GMappedFile *mf = g_mapped_file_new(filename, FALSE, &error);
@@ -196,9 +191,8 @@ gchar *trg_base64encode(const gchar * filename)
         g_error("%s", error->message);
         g_error_free(error);
     } else {
-        b64out =
-            g_base64_encode((guchar *) g_mapped_file_get_contents(mf),
-                            g_mapped_file_get_length(mf));
+        b64out = g_base64_encode((guchar *)g_mapped_file_get_contents(mf),
+                                 g_mapped_file_get_length(mf));
     }
 
     g_mapped_file_unref(mf);
@@ -206,7 +200,7 @@ gchar *trg_base64encode(const gchar * filename)
     return b64out;
 }
 
-gchar *trg_gregex_get_first(GRegex * rx, const gchar * src)
+gchar *trg_gregex_get_first(GRegex *rx, const gchar *src)
 {
     GMatchInfo *mi = NULL;
     gchar *dst = NULL;
@@ -220,18 +214,17 @@ gchar *trg_gregex_get_first(GRegex * rx, const gchar * src)
 
 GRegex *trg_uri_host_regex_new(void)
 {
-    return
-        g_regex_new
-        ("^[^:/?#]+:?//(?:www\\.|torrent\\.|torrents\\.|tracker\\.|\\d+\\.)?([^/?#:]*)",
-         G_REGEX_OPTIMIZE, 0, NULL);
+    return g_regex_new(
+        "^[^:/?#]+:?//(?:www\\.|torrent\\.|torrents\\.|tracker\\.|\\d+\\.)?([^/?#:]*)",
+        G_REGEX_OPTIMIZE, 0, NULL);
 }
 
-void g_str_slist_free(GSList * list)
+void g_str_slist_free(GSList *list)
 {
-    g_slist_free_full(list, (GDestroyNotify) g_free);
+    g_slist_free_full(list, (GDestroyNotify)g_free);
 }
 
-void rm_trailing_slashes(gchar * str)
+void rm_trailing_slashes(gchar *str)
 {
     int i, len;
 
@@ -251,7 +244,7 @@ void rm_trailing_slashes(gchar * str)
 
 /* Working with torrents.. */
 
-void add_file_id_to_array(JsonObject * args, const gchar * key, gint index)
+void add_file_id_to_array(JsonObject *args, const gchar *key, gint index)
 {
     JsonArray *array;
     if (json_object_has_member(args, key)) {
@@ -280,11 +273,9 @@ GtkWidget *gtr_combo_box_new_enum(const char *text_1, ...)
     if (text != NULL)
         do {
             const int val = va_arg(vl, int);
-            gtk_list_store_insert_with_values(store, NULL, INT_MAX, 0, val,
-                                              1, text, -1);
+            gtk_list_store_insert_with_values(store, NULL, INT_MAX, 0, val, 1, text, -1);
             text = va_arg(vl, const char *);
-        }
-        while (text != NULL);
+        } while (text != NULL);
 
     w = gtk_combo_box_new_with_model(GTK_TREE_MODEL(store));
     r = gtk_cell_renderer_text_new();
@@ -296,14 +287,12 @@ GtkWidget *gtr_combo_box_new_enum(const char *text_1, ...)
     return w;
 }
 
-GtkWidget *my_scrolledwin_new(GtkWidget * child)
+GtkWidget *my_scrolledwin_new(GtkWidget *child)
 {
     GtkWidget *scrolled_win = gtk_scrolled_window_new(NULL, NULL);
-    gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scrolled_win),
-                                   GTK_POLICY_AUTOMATIC,
+    gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scrolled_win), GTK_POLICY_AUTOMATIC,
                                    GTK_POLICY_AUTOMATIC);
-    gtk_scrolled_window_set_shadow_type (GTK_SCROLLED_WINDOW(scrolled_win),
-                                        GTK_SHADOW_ETCHED_IN);
+    gtk_scrolled_window_set_shadow_type(GTK_SCROLLED_WINDOW(scrolled_win), GTK_SHADOW_ETCHED_IN);
     gtk_container_add(GTK_CONTAINER(scrolled_win), child);
     return scrolled_win;
 }
@@ -311,7 +300,7 @@ GtkWidget *my_scrolledwin_new(GtkWidget * child)
 /* gtk_widget_set_sensitive() was introduced in 2.18, we can have a minimum of
  * 2.16 otherwise. */
 
-void trg_widget_set_visible(GtkWidget * w, gboolean visible)
+void trg_widget_set_visible(GtkWidget *w, gboolean visible)
 {
     if (visible)
         gtk_widget_show(w);
@@ -319,34 +308,29 @@ void trg_widget_set_visible(GtkWidget * w, gboolean visible)
         gtk_widget_hide(w);
 }
 
-void trg_error_dialog(GtkWindow * parent, trg_response * response)
+void trg_error_dialog(GtkWindow *parent, trg_response *response)
 {
     gchar *msg = make_error_message(response->obj, response->status);
-    GtkWidget *dialog = gtk_message_dialog_new(parent,
-                                               GTK_DIALOG_MODAL,
-                                               GTK_MESSAGE_ERROR,
-                                               GTK_BUTTONS_OK, "%s",
-                                               msg);
+    GtkWidget *dialog = gtk_message_dialog_new(parent, GTK_DIALOG_MODAL, GTK_MESSAGE_ERROR,
+                                               GTK_BUTTONS_OK, "%s", msg);
     gtk_window_set_title(GTK_WINDOW(dialog), _("Error"));
     gtk_dialog_run(GTK_DIALOG(dialog));
     gtk_widget_destroy(dialog);
     g_free(msg);
 }
 
-gchar *make_error_message(JsonObject * response, int status)
+gchar *make_error_message(JsonObject *response, int status)
 {
     if (status == FAIL_JSON_DECODE) {
         return g_strdup(_("JSON decoding error."));
     } else if (response && status == FAIL_RESPONSE_UNSUCCESSFUL) {
-        const gchar *resultStr =
-            json_object_get_string_member(response, "result");
+        const gchar *resultStr = json_object_get_string_member(response, "result");
         if (resultStr == NULL)
             return g_strdup(_("Server responded, but with no result."));
         else
             return g_strdup(resultStr);
     } else if (status <= -100) {
-        return g_strdup_printf(_("Request failed with HTTP code %d"),
-                               -(status + 100));
+        return g_strdup_printf(_("Request failed with HTTP code %d"), -(status + 100));
     } else {
         return g_strdup(curl_easy_strerror(status));
     }
@@ -370,17 +354,16 @@ char *tr_strlpercent(char *buf, double x, size_t buflen)
 
 double tr_truncd(double x, int decimal_places)
 {
-    const int i = (int) pow(10, decimal_places);
-    double x2 = (int) (x * i);
+    const int i = (int)pow(10, decimal_places);
+    double x2 = (int)(x * i);
     return x2 / i;
 }
 
-char *tr_strratio(char *buf, size_t buflen, double ratio,
-                  const char *infinity)
+char *tr_strratio(char *buf, size_t buflen, double ratio, const char *infinity)
 {
-    if ((int) ratio == TR_RATIO_NA)
+    if ((int)ratio == TR_RATIO_NA)
         g_strlcpy(buf, _("None"), buflen);
-    else if ((int) ratio == TR_RATIO_INF)
+    else if ((int)ratio == TR_RATIO_INF)
         g_strlcpy(buf, infinity, buflen);
     else if (ratio < 10.0)
         g_snprintf(buf, buflen, "%.2f", tr_truncd(ratio, 2));
@@ -426,12 +409,9 @@ char *tr_strltime_long(char *buf, long seconds, size_t buflen)
     seconds = (seconds % 3600) % 60;
 
     g_snprintf(d, sizeof(d), ngettext("%d day", "%d days", days), days);
-    g_snprintf(h, sizeof(h), ngettext("%d hour", "%d hours", hours),
-               hours);
-    g_snprintf(m, sizeof(m), ngettext("%d minute", "%d minutes", minutes),
-               minutes);
-    g_snprintf(s, sizeof(s),
-               ngettext("%ld second", "%ld seconds", seconds), seconds);
+    g_snprintf(h, sizeof(h), ngettext("%d hour", "%d hours", hours), hours);
+    g_snprintf(m, sizeof(m), ngettext("%d minute", "%d minutes", minutes), minutes);
+    g_snprintf(s, sizeof(s), ngettext("%ld second", "%ld seconds", seconds), seconds);
 
     if (days) {
         if (days >= 4 || !hours) {
@@ -480,8 +460,8 @@ char *gtr_localtime2(char *buf, time_t time, size_t buflen)
 
 gchar *epoch_to_string(gint64 epoch)
 {
-	if(epoch == 0)
-		return g_strdup(_("N/A"));
+    if (epoch == 0)
+        return g_strdup(_("N/A"));
     GDateTime *dt = g_date_time_new_from_unix_local(epoch);
     gchar *timestring = g_date_time_format(dt, "%F %H:%M:%S");
     g_date_time_unref(dt);
@@ -492,30 +472,28 @@ gchar *epoch_to_string(gint64 epoch)
  * with or without any links - a newly allocated string is returned.
  * Note that a markup-escaped string is always returned. */
 
-gchar *add_links_to_text(const gchar * original)
+gchar *add_links_to_text(const gchar *original)
 {
     /* return if original already contains links */
     if (g_regex_match_simple("<a\\s.*>", original, 0, 0)) {
-      return g_strdup(original);
+        return g_strdup(original);
     }
 
     gchar *newText, *url, *link;
     GMatchInfo *match_info;
-    GRegex *regex =
-      g_regex_new("(https?://[a-zA-Z0-9_\\-\\./?=&]+)", 0, 0, NULL);
+    GRegex *regex = g_regex_new("(https?://[a-zA-Z0-9_\\-\\./?=&]+)", 0, 0, NULL);
 
     // extract url and build escaped link
     g_regex_match(regex, original, 0, &match_info);
     url = g_match_info_fetch(match_info, 1);
 
-    if(url) {
-      link = g_markup_printf_escaped("<a href='%s'>%s</a>", url, url);
-      newText = g_regex_replace(regex, original, -1, 0, link,
-                                       0, NULL);
-      g_free(url);
-      g_free(link);
+    if (url) {
+        link = g_markup_printf_escaped("<a href='%s'>%s</a>", url, url);
+        newText = g_regex_replace(regex, original, -1, 0, link, 0, NULL);
+        g_free(url);
+        g_free(link);
     } else {
-      newText = g_markup_escape_text(original, -1);
+        newText = g_markup_escape_text(original, -1);
     }
 
     g_regex_unref(regex);
@@ -533,10 +511,9 @@ char *tr_strlsize(char *buf, guint64 bytes, size_t buflen)
     return buf;
 }
 
-gboolean is_minimised_arg(const gchar * arg)
+gboolean is_minimised_arg(const gchar *arg)
 {
-    return !g_strcmp0(arg, "-m")
-        || !g_strcmp0(arg, "--minimized") || !g_strcmp0(arg, "/m");
+    return !g_strcmp0(arg, "-m") || !g_strcmp0(arg, "--minimized") || !g_strcmp0(arg, "/m");
 }
 
 gboolean should_be_minimised(int argc, char *argv[])
@@ -566,10 +543,9 @@ GtkWidget *trg_vbox_new(gboolean homogeneous, gint spacing)
 }
 
 #ifdef G_OS_WIN32
-gchar *trg_win32_support_path(gchar * file)
+gchar *trg_win32_support_path(gchar *file)
 {
-    gchar *moddir =
-        g_win32_get_package_installation_directory_of_module(NULL);
+    gchar *moddir = g_win32_get_package_installation_directory_of_module(NULL);
     gchar *path = g_build_filename(moddir, file, NULL);
     g_free(moddir);
     return path;

--- a/src/util.h
+++ b/src/util.h
@@ -22,17 +22,17 @@
 #ifndef UTIL_H_
 #define UTIL_H_
 
-#include <gtk/gtk.h>
 #include <glib-object.h>
+#include <gtk/gtk.h>
 #include <json-glib/json-glib.h>
 
 #include "trg-client.h"
 
-#define trg_strlspeed(a, b) tr_formatter_speed_KBps(a, b, sizeof(a))
+#define trg_strlspeed(a, b)   tr_formatter_speed_KBps(a, b, sizeof(a))
 #define trg_strlpercent(a, b) tr_strlpercent(a, b, sizeof(a))
-#define trg_strlsize(a, b) tr_formatter_size_B(a, b, sizeof(a))
-#define trg_strlratio(a, b) tr_strlratio(a, b, sizeof(a))
-#define MAX3(a,b,c) MAX(a,MAX(b,c))
+#define trg_strlsize(a, b)    tr_formatter_size_B(a, b, sizeof(a))
+#define trg_strlratio(a, b)   tr_strlratio(a, b, sizeof(a))
+#define MAX3(a, b, c)         MAX(a, MAX(b, c))
 
 #define TR_RATIO_NA  -1
 #define TR_RATIO_INF -2
@@ -49,53 +49,47 @@ extern const char *speed_M_str;
 extern const char *speed_G_str;
 extern const char *speed_T_str;
 
-void add_file_id_to_array(JsonObject * args, const gchar * key,
-                          gint index);
-void g_str_slist_free(GSList * list);
+void add_file_id_to_array(JsonObject *args, const gchar *key, gint index);
+void g_str_slist_free(GSList *list);
 GRegex *trg_uri_host_regex_new(void);
-gchar *trg_gregex_get_first(GRegex * rx, const gchar * uri);
-gchar *make_error_message(JsonObject * response, int status);
-void trg_error_dialog(GtkWindow * parent, trg_response * response);
-gchar *add_links_to_text(const gchar * original);
+gchar *trg_gregex_get_first(GRegex *rx, const gchar *uri);
+gchar *make_error_message(JsonObject *response, int status);
+void trg_error_dialog(GtkWindow *parent, trg_response *response);
+gchar *add_links_to_text(const gchar *original);
 
-void
-tr_formatter_size_init(unsigned int kilo,
-                       const char *kb, const char *mb,
-                       const char *gb, const char *tb);
+void tr_formatter_size_init(unsigned int kilo, const char *kb, const char *mb, const char *gb,
+                            const char *tb);
 char *tr_formatter_size_B(char *buf, gint64 bytes, size_t buflen);
 
-void
-tr_formatter_speed_init(unsigned int kilo,
-                        const char *kb, const char *mb,
-                        const char *gb, const char *tb);
+void tr_formatter_speed_init(unsigned int kilo, const char *kb, const char *mb, const char *gb,
+                             const char *tb);
 char *tr_formatter_speed_KBps(char *buf, double KBps, size_t buflen);
 
 char *tr_strltime_long(char *buf, long seconds, size_t buflen);
 gchar *epoch_to_string(gint64 epoch);
 char *tr_strltime_short(char *buf, long seconds, size_t buflen);
 char *tr_strlpercent(char *buf, double x, size_t buflen);
-char *tr_strratio(char *buf, size_t buflen, double ratio,
-                  const char *infinity);
+char *tr_strratio(char *buf, size_t buflen, double ratio, const char *infinity);
 char *tr_strlratio(char *buf, double ratio, size_t buflen);
 char *gtr_localtime(time_t time);
 char *gtr_localtime2(char *buf, time_t time, size_t buflen);
 double tr_truncd(double x, int decimal_places);
 char *tr_strlsize(char *buf, guint64 bytes, size_t buflen);
-void rm_trailing_slashes(gchar * str);
-void trg_widget_set_visible(GtkWidget * w, gboolean visible);
-gchar *trg_base64encode(const gchar * filename);
-GtkWidget *my_scrolledwin_new(GtkWidget * child);
-gboolean is_url(const gchar * string);
-gboolean is_magnet(const gchar * string);
+void rm_trailing_slashes(gchar *str);
+void trg_widget_set_visible(GtkWidget *w, gboolean visible);
+gchar *trg_base64encode(const gchar *filename);
+GtkWidget *my_scrolledwin_new(GtkWidget *child);
+gboolean is_url(const gchar *string);
+gboolean is_magnet(const gchar *string);
 GtkWidget *gtr_combo_box_new_enum(const char *text_1, ...);
 
 gboolean should_be_minimised(int argc, char *argv[]);
-gboolean is_minimised_arg(const gchar * arg);
+gboolean is_minimised_arg(const gchar *arg);
 GtkWidget *trg_vbox_new(gboolean homogeneous, gint spacing);
 GtkWidget *trg_hbox_new(gboolean homogeneous, gint spacing);
 
 #ifdef G_OS_WIN32
-gchar *trg_win32_support_path(gchar * file);
+gchar *trg_win32_support_path(gchar *file);
 #endif
 
-#endif                          /* UTIL_H_ */
+#endif /* UTIL_H_ */


### PR DESCRIPTION
This is highly opinionated, but it is a style that tries to reduce the
amount of churn in the code base. There are many places where whole
files need to be re-written because their styles are incredibly outside
of every other file.

The CI is updated with a format checker as well as an included
scripts/pre-commit git hook for local use.

closes #186 