### PR TITLE
Trash torrents instead of deleting them

### DIFF
--- a/src/requests.c
+++ b/src/requests.c
@@ -251,6 +251,15 @@ JsonNode *torrent_add_from_response(trg_response *response, gint flags)
     return root;
 }
 
+static void trash_cb(GObject *source_object, GAsyncResult *res, gpointer user_data)
+{
+    g_autoptr(GError) error = NULL;
+
+    if (!g_file_trash_finish(G_FILE(source_object), res, &error))
+        g_warning("Failed to trash '%s': %s", g_file_peek_path(G_FILE(source_object)),
+                  error->message);
+}
+
 JsonNode *torrent_add_from_file(gchar *target, gint flags)
 {
     JsonNode *root;
@@ -282,8 +291,12 @@ JsonNode *torrent_add_from_file(gchar *target, gint flags)
 
     json_object_set_boolean_member(args, PARAM_PAUSED, (flags & TORRENT_ADD_FLAG_PAUSED));
 
-    if ((flags & TORRENT_ADD_FLAG_DELETE))
-        g_unlink(target);
+    if ((flags & TORRENT_ADD_FLAG_DELETE)) {
+        g_autoptr(GFile) file = NULL;
+
+        file = g_file_new_for_path(target);
+        g_file_trash_async(file, G_PRIORITY_DEFAULT, NULL, trash_cb, NULL);
+    }
 
     return root;
 }


### PR DESCRIPTION
If the torrent fails to be added on the server properly, unlinking the
torrent means that it will be lost forever. Trashing the torrent means
it could at least be restored to be downloaded with some other client.