### PR TITLE
meson: validate appdata without net

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -62,5 +62,5 @@ appdata_file = i18n.merge_file(input: '@0@.appdata.xml.in'.format(app_id),
 
 appstream_util = find_program('appstream-util', required: false)
 if appstream_util.found()
-  test('Validate appdata.xml', appstream_util, args: ['validate-relax', appdata_file])
+  test('Validate appdata.xml', appstream_util, args: ['validate-relax', '--nonet', appdata_file])
 endif


### PR DESCRIPTION
this allows the test to work in network-disconnected build environments; it's what most projects do with this kind of test so it works everywhere