### PR TITLE
Fix windows CI's "allow dirty" fix with git config

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -79,23 +79,12 @@ jobs:
                     \
                     ${mingw}-appstream-glib \
                     ${mingw}-desktop-file-utils
-
+      - name: setup git eol
+        run: git config --global core.autocrlf false
       - uses: actions/checkout@v3
       - name: configure
         run: meson setup build
       - name: build
         run: meson compile -C build
       - name: dist
-        run: |
-          # Why? Line Endings.
-          # actions/checkout runs as a native windows environment and wants
-          # to put CRLF on all lines, while msys2 looks at this and thinks
-          # that every single file has been changed since the line ending is
-          # not LF. Afterwards, `meson dist` (on msys2) will report the repo as
-          # dirty then fail on meson >=0.62 due to the changed default behavior
-          # dist fails on dirty repos. The solution to this is to just add
-          # `--allow-dirty` since our CI runners use the latest meson. But this
-          # is not the cleanest solution since we do care if the repo is dirty,
-          # so add a non-whitespace diff-index check before running meson-dist.
-          git --no-pager diff-index --quiet -b HEAD 2>/dev/null || { git --no-pager diff -b; exit 1; }
-          meson dist --allow-dirty -C build
+        run: meson dist -C build


### PR DESCRIPTION
Gets rid of repo check and allow dirty flag from windows CI, by making sure git doesn't change LFs to CRLFs. I haven't tested it yet, I'll open the PR after being able to build.

The alternative fix would be opening a PR to meson project to do this change

```patch
-        ret = subprocess.call(['git', '-C', self.src_root, 'diff-index', '--quiet', 'HEAD'])
+        ret = subprocess.call(['git', '-C', self.src_root, 'diff-index', '--quiet', '--ignore-cr-at-eol', 'HEAD'])
```
in

https://github.com/mesonbuild/meson/blob/64535bbc821c0276ffe8c894502067a14229e10b/mesonbuild/mdist.py#L174-L180

but only in the cases where the host is windows and the git's `core.autocrlf` config is not set to `false`.

Which is more effort to me right now, than to patch this file. :3