### PR TITLE
Fix spacing in torrent information panel

### DIFF
--- a/src/trg-general-panel.c
+++ b/src/trg-general-panel.c
@@ -321,7 +321,8 @@ TrgGeneralPanel *trg_general_panel_new(GtkTreeModel *model, TrgClient *tc)
     GObject *obj;
     TrgGeneralPanelPrivate *priv;
 
-    obj = g_object_new(TRG_TYPE_GENERAL_PANEL, NULL);
+    obj = g_object_new(TRG_TYPE_GENERAL_PANEL, "row-homogeneous", FALSE, "row-spacing", 6,
+                       "column-spacing", 8, NULL);
 
     priv = TRG_GENERAL_PANEL_GET_PRIVATE(obj);
     priv->model = model;


### PR DESCRIPTION
Use grid properties to reinstate the spacing and behaviour of the
original GtkTable.

Closes: #178 
Fixes: e274990 ("change GtkTable to GtkGrid")