### PR TITLE
stop overcounting seeders/leechers

### DIFF
--- a/src/trg-torrent-model.c
+++ b/src/trg-torrent-model.c
@@ -131,8 +131,8 @@ static void trg_torrent_model_count_peers(TrgTorrentModel *model, GtkTreeIter *i
     for (li = trackersList; li; li = g_list_next(li)) {
         JsonObject *tracker = json_node_get_object((JsonNode *)li->data);
 
-        seeders += tracker_stats_get_seeder_count(tracker);
-        leechers += tracker_stats_get_leecher_count(tracker);
+        seeders = MAX(seeders, tracker_stats_get_seeder_count(tracker));
+        leechers = MAX(leechers, tracker_stats_get_leecher_count(tracker));
         downloads += tracker_stats_get_download_count(tracker);
     }
 


### PR DESCRIPTION
Peers connect to all available trackers by default, so we should not count them more than once by adding up reported seeds/peers from individual trackers.

Instead, we use the maximum reported value to get much more realistic stats. The probability of undercounting because different peers do not share trackers is very small and much less damaging than massive overcounting.