### PR TITLE
Remove timer source when stats dialog gets closed

### DIFF
--- a/src/trg-stats-dialog.c
+++ b/src/trg-stats-dialog.c
@@ -97,8 +97,7 @@ static void trg_stats_dialog_set_property(GObject *object, guint property_id, co
 static void trg_stats_response_cb(GtkDialog *dlg, gint res_id, gpointer data G_GNUC_UNUSED)
 {
     TrgStatsDialog *trg_dlg = TRG_STATS_DIALOG(dlg);
-    if (trg_dlg->update_stats_timer_tag)
-        g_clear_handle_id(&trg_dlg->update_stats_timer_tag, g_source_remove);
+    g_clear_handle_id(&trg_dlg->update_stats_timer_tag, g_source_remove);
     gtk_widget_destroy(GTK_WIDGET(dlg));
     instance = NULL;
 }


### PR DESCRIPTION
Addresses the following crash:

    #0  0x0000555555574739 in TRG_IS_STATS_DIALOG (ptr=0x55555747e700) at ../src/trg-stats-dialog.h:28
    #1  trg_update_stats_timerfunc (data=data@entry=0x55555747e700) at ../src/trg-stats-dialog.c:234
    #2  0x00007ffff7328359 in g_timeout_dispatch
        (source=0x555556638770, callback=0x555555574720 <trg_update_stats_timerfunc>, user_data=0x55555747e700)
        at ../glib/gmain.c:5070
    #3  0x00007ffff732212c in g_main_dispatch (context=0x5555555b1d50) at ../glib/gmain.c:3357
    #4  g_main_context_dispatch_unlocked (context=0x5555555b1d50) at ../glib/gmain.c:4208
    #5  0x00007ffff7382578 in g_main_context_iterate_unlocked.isra.0
        (context=context@entry=0x5555555b1d50, block=block@entry=1, dispatch=dispatch@entry=1, self=<optimized out>)
        at ../glib/gmain.c:4273
    #6  0x00007ffff7323603 in g_main_context_iteration
        (context=context@entry=0x5555555b1d50, may_block=may_block@entry=1) at ../glib/gmain.c:4338
    #7  0x00007ffff74e0cbd in g_application_run
        (application=application@entry=0x5555555c0b90 [TrgGtkApp], argc=argc@entry=1, argv=argv@entry=0x7fffffffd2d8)
        at ../gio/gapplication.c:2715
    #8  0x0000555555557726 in main (argc=1, argv=0x7fffffffd2d8) at ../src/main.c:57