### PR TITLE
Udpate Linux CI for Ubuntu 22.04

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -8,15 +8,14 @@ on:
 
 jobs:
   build-unix:
-    # NOTE: temporarily setting this to get over 20.04 not having libsoup3
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: install deps
         run: |
           sudo apt-get update
           sudo apt-get upgrade
-          sudo apt-get install python3-pip gcc \
+          sudo apt-get install meson gcc \
                                libgtk-3-dev \
                                libjson-glib-dev \
                                libsoup-3.0-dev \
@@ -24,12 +23,9 @@ jobs:
                                \
                                libgeoip-dev \
                                libappstream-dev \
-                               appstream-util \
-
-          # Meson is too old on ubuntu
-          pip3 install --no-input meson ninja
+                               appstream-util
       - name: meson configure
-        run: meson build
+        run: meson setup build
       - name: build
         run: meson compile -C build
       - name: dist

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -32,37 +32,34 @@ jobs:
         run: meson dist -C build
 
   build-windows:
-
     runs-on: windows-latest
-
     defaults:
       run:
         shell: msys2 {0}
-
     steps:
-
       - uses: msys2/setup-msys2@v2
       - name: install deps
         run: |
+          mingw="mingw-w64-x86_64"
           pacman -S --noconfirm \
                     git \
-                    mingw-w64-x86_64-gcc \
-                    mingw-w64-x86_64-meson \
-                    mingw-w64-x86_64-ninja \
-                    mingw-w64-x86_64-pkg-config \
+                    ${mingw}-gcc \
+                    ${mingw}-meson \
+                    ${mingw}-ninja \
+                    ${mingw}-pkg-config \
                     \
-                    mingw-w64-x86_64-gtk3 \
-                    mingw-w64-x86_64-libsoup3 \
-                    mingw-w64-x86_64-glib2 \
-                    mingw-w64-x86_64-gettext \
-                    mingw-w64-x86_64-json-glib \
+                    ${mingw}-gtk3 \
+                    ${mingw}-libsoup3 \
+                    ${mingw}-glib2 \
+                    ${mingw}-gettext \
+                    ${mingw}-json-glib \
                     \
-                    mingw-w64-x86_64-appstream-glib \
-                    mingw-w64-x86_64-desktop-file-utils
+                    ${mingw}-appstream-glib \
+                    ${mingw}-desktop-file-utils
 
       - uses: actions/checkout@v3
       - name: configure
-        run: meson build
+        run: meson setup build
       - name: build
         run: meson compile -C build
       - name: dist


### PR DESCRIPTION
`ubuntu-latest` on github actions is now 22.04, which allows us to use that as the runner ID again. Furthermore, since 22.04 has meson
>=0.59.0 it lets us drop pip.