### PR TITLE
Add Faroese translation

### DIFF
--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -4,6 +4,7 @@ cs
 de
 el
 es
+fo
 fr
 hu
 it

--- a/po/fo.po
+++ b/po/fo.po
@@ -1,7 +1,5 @@
 # Faroese translation for transmission-remote-gtk
-# Copyright (c) 2026 Rosetta Contributors and Canonical Ltd 2026
 # This file is distributed under the same license as the transmission-remote-gtk package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
 #
 msgid ""
 msgstr ""

--- a/po/fo.po
+++ b/po/fo.po
@@ -302,7 +302,7 @@ msgstr "Liðugt"
 
 #: ../src/trg-general-panel.c:326 ../src/trg-torrent-tree-view.c:127
 msgid "ETA"
-msgstr "Væntandi liðugt um"
+msgstr "Írestandi tíð"
 
 #: ../src/trg-general-panel.c:328
 msgid "Rate Up"
@@ -1293,7 +1293,7 @@ msgstr "_Torrent fíla:"
 
 #: ../src/trg-torrent-add-dialog.c:766
 msgid "_Destination folder:"
-msgstr "_Skjátta at goyma í:"
+msgstr "_Goym í:"
 
 #: ../src/trg-torrent-add-dialog.c:775
 msgid "Apply to all:"

--- a/po/fo.po
+++ b/po/fo.po
@@ -814,7 +814,7 @@ msgstr "Vís í stýrikervistøðuteiginum."
 
 #: src/trg-preferences-dialog.c:637
 msgid "System tray not supported."
-msgstr "Stýrikervistøðuteigafunka er ikki virkja í ritbúnaði."
+msgstr "Stýrikervistøðuteigafunka er ikki virkt í ritbúnaði."
 
 #: ../src/trg-preferences-dialog.c:776
 msgid "Minimise to system tray"

--- a/po/fo.po
+++ b/po/fo.po
@@ -1,0 +1,1705 @@
+# Faroese translation for transmission-remote-gtk
+# Copyright (c) 2026 Rosetta Contributors and Canonical Ltd 2026
+# This file is distributed under the same license as the transmission-remote-gtk package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: transmission-remote-gtk\n"
+"Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2016-10-03 07:31+0000\n"
+"PO-Revision-Date: 2026-06-13 18:00+0000\n"
+"Last-Translator: krvi <Unknown>\n"
+"Language-Team: Faroese <fo@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Launchpad-Export-Date: 2026-06-12 02:52+0000\n"
+"X-Generator: Launchpad (build 81b3240738cf12f6bd4aac6593260fef8d7b0d96)\n"
+
+#: ../data/transmission-remote-gtk.desktop.in.h:1 ../src/trg-main-window.c:2717
+msgid "Transmission Remote"
+msgstr "Transmission fjarstýring"
+
+#: ../data/transmission-remote-gtk.desktop.in.h:2
+msgid "Remotely manage the Transmission BitTorrent client"
+msgstr "Fjarumsit Transmission BitTorrent viðskiftaran"
+
+#: ../data/transmission-remote-gtk.appdata.xml.in.h:1
+msgid "Transmission Remote Gtk Team"
+msgstr "Transmission Remote GTK toymið"
+
+#: ../data/transmission-remote-gtk.appdata.xml.in.h:2
+msgid ""
+"Transmission Remote Gtk allows you to remotely manage the Transmission "
+"BitTorrent client using its RPC interface. You can use it to to manage "
+"torrents (start/stop/verify/reannounce/remove/remove and delete), add new "
+"ones (it works as a .torrent fle handler from a webbrowser), and configure "
+"settings on transmission-daemon."
+msgstr ""
+"Við Transmission Remote GTK kanst tú fjarumsita Transmission BitTorrent "
+"viðskiftaran umvegis RPC markamót hansara. Innles torrent fílur, byrja, "
+"steðga, strika, vátta og endurfráboða torrentir. Transmission Remote GTK "
+" virkar sum ein handfari fyri .torrent fílar (t.d. frá einum vevkaga)."
+
+#: ../data/transmission-remote-gtk.appdata.xml.in.h:3
+msgid "Features:"
+msgstr "Hentleikar:"
+
+#: ../data/transmission-remote-gtk.appdata.xml.in.h:6
+msgid ""
+"Set torrent properties such as speed, seed, peer limits, file priorities, "
+"add/edit/remove trackers"
+msgstr ""
+"Tillaga torrent eginleikar, eitt nú ferð-, deili- og javningamørk, rekjarar "
+"og fílueginleikar."
+
+#: ../data/transmission-remote-gtk.appdata.xml.in.h:7
+msgid ""
+"Change remote settings like global limits, download directory, and "
+"connectivity preferences"
+msgstr ""
+"Tillaga stillingar, harímillum heiltøk mørk, skjáttur og "
+"sambindingarstillingar"
+
+#: ../src/torrent.c:369 ../src/torrent.c:389
+msgid "Metadata Downloading"
+msgstr "Niðurtekur metadátur"
+
+#: ../src/torrent.c:371 ../src/torrent.c:391 ../src/trg-state-selector.c:677
+msgid "Downloading"
+msgstr "Niðurtekur"
+
+#: ../src/torrent.c:373
+msgid "Queued download"
+msgstr "Niðurtøka í bíðirøð"
+
+#: ../src/torrent.c:375 ../src/torrent.c:399
+msgid "Waiting To Check"
+msgstr "Bíðar eftir kanning"
+
+#: ../src/torrent.c:377 ../src/torrent.c:397 ../src/trg-state-selector.c:703
+msgid "Checking"
+msgstr "Kannar"
+
+#: ../src/torrent.c:379
+msgid "Queued seed"
+msgstr "Deiling í bíðirøð"
+
+#: ../src/torrent.c:381 ../src/torrent.c:395
+#: ../src/trg-remote-prefs-dialog.c:364 ../src/trg-state-selector.c:684
+#: ../src/trg-torrent-props-dialog.c:446
+msgid "Seeding"
+msgstr "Deilir"
+
+#: ../src/torrent.c:383 ../src/torrent.c:393 ../src/torrent-cell-renderer.c:282
+#: ../src/trg-state-selector.c:691
+msgid "Paused"
+msgstr "Steðgað"
+
+#: ../src/torrent.c:403
+msgid "Unknown"
+msgstr "Ókend"
+
+#. %1$s is how much we've got,
+#. %2$s is how much we'll have when done,
+#. %3$s%% is a percentage of the two
+#: ../src/torrent-cell-renderer.c:154
+#, c-format
+msgid "%1$s of %2$s (%3$s)"
+msgstr "%1$s av %2$s (%3$s)"
+
+#: ../src/torrent-cell-renderer.c:164
+#, c-format
+msgid "%1$s of %2$s (%3$s), uploaded %4$s (Ratio: %5$s Goal: %6$s)"
+msgstr "%1$s av %2$s (%3$s), uppsent %4$s (Lutfall: %5$s Mál: %6$s)"
+
+#: ../src/torrent-cell-renderer.c:180
+#, c-format
+msgid "%1$s of %2$s (%3$s), uploaded %4$s (Ratio: %5$s)"
+msgstr "%1$s av %2$s (%3$s), uppsent %4$s (Lutfall: %5$s)"
+
+#: ../src/torrent-cell-renderer.c:197
+#, c-format
+msgid "%1$s, uploaded %2$s (Ratio: %3$s Goal: %4$s)"
+msgstr "%1$s, uppsent %2$s (Lutfall: %3$s Mál: %4$s)"
+
+#. %1$s is the torrent's total size,
+#. %2$s is how much we've uploaded,
+#. %3$s is our upload-to-download ratio
+#: ../src/torrent-cell-renderer.c:211
+#, c-format
+msgid "%1$s, uploaded %2$s (Ratio: %3$s)"
+msgstr "%1$s, uppsent %2$s (Lutfall: %3$s)"
+
+#: ../src/torrent-cell-renderer.c:227
+msgid "Remaining time unknown"
+msgstr "Ókend tíð eftir"
+
+#. time remaining
+#: ../src/torrent-cell-renderer.c:232
+#, c-format
+msgid "%s remaining"
+msgstr "%s eftir"
+
+#. 1==down arrow, 2==down speed, 3==up arrow, 4==down speed
+#: ../src/torrent-cell-renderer.c:256
+#, c-format
+msgid "%1$s %2$s, %3$s %4$s"
+msgstr "%1$s %2$s, %3$s %4$s"
+
+#. bandwidth speed + unicode arrow
+#: ../src/torrent-cell-renderer.c:260 ../src/torrent-cell-renderer.c:263
+#, c-format
+msgid "%1$s %2$s"
+msgstr "%1$s %2$s"
+
+#: ../src/torrent-cell-renderer.c:267
+msgid "Idle"
+msgstr "Stígur"
+
+#: ../src/torrent-cell-renderer.c:281
+msgid "Finished"
+msgstr "Liðugt"
+
+#: ../src/torrent-cell-renderer.c:284
+msgid "Queued for verification"
+msgstr "Váttan í bíðirøð"
+
+#: ../src/torrent-cell-renderer.c:286
+msgid "Queued for download"
+msgstr "Niðurtøka í bíðirøð"
+
+#: ../src/torrent-cell-renderer.c:288
+msgid "Queued for seeding"
+msgstr "Deiling í bíðirøð"
+
+#: ../src/torrent-cell-renderer.c:291
+#, c-format
+msgid "Verifying data (%1$s tested)"
+msgstr "Váttar dátur (%1$s nároyndar)"
+
+#: ../src/torrent-cell-renderer.c:299
+#, c-format
+msgid "Ratio %s"
+msgstr "Lutfall %s"
+
+#: ../src/torrent-cell-renderer.c:313
+#, c-format
+msgid "Tracker gave a warning: \"%s\""
+msgstr "Rekjari ávaraði: \"%s\""
+
+#: ../src/torrent-cell-renderer.c:314
+#, c-format
+msgid "Tracker gave an error: \"%s\""
+msgstr "Rekjari boðaði frá villu: \"%s\""
+
+#: ../src/torrent-cell-renderer.c:315
+#, c-format
+msgid "Error: %s"
+msgstr "Villa: %s"
+
+#: ../src/torrent-cell-renderer.c:329
+msgid "Downloading from %1$"
+msgid_plural "Downloading from %1$"
+msgstr[0] "Niðurtekur frá %1$"
+msgstr[1] "Niðurtekur frá %1$"
+
+#: ../src/torrent-cell-renderer.c:337
+msgid "Downloading metadata from %1$"
+msgid_plural "Downloading metadata from %1$"
+msgstr[0] "Niðurtekur metadátur frá %1$"
+msgstr[1] "Niðurtekur metadátur frá %1$"
+
+#: ../src/torrent-cell-renderer.c:348
+msgid "Seeding to %1$"
+msgid_plural "Seeding to %1$"
+msgstr[0] "Deilir við %1$"
+msgstr[1] "Deilir við %1$"
+
+#: ../src/trg-about-window.c:59
+msgid "A remote client to transmission-daemon."
+msgstr "Ein fjarviskiftari til transmission-daemon."
+
+#: ../src/trg-cell-renderer-priority.c:78 ../src/trg-general-panel.c:202
+#: ../src/trg-main-window.c:2079 ../src/trg-torrent-add-dialog.c:382
+#: ../src/trg-torrent-props-dialog.c:415
+msgid "Low"
+msgstr "Lágt"
+
+#: ../src/trg-cell-renderer-priority.c:80 ../src/trg-general-panel.c:208
+#: ../src/trg-main-window.c:2075 ../src/trg-torrent-add-dialog.c:383
+#: ../src/trg-torrent-props-dialog.c:417
+msgid "High"
+msgstr "Høgt"
+
+#: ../src/trg-cell-renderer-priority.c:82 ../src/trg-general-panel.c:205
+#: ../src/trg-main-window.c:2077 ../src/trg-torrent-add-dialog.c:382
+#: ../src/trg-torrent-props-dialog.c:416
+msgid "Normal"
+msgstr "Vanligt"
+
+#: ../src/trg-cell-renderer-priority.c:84
+msgid "Mixed"
+msgstr "Ymisk"
+
+#: ../src/trg-files-tree-view.c:189 ../src/trg-general-panel.c:316
+#: ../src/trg-preferences-dialog.c:653 ../src/trg-torrent-add-dialog.c:284
+#: ../src/trg-torrent-tree-view.c:56
+msgid "Name"
+msgstr "Navn"
+
+#. add "size" column
+#: ../src/trg-files-tree-view.c:193 ../src/trg-general-panel.c:319
+#: ../src/trg-torrent-add-dialog.c:302 ../src/trg-torrent-tree-view.c:61
+msgid "Size"
+msgstr "Stødd"
+
+#: ../src/trg-files-tree-view.c:195 ../src/trg-peers-tree-view.c:74
+msgid "Progress"
+msgstr "Liðið"
+
+#. add "enabled" column
+#: ../src/trg-files-tree-view.c:197 ../src/trg-torrent-add-dialog.c:315
+#: ../src/trg-torrent-add-dialog.c:665 ../src/trg-files-tree-view-common.c:69
+msgid "Download"
+msgstr "Tak niður"
+
+#. add priority column
+#: ../src/trg-files-tree-view.c:199 ../src/trg-general-panel.c:349
+#: ../src/trg-main-window.c:2068 ../src/trg-torrent-add-dialog.c:331
+#: ../src/trg-torrent-tree-view.c:149
+msgid "Priority"
+msgstr "Raðfesti"
+
+#: ../src/trg-general-panel.c:176 ../src/trg-general-panel.c:250
+#: ../src/trg-torrent-props-dialog.c:344 ../src/util.c:487
+msgid "N/A"
+msgstr "—"
+
+#: ../src/trg-general-panel.c:194
+msgid "(Private)"
+msgstr "(Privat)"
+
+#: ../src/trg-general-panel.c:194
+msgid "(Public)"
+msgstr "(Alment)"
+
+#: ../src/trg-general-panel.c:238 ../src/trg-main-window.c:1142
+#: ../src/trg-main-window.c:1555 ../src/trg-main-window.c:2203
+#: ../src/trg-rss-window.c:207 ../src/trg-rss-window.c:221
+#: ../src/trg-state-selector.c:557 ../src/trg-torrent-add-url-dialog.c:71
+#: ../src/util.c:333
+msgid "Error"
+msgstr "Villa"
+
+#: ../src/trg-general-panel.c:321
+msgid "Rate Down"
+msgstr "Niðurtøkuferð"
+
+#: ../src/trg-general-panel.c:323 ../src/trg-torrent-tree-view.c:155
+msgid "Completed"
+msgstr "Liðugt"
+
+#: ../src/trg-general-panel.c:326 ../src/trg-torrent-tree-view.c:127
+msgid "ETA"
+msgstr "Væntandi liðugt um"
+
+#: ../src/trg-general-panel.c:328
+msgid "Rate Up"
+msgstr "Uppsendiferð"
+
+#: ../src/trg-general-panel.c:330 ../src/trg-torrent-tree-view.c:132
+msgid "Downloaded"
+msgstr "Niðurtikið"
+
+#: ../src/trg-general-panel.c:333
+msgid "Seeders"
+msgstr "Deilarir"
+
+#: ../src/trg-general-panel.c:335 ../src/trg-stats-dialog.c:321
+#: ../src/trg-torrent-tree-view.c:135
+msgid "Ratio"
+msgstr "Deililutfall"
+
+#: ../src/trg-general-panel.c:337 ../src/trg-torrent-tree-view.c:129
+msgid "Uploaded"
+msgstr "Uppsent"
+
+#: ../src/trg-general-panel.c:340 ../src/trg-torrent-tree-view.c:74
+msgid "Leechers"
+msgstr "Niðurtakarar"
+
+#: ../src/trg-general-panel.c:342
+msgid "Ratio limit"
+msgstr "Deililutfalsmark"
+
+#: ../src/trg-general-panel.c:344
+msgid "Corrupted"
+msgstr "Lýtt"
+
+#: ../src/trg-general-panel.c:347 ../src/trg-torrent-tree-view.c:67
+msgid "Status"
+msgstr "Støða"
+
+#: ../src/trg-general-panel.c:351
+msgid "Completed At"
+msgstr "Liðugt tann"
+
+#: ../src/trg-general-panel.c:354 ../src/trg-torrent-tree-view.c:143
+msgid "Location"
+msgstr "Stað"
+
+#: ../src/trg-general-panel.c:357
+msgid "Comment"
+msgstr "Viðmerking"
+
+#: ../src/trg-gtk-app.c:183 ../src/trg-peers-tree-view.c:78
+msgid "Client"
+msgstr "Viðskiftari"
+
+#: ../src/trg-gtk-app.c:192
+msgid "Min On Start"
+msgstr "Minsta undir byrjan"
+
+#: ../src/trg-main-window.c:368
+msgid "This torrent has completed."
+msgstr "Torrentið er liðugt."
+
+#: ../src/trg-main-window.c:380
+msgid "This torrent has been added."
+msgstr "Torrentið er innlagt."
+
+#: ../src/trg-main-window.c:610
+msgid "No hostname set"
+msgstr "Vertsnavn ikki ásett"
+
+#: ../src/trg-main-window.c:613
+msgid "Unknown error getting settings"
+msgstr "Ókend villa undir innlesing av stillingum"
+
+#: ../src/trg-main-window.c:633
+msgid "Connecting..."
+msgstr "Sambindur…"
+
+#: ../src/trg-main-window.c:902
+#, c-format
+msgid "<big><b>Remove torrent \"%s\"?</b></big>"
+msgstr "<big><b>Ynskir tú at strika torrentið \"%s\"?</b></big>"
+
+#: ../src/trg-main-window.c:903
+#, c-format
+msgid "<big><b>Remove %d torrents?</b></big>"
+msgstr "<big><b>Ynskir tú at strika %d torrentir?</b></big>"
+
+#: ../src/trg-main-window.c:925
+#, c-format
+msgid "<big><b>Remove and delete torrent \"%s\"?</b></big>"
+msgstr "<big><b>Ynskir tú at strika torrentið og dáturnar \"%s\"?</b></big>"
+
+#: ../src/trg-main-window.c:927
+#, c-format
+msgid "<big><b>Remove and delete %d torrents?</b></big>"
+msgstr "<big><b>Ynskir tú at strika %d torrentir og teirra dátur?</b></big>"
+
+#: src/trg-main-window.c:704 src/trg-torrent-add-dialog.c:487
+#: src/trg-torrent-add-dialog.c:592
+msgid "_Cancel"
+msgstr "_Angra"
+
+#: src/trg-main-window.c:740
+msgid "_Remove"
+msgstr "Strika t_orrent"
+
+#: ../src/trg-main-window.c:1026 ../src/trg-preferences-dialog.c:947
+#: ../src/trg-remote-prefs-dialog.c:697
+msgid "General"
+msgstr "Yvirskipað"
+
+#: ../src/trg-main-window.c:1035 ../src/trg-torrent-props-dialog.c:621
+msgid "Trackers"
+msgstr "Rekjarar"
+
+#: ../src/trg-main-window.c:1043 ../src/trg-torrent-props-dialog.c:590
+msgid "Files"
+msgstr "Fílur"
+
+#: ../src/trg-main-window.c:1051 ../src/trg-remote-prefs-dialog.c:403
+#: ../src/trg-torrent-props-dialog.c:464 ../src/trg-torrent-props-dialog.c:604
+#: ../src/trg-trackers-tree-view.c:194
+msgid "Peers"
+msgstr "Javningar"
+
+#: ../src/trg-main-window.c:1134
+#, c-format
+msgid "This application supports Transmission %g and later, you have %g."
+msgstr ""
+"Hetta nýtsluforritið virkar við Transmission útgávu %g og nýggjari. Tú hevur "
+"%g."
+
+#: ../src/trg-main-window.c:1200 ../src/trg-status-bar.c:78
+#: ../src/trg-status-bar.c:108
+msgid "Disconnected"
+msgstr "Ósambundin"
+
+#: ../src/trg-main-window.c:1245
+#, c-format
+msgid "%d Downloading @ %s"
+msgstr "%d Niðurtekur @ %s"
+
+#: ../src/trg-main-window.c:1252
+#, c-format
+msgid "%d Seeding @ %s"
+msgstr "Deilir %d við %s"
+
+#: ../src/trg-main-window.c:1303
+#, c-format
+msgid "Request %d/%d failed: %s"
+msgstr "Umbøn %d/%d miseydnaðist: %s"
+
+#: ../src/trg-main-window.c:2123
+msgid "No Limit"
+msgstr "Einki mark"
+
+#: ../src/trg-main-window.c:2224 ../src/trg-menu-bar.c:712
+#: ../src/trg-toolbar.c:228
+msgid "Properties"
+msgstr "Eginleikar"
+
+#: src/trg-main-window.c:1817
+msgid "Copy Magnet Link"
+msgstr "Avrita magnet-leinkju"
+
+#: ../src/trg-main-window.c:2227 ../src/trg-toolbar.c:221
+msgid "Resume"
+msgstr "Tak uppaftur"
+
+#: ../src/trg-main-window.c:2230 ../src/trg-toolbar.c:224
+msgid "Pause"
+msgstr "Steðga"
+
+#: ../src/trg-main-window.c:2233
+msgid "Verify"
+msgstr "Vátta"
+
+#: ../src/trg-main-window.c:2236
+msgid "Re-announce"
+msgstr "Endurfráboða"
+
+#: ../src/trg-main-window.c:2239 ../src/trg-torrent-move-dialog.c:122
+#: ../src/trg-torrent-move-dialog.c:129
+msgid "Move"
+msgstr "Flyt"
+
+#: ../src/trg-main-window.c:2242 ../src/trg-menu-bar.c:743
+#: ../src/trg-toolbar.c:232
+msgid "Remove"
+msgstr "Strika torrent"
+
+#: ../src/trg-main-window.c:2245 ../src/trg-menu-bar.c:749
+#: ../src/trg-toolbar.c:236
+msgid "Remove and delete data"
+msgstr "Strika torrent og dátur"
+
+#: ../src/trg-main-window.c:2269 ../src/trg-preferences-dialog.c:957
+msgid "Actions"
+msgstr "Atgerðir"
+
+#: ../src/trg-main-window.c:2298 ../src/trg-menu-bar.c:759
+msgid "Start Now"
+msgstr "Byrja nú"
+
+#: ../src/trg-main-window.c:2301 ../src/trg-menu-bar.c:764
+msgid "Move Up Queue"
+msgstr "Flyt fram í bíðirøðini"
+
+#: ../src/trg-main-window.c:2304 ../src/trg-menu-bar.c:771
+msgid "Move Down Queue"
+msgstr "Flyt aftur í bíðirøðini"
+
+#: ../src/trg-main-window.c:2307 ../src/trg-menu-bar.c:778
+msgid "Bottom Of Queue"
+msgstr "Set aftast í bíðirøðini"
+
+#: ../src/trg-main-window.c:2310 ../src/trg-menu-bar.c:782
+msgid "Top Of Queue"
+msgstr "Set fremst í bíðirøðini"
+
+#: ../src/trg-main-window.c:2319 ../src/trg-main-window.c:2402
+msgid "Down Limit"
+msgstr "Niðurtøkumark"
+
+#: ../src/trg-main-window.c:2324 ../src/trg-main-window.c:2406
+msgid "Up Limit"
+msgstr "Uppsendimark"
+
+#: ../src/trg-main-window.c:2353 ../src/trg-main-window.c:2360
+#: ../src/trg-remote-prefs-dialog.c:501
+msgid "Updating..."
+msgstr "Innlesur"
+
+#: ../src/trg-main-window.c:2374 ../src/trg-menu-bar.c:671
+#: ../src/trg-toolbar.c:200
+msgid "Connect"
+msgstr "Sambind"
+
+#: ../src/trg-main-window.c:2381 ../src/trg-toolbar.c:211
+msgid "Disconnect"
+msgstr "Slít samband"
+
+#: ../src/trg-main-window.c:2385 ../src/trg-toolbar.c:214
+#: ../src/trg-trackers-tree-view.c:288 ../src/trg-trackers-tree-view.c:315
+msgid "Add"
+msgstr "Legg inn"
+
+#: ../src/trg-main-window.c:2389
+msgid "Add from URL"
+msgstr "Innles frá leinkju"
+
+#: ../src/trg-main-window.c:2393
+msgid "Resume All"
+msgstr "Tak øll uppaftur"
+
+#: ../src/trg-main-window.c:2397
+msgid "Pause All"
+msgstr "Steðga øllum"
+
+#: ../src/trg-main-window.c:2413
+msgid "Quit"
+msgstr "Loka"
+
+#: ../src/trg-main-window.c:2527 ../src/trg-menu-bar.c:565
+msgid "Graph"
+msgstr "Linjumynd"
+
+#: ../src/trg-menu-bar.c:485
+msgid "_View"
+msgstr "Sýn_i"
+
+#: ../src/trg-menu-bar.c:494
+msgid "Transmission Style"
+msgstr "Transmission snið"
+
+#: ../src/trg-menu-bar.c:504
+msgid "Transmission Compact Style"
+msgstr "Stappað Transmission snið"
+
+#: ../src/trg-menu-bar.c:514
+msgid "Classic Style"
+msgstr "Klassiskt snið"
+
+#: ../src/trg-menu-bar.c:520
+msgid "Sort"
+msgstr "Raða"
+
+#: ../src/trg-menu-bar.c:525 ../src/trg-preferences-dialog.c:718
+msgid "State selector"
+msgstr "Støðuveljari"
+
+#: ../src/trg-menu-bar.c:531 ../src/trg-preferences-dialog.c:725
+msgid "Directory filters"
+msgstr "Skjáttufiltur"
+
+#: ../src/trg-menu-bar.c:540 ../src/trg-preferences-dialog.c:732
+msgid "Tracker filters"
+msgstr "Rekjarafiltur"
+
+#: ../src/trg-menu-bar.c:549 ../src/trg-preferences-dialog.c:739
+msgid "Directories first"
+msgstr "Skjáttur uppiyvir rekjarum"
+
+#: ../src/trg-menu-bar.c:557 ../src/trg-preferences-dialog.c:746
+msgid "Torrent Details"
+msgstr "Torrent-upplýsingar"
+
+#: ../src/trg-menu-bar.c:571
+msgid "_Statistics"
+msgstr "_Hagtøl"
+
+#: ../src/trg-menu-bar.c:578
+msgid "_RSS"
+msgstr "_RSS"
+
+#: ../src/trg-menu-bar.c:591
+msgid "_Options"
+msgstr "_Stillingar"
+
+#: ../src/trg-menu-bar.c:597
+msgid "_Local Preferences"
+msgstr "_Nærstillingar"
+
+#: ../src/trg-menu-bar.c:604
+msgid "_Remote Preferences"
+msgstr "_Fjarstillingar"
+
+#: ../src/trg-menu-bar.c:664
+msgid "_File"
+msgstr "_Fíla"
+
+#: ../src/trg-menu-bar.c:677
+msgid "_Disconnect"
+msgstr "_Slít samband"
+
+#: ../src/trg-menu-bar.c:683
+msgid "_Add"
+msgstr "Legg _inn"
+
+#: ../src/trg-menu-bar.c:688
+msgid "Add from _URL"
+msgstr "Innles frá _leinkju"
+
+#: ../src/trg-menu-bar.c:694
+msgid "_Quit"
+msgstr "L_oka"
+
+#: ../src/trg-menu-bar.c:705
+msgid "_Torrent"
+msgstr "_Torrent"
+
+#: src/trg-menu-bar.c:575
+msgid "_Copy Magnet Link"
+msgstr "_Avrita magnet-leinkju"
+
+#: ../src/trg-menu-bar.c:717
+msgid "_Resume"
+msgstr "_Tak uppaftur"
+
+#: ../src/trg-menu-bar.c:722
+msgid "_Pause"
+msgstr "_Steðga"
+
+#: ../src/trg-menu-bar.c:727
+msgid "_Verify"
+msgstr "_Vátta"
+
+#: ../src/trg-menu-bar.c:733
+msgid "Re-_announce"
+msgstr "Endur_fráboða"
+
+#: ../src/trg-menu-bar.c:738
+msgid "_Move"
+msgstr "_Flyt"
+
+#: ../src/trg-menu-bar.c:790
+msgid "_Resume All"
+msgstr "_Tak øll uppaftur"
+
+#: ../src/trg-menu-bar.c:796
+msgid "_Pause All"
+msgstr "_Steðga øllum"
+
+#: ../src/trg-menu-bar.c:808
+msgid "_Help"
+msgstr "_Hjálp"
+
+#: ../src/trg-menu-bar.c:814
+msgid "_About"
+msgstr "_Um"
+
+#: ../src/trg-peers-tree-view.c:54
+msgid "IP"
+msgstr "IP"
+
+#: ../src/trg-peers-tree-view.c:58 ../src/trg-trackers-tree-view.c:213
+msgid "Host"
+msgstr "Vertur"
+
+#: ../src/trg-peers-tree-view.c:63
+msgid "Country"
+msgstr "Land"
+
+#: ../src/trg-peers-tree-view.c:67
+msgid "City"
+msgstr "Býur"
+
+#: ../src/trg-peers-tree-view.c:70 ../src/trg-torrent-tree-view.c:121
+msgid "Down Speed"
+msgstr "Niðurtøkuferð"
+
+#: ../src/trg-peers-tree-view.c:72 ../src/trg-torrent-tree-view.c:124
+msgid "Up Speed"
+msgstr "Uppsendiferð"
+
+#: ../src/trg-peers-tree-view.c:76
+msgid "Flags"
+msgstr "Fløgg"
+
+#: ../src/trg-preferences-dialog.c:409
+msgid "Updates"
+msgstr "Innlesingar"
+
+#: ../src/trg-preferences-dialog.c:411
+msgid "Update active torrents only"
+msgstr "Innles einans virkin torrentir"
+
+#: ../src/trg-preferences-dialog.c:418
+msgid "Full update every (?) updates"
+msgstr "Innles øll fyri (?). hvørja innlesing"
+
+#: ../src/trg-preferences-dialog.c:432
+msgid "Update interval:"
+msgstr "Innlesimillumbil"
+
+#: ../src/trg-preferences-dialog.c:436
+msgid "Minimised update interval:"
+msgstr "Innlesimillumbil í minstaðari støðu:"
+
+#: ../src/trg-preferences-dialog.c:441
+msgid "Session update interval:"
+msgstr "Setuendurskapanarmillumbil:"
+
+#: ../src/trg-preferences-dialog.c:443
+msgid "Torrents"
+msgstr "Torrentir"
+
+#: ../src/trg-preferences-dialog.c:445
+msgid "Start paused"
+msgstr "Ikki byrja innlisin torrentir"
+
+#: ../src/trg-preferences-dialog.c:449
+msgid "Options dialog on add"
+msgstr "Vís innleggingarkostir"
+
+#: ../src/trg-preferences-dialog.c:454 ../src/trg-torrent-add-dialog.c:737
+msgid "Delete local .torrent file after adding"
+msgstr "Strika .torrent fílu eftir at hon er innløgd"
+
+#: ../src/trg-preferences-dialog.c:607
+msgid "Commands"
+msgstr "Stýriboð"
+
+#: ../src/trg-preferences-dialog.c:617 ../src/trg-preferences-dialog.c:691
+msgid "Label"
+msgstr "Frámerki"
+
+#: ../src/trg-preferences-dialog.c:620
+msgid "Command"
+msgstr "Stýriboð"
+
+#: ../src/trg-preferences-dialog.c:643 ../src/trg-preferences-dialog.c:968
+#: ../src/trg-rss-window.c:274
+msgid "RSS Feeds"
+msgstr "RSS leinkjur"
+
+#: ../src/trg-preferences-dialog.c:656
+msgid "URL"
+msgstr "URL"
+
+#: ../src/trg-preferences-dialog.c:681
+msgid "Remote Download Directories"
+msgstr "Fjarniðurtøkuskjáttur"
+
+#: ../src/trg-preferences-dialog.c:694
+msgid "Directory"
+msgstr "Skjátta"
+
+#: ../src/trg-preferences-dialog.c:716 ../src/trg-preferences-dialog.c:952
+msgid "View"
+msgstr "Sýni"
+
+#: ../src/trg-preferences-dialog.c:754
+msgid "Show graph"
+msgstr "Vís linjumynd"
+
+#: ../src/trg-preferences-dialog.c:761
+msgid "System Tray"
+msgstr "Stýrikervistøðuteigur"
+
+#: ../src/trg-preferences-dialog.c:764
+msgid "Show in system tray (needs whitelisting in unity)"
+msgstr "Vís í stýrikervistøðuteigi (tørvur er á loyvi í Unity)"
+
+#: ../src/trg-preferences-dialog.c:766
+msgid "Show in system tray"
+msgstr "Vís í stýrikervistøðuteiginum."
+
+#: src/trg-preferences-dialog.c:637
+msgid "System tray not supported."
+msgstr "Stýrikevistøðuteigafunka er ikki virkja í ritbúnaði."
+
+#: ../src/trg-preferences-dialog.c:776
+msgid "Minimise to system tray"
+msgstr "Minsta til stýrikervistøðuteigin."
+
+#: ../src/trg-preferences-dialog.c:786
+msgid "Notifications"
+msgstr "Fráboðanir"
+
+#: ../src/trg-preferences-dialog.c:788
+msgid "Torrent added notifications"
+msgstr "Fráboða um innlagt torrent"
+
+#: ../src/trg-preferences-dialog.c:792
+msgid "Torrent complete notifications"
+msgstr "Fráboða um liðug torrentir"
+
+#: ../src/trg-preferences-dialog.c:819
+msgid "Profile: "
+msgstr "Umhvarv: "
+
+#: src/trg-preferences-dialog.c:683
+msgid "New"
+msgstr "Nýtt"
+
+#: ../src/trg-preferences-dialog.c:845
+msgid "Name:"
+msgstr "Navn:"
+
+#: ../src/trg-preferences-dialog.c:850 ../src/trg-preferences-dialog.c:942
+msgid "Connection"
+msgstr "Samband"
+
+#: ../src/trg-preferences-dialog.c:853
+msgid "Host:"
+msgstr "Vertur:"
+
+#: ../src/trg-preferences-dialog.c:857
+msgid "Port:"
+msgstr "Portur:"
+
+#: ../src/trg-preferences-dialog.c:859
+msgid "RPC URL Path:"
+msgstr "RPC URL leið:"
+
+#: ../src/trg-preferences-dialog.c:862
+msgid "Username:"
+msgstr "Brúkaranavn:"
+
+#: ../src/trg-preferences-dialog.c:866
+msgid "Password:"
+msgstr "Loyniorð:"
+
+#: ../src/trg-preferences-dialog.c:868
+msgid "Automatically connect"
+msgstr "Sambind sjálvvirkandi"
+
+#: ../src/trg-preferences-dialog.c:874
+msgid "SSL"
+msgstr "SSL"
+
+#: ../src/trg-preferences-dialog.c:877
+msgid "Validate SSL Certificate"
+msgstr "Vátta SSL-sertifikat"
+
+#: ../src/trg-preferences-dialog.c:885
+msgid "Timeout:"
+msgstr "Bíðitíð:"
+
+#: ../src/trg-preferences-dialog.c:889
+msgid "Retries:"
+msgstr "Endurroyndir:"
+
+#: src/trg-preferences-dialog.c:738
+msgid "Headers"
+msgstr "Høvd"
+
+#: src/trg-preferences-dialog.c:746
+msgid "Value"
+msgstr "Virði"
+
+#: src/trg-preferences-dialog.c:778 src/trg-remote-prefs-dialog.c:627
+#: src/trg-stats-dialog.c:267 src/trg-torrent-add-url-dialog.c:130
+#: src/trg-torrent-move-dialog.c:105 src/trg-torrent-props-dialog.c:491
+msgid "_Close"
+msgstr "_Loka"
+
+#: ../src/trg-preferences-dialog.c:931 ../src/trg-toolbar.c:243
+msgid "Local Preferences"
+msgstr "Nærstillingar"
+
+#: ../src/trg-preferences-dialog.c:962
+msgid "Directories"
+msgstr "Skjáttur"
+
+#: ../src/trg-remote-prefs-dialog.c:309
+msgid "Bandwidth limits"
+msgstr "Bandbreiddaravmarkingar"
+
+#: ../src/trg-remote-prefs-dialog.c:313
+msgid "Down Limit (KiB/s)"
+msgstr "Niðurtøkumark (KiB/s)"
+
+#: ../src/trg-remote-prefs-dialog.c:320
+msgid "Up Limit (KiB/s)"
+msgstr "Uppsendimark (KiB/s)"
+
+#: ../src/trg-remote-prefs-dialog.c:325
+msgid "Alternate limits"
+msgstr "Tiltaksmørk"
+
+#: ../src/trg-remote-prefs-dialog.c:330
+msgid "Alternate speed limits active"
+msgstr "Virkja tiltaksferðmørk"
+
+#: ../src/trg-remote-prefs-dialog.c:337
+msgid "Alternate time range"
+msgstr "Galdandi í tíðarskeiðinum"
+
+#: src/trg-remote-prefs-dialog.c:339
+msgid "Alternate days"
+msgstr "Dagar galdandi"
+
+#: ../src/trg-remote-prefs-dialog.c:344
+msgid "Alternate down limit (KiB/s)"
+msgstr "Tiltaksniðurtøkumark (KiB/s)"
+
+#: ../src/trg-remote-prefs-dialog.c:349
+msgid "Alternate up limit (KiB/s)"
+msgstr "Tiltaksuppsendimark (KiB/s)"
+
+#: ../src/trg-remote-prefs-dialog.c:368
+msgid "Seed ratio limit"
+msgstr "Deililutfalsmark"
+
+#: ../src/trg-remote-prefs-dialog.c:375
+msgid "Queues"
+msgstr "Bíðirøðir"
+
+#: ../src/trg-remote-prefs-dialog.c:379
+msgid "Download queue size"
+msgstr "Samstundis niðurtøkur"
+
+#: ../src/trg-remote-prefs-dialog.c:387
+msgid "Seed queue size"
+msgstr "Samstundis uppsendingar"
+
+#: ../src/trg-remote-prefs-dialog.c:395
+msgid "Ignore stalled (minutes)"
+msgstr "Minuttir uttan virksemi áðrenn útilokan"
+
+#: ../src/trg-remote-prefs-dialog.c:408
+msgid "Global peer limit"
+msgstr "Heiltøkt javningamark"
+
+#: ../src/trg-remote-prefs-dialog.c:413
+msgid "Per torrent peer limit"
+msgstr "Javningamark fyri hvørt torrent"
+
+#: ../src/trg-remote-prefs-dialog.c:426
+msgid "Retest"
+msgstr "Royn aftur"
+
+#: ../src/trg-remote-prefs-dialog.c:437
+msgid "Port is <span font_weight=\"bold\" fgcolor=\"darkgreen\">open</span>"
+msgstr ""
+"Portrið er <span font_weight=\"bold\" fgcolor=\"darkgreen\">opið</span>"
+
+#: ../src/trg-remote-prefs-dialog.c:441
+msgid "Port is <span font_weight=\"bold\" fgcolor=\"red\">closed</span>"
+msgstr "Portrið er <span font_weight=\"bold\" fgcolor=\"red\">læst</span>"
+
+#: ../src/trg-remote-prefs-dialog.c:457 ../src/trg-remote-prefs-dialog.c:526
+msgid "Port test"
+msgstr "Nároyn portur"
+
+#: ../src/trg-remote-prefs-dialog.c:458
+msgid "Testing..."
+msgstr "Nároynur..."
+
+#: ../src/trg-remote-prefs-dialog.c:473 ../src/trg-remote-prefs-dialog.c:581
+msgid "Update"
+msgstr "Dagfør"
+
+#: ../src/trg-remote-prefs-dialog.c:478 ../src/trg-remote-prefs-dialog.c:572
+msgid "Blocklist (%"
+msgstr "Svartalisti (%"
+
+#: ../src/trg-remote-prefs-dialog.c:520 ../src/trg-remote-prefs-dialog.c:702
+msgid "Connections"
+msgstr "Sambindingar"
+
+#: ../src/trg-remote-prefs-dialog.c:524
+msgid "Peer port"
+msgstr "Javningaportur"
+
+#: ../src/trg-remote-prefs-dialog.c:527
+msgid "Test"
+msgstr "Nároyn"
+
+#: ../src/trg-remote-prefs-dialog.c:531
+msgid "Required"
+msgstr "Kravd"
+
+#: ../src/trg-remote-prefs-dialog.c:532
+msgid "Preferred"
+msgstr "Ynskt"
+
+#: ../src/trg-remote-prefs-dialog.c:533
+msgid "Tolerated"
+msgstr "Told"
+
+#: ../src/trg-remote-prefs-dialog.c:544
+msgid "Encryption"
+msgstr "Bronglan"
+
+#: ../src/trg-remote-prefs-dialog.c:548
+msgid "Random peer port on start"
+msgstr "Vel tilvildarligt javningaportur undir hvørjari koyring"
+
+#: ../src/trg-remote-prefs-dialog.c:511
+msgid "Request forwarding of the peer port using UPnP or NAT-PMP"
+msgstr "Bið um porturvíðaristilling umvegis UPnP ella NAT-PMP"
+
+#: ../src/trg-remote-prefs-dialog.c:553
+msgid "Peer port forwarding"
+msgstr "Javninga porturvíðaristilling"
+
+#: ../src/trg-remote-prefs-dialog.c:556
+msgid "Protocol"
+msgstr "Samskiftisreglur"
+
+#: ../src/trg-remote-prefs-dialog.c:559
+msgid "Peer exchange (PEX)"
+msgstr "Javningaumbýti (PEX)"
+
+#: ../src/trg-remote-prefs-dialog.c:563
+msgid "Distributed Hash Table (DHT)"
+msgstr "Útbýttar hash-talvur (DHT)"
+
+#: ../src/trg-remote-prefs-dialog.c:567
+msgid "Local peer discovery"
+msgstr "Javningaviðraking á nærneti"
+
+#: ../src/trg-remote-prefs-dialog.c:570
+msgid "Blocklist"
+msgstr "Svartalisti"
+
+#: ../src/trg-remote-prefs-dialog.c:590
+msgid "Blocklist URL:"
+msgstr "Svartalistaleinkja:"
+
+#: ../src/trg-remote-prefs-dialog.c:608
+msgid "Environment"
+msgstr "Umhvørvi"
+
+#: ../src/trg-remote-prefs-dialog.c:612
+msgid "Download directory"
+msgstr "Skjátta til niðurtøkur"
+
+#: ../src/trg-remote-prefs-dialog.c:616
+msgid "Incomplete download dir"
+msgstr "Skjátta til ólidnar niðurtøkur"
+
+#: ../src/trg-remote-prefs-dialog.c:623
+msgid "Torrent done script"
+msgstr "Skeljarrit at koyra tá torrentir eru liðug"
+
+#: ../src/trg-remote-prefs-dialog.c:632
+msgid "Cache size (MiB)"
+msgstr "Kovastødd (MiB)"
+
+#: ../src/trg-remote-prefs-dialog.c:635
+msgid "Behavior"
+msgstr "Atburður"
+
+#: ../src/trg-remote-prefs-dialog.c:639
+msgid "Rename partial files"
+msgstr "Navnaeftirfesti á ólidnar fílar"
+
+#: ../src/trg-remote-prefs-dialog.c:644
+msgid "Trash original torrent files"
+msgstr "Strika upprunaligu torrent fílur"
+
+#: ../src/trg-remote-prefs-dialog.c:649
+msgid "Start added torrents"
+msgstr "Byrja innlisin torrentir"
+
+#: ../src/trg-remote-prefs-dialog.c:675 ../src/trg-toolbar.c:247
+msgid "Remote Preferences"
+msgstr "Fjarstillingar"
+
+#: ../src/trg-remote-prefs-dialog.c:707 ../src/trg-torrent-props-dialog.c:408
+msgid "Bandwidth"
+msgstr "Bandbreidd"
+
+#: ../src/trg-remote-prefs-dialog.c:712 ../src/trg-torrent-props-dialog.c:635
+msgid "Limits"
+msgstr "Mørk"
+
+#: src/trg-state-selector.c:204
+msgid "Refresh"
+msgstr "Endurinnles"
+
+#: ../src/trg-rss-window.c:197 ../src/util.c:351
+#, c-format
+msgid "Request failed with HTTP code %d"
+msgstr "Umbøn miseydnaðist við HTTP svarkotu %d"
+
+#: ../src/trg-rss-window.c:214
+#, c-format
+msgid "Error parsing RSS feed \"%s\": %s"
+msgstr "RSS greiningarvilla \"%s\": %s"
+
+#: ../src/trg-state-selector.c:675
+msgid "All"
+msgstr "Allar"
+
+#: ../src/trg-state-selector.c:680 ../src/trg-state-selector.c:753
+msgid "Queue Down"
+msgstr "Niðurtøka í bíðirøð"
+
+#: ../src/trg-state-selector.c:687 ../src/trg-state-selector.c:757
+msgid "Queue Up"
+msgstr "Uppsending í bíðirøð"
+
+#: ../src/trg-state-selector.c:694
+msgid "Complete"
+msgstr "Liðugt"
+
+#: ../src/trg-state-selector.c:697
+msgid "Incomplete"
+msgstr "Óliðugt"
+
+#: ../src/trg-state-selector.c:700
+msgid "Active"
+msgstr "Virkið"
+
+#: ../src/trg-stats-dialog.c:296
+msgid "Statistics"
+msgstr "Hagtøl"
+
+#: ../src/trg-stats-dialog.c:315
+msgid "Version"
+msgstr "Útgáva"
+
+#: ../src/trg-stats-dialog.c:317
+msgid "Download Total"
+msgstr "Samlað niðurtøkið"
+
+#: ../src/trg-stats-dialog.c:319
+msgid "Upload Total"
+msgstr "Samlað uppsent"
+
+#: ../src/trg-stats-dialog.c:323
+msgid "Files Added"
+msgstr "Fílur innlagdar"
+
+#: ../src/trg-stats-dialog.c:325
+msgid "Session Count"
+msgstr "Setur"
+
+#: ../src/trg-stats-dialog.c:327
+msgid "Time Active"
+msgstr "Koyritíð"
+
+#: ../src/trg-stats-dialog.c:332
+msgid "Statistic"
+msgstr "Hagtal"
+
+#: ../src/trg-stats-dialog.c:334
+msgid "Session"
+msgstr "Seta"
+
+#: ../src/trg-stats-dialog.c:337
+msgid "Cumulative"
+msgstr "Samlað"
+
+#: ../src/trg-status-bar.c:145
+#, c-format
+msgid "Connected: %s :: %s"
+msgstr "Sambundin við: %s :: %s"
+
+#: ../src/trg-status-bar.c:163
+msgid "Updating torrents..."
+msgstr "Innlesur torrentir..."
+
+#: ../src/trg-status-bar.c:176
+#, c-format
+msgid "Free space: %s"
+msgstr "Tøkt pláss: %s"
+
+#: ../src/trg-status-bar.c:188
+msgid "Disable alternate speed limits"
+msgstr "Óvirkja tiltaksferðmørk"
+
+#: ../src/trg-status-bar.c:189
+msgid "Enable alternate speed limits"
+msgstr "Virkja tiltaksferðmørk"
+
+#: ../src/trg-status-bar.c:226 ../src/trg-status-bar.c:233
+#, c-format
+msgid " (Limit: %s)"
+msgstr " (Mark: %s)"
+
+#: ../src/trg-status-bar.c:238
+#, c-format
+msgid "Down: %s%s, Up: %s%s"
+msgstr "Niður: %s%s, Upp: %s%s"
+
+#: ../src/trg-torrent-add-dialog.c:392
+msgid "Torrent files"
+msgstr "Torrent-fílur"
+
+#: ../src/trg-torrent-add-dialog.c:397
+msgid "All files"
+msgstr "Allar fílur"
+
+#: ../src/trg-torrent-add-dialog.c:432
+msgid ""
+"Unable to parse torrent file. File preferences unavailable, but you can "
+"still try uploading it."
+msgstr ""
+"Bar ikki til at greina torrent fíluna. Tú kanst tó gera eina roynd at "
+"uppsenda hana hóast fílugreiningin ikki er tøk."
+
+#: ../src/trg-torrent-add-dialog.c:445
+#, c-format
+msgid "Unable to open torrent file: %s"
+msgstr "Bar ikki til at lata torrent fíluna upp: %s"
+
+#: ../src/trg-torrent-add-dialog.c:538
+msgid "(None)"
+msgstr "(Ongar)"
+
+#: ../src/trg-torrent-add-dialog.c:540
+msgid "(Multiple)"
+msgstr "(Fleiri)"
+
+#: ../src/trg-torrent-add-dialog.c:563
+msgid "Add a Torrent"
+msgstr "Legg torrent inn"
+
+#: ../src/trg-torrent-add-dialog.c:656 ../src/trg-files-tree-view-common.c:54
+msgid "High Priority"
+msgstr "Høgt raðfesti"
+
+#: ../src/trg-torrent-add-dialog.c:659 ../src/trg-files-tree-view-common.c:58
+msgid "Normal Priority"
+msgstr "Vanligt raðfesti"
+
+#: ../src/trg-torrent-add-dialog.c:662 ../src/trg-files-tree-view-common.c:62
+msgid "Low Priority"
+msgstr "Lágt raðfesti"
+
+#: ../src/trg-torrent-add-dialog.c:668 ../src/trg-files-tree-view-common.c:73
+msgid "Skip"
+msgstr "Leyp um"
+
+#. window
+#: ../src/trg-torrent-add-dialog.c:707
+msgid "Add Torrent"
+msgstr "Legg torrent inn"
+
+#: src/trg-torrent-add-dialog.c:593
+msgid "_Open"
+msgstr "_Innles"
+
+#: ../src/trg-torrent-add-dialog.c:730
+msgid "Start _paused"
+msgstr "Innles uttan at byrja"
+
+#: ../src/trg-torrent-add-dialog.c:747
+msgid "_Torrent file:"
+msgstr "_Torrent fíla:"
+
+#: ../src/trg-torrent-add-dialog.c:766
+msgid "_Destination folder:"
+msgstr "_Skjátta at goyma í:"
+
+#: ../src/trg-torrent-add-dialog.c:775
+msgid "Apply to all:"
+msgstr "Áset á allar fílur:"
+
+#: ../src/trg-torrent-add-dialog.c:777
+msgid "Torrent _priority:"
+msgstr "Torrent _raðfesti:"
+
+#: ../src/trg-torrent-add-dialog.c:893
+msgid "Show _options dialog"
+msgstr "Vís innleggingar_kostir"
+
+#: ../src/trg-torrent-add-url-dialog.c:65
+msgid ""
+"You are trying to add a magnet torrent, but DHT is disabled. Distributed "
+"Hash Table (DHT) should be enabled in remote settings."
+msgstr ""
+"Tú ert í ferð við at leggja eitt magnet torrent inn men DHT er óvirkt. Tú "
+"skuldi virkt útbýttar hash-talvur (DHT) undir fjarstillingum."
+
+#: ../src/trg-torrent-add-url-dialog.c:124
+msgid "URL:"
+msgstr "Leinkja:"
+
+#: ../src/trg-torrent-add-url-dialog.c:127
+msgid "Start Paused"
+msgstr "Innles uttan at byrja"
+
+#: ../src/trg-torrent-add-url-dialog.c:130
+msgid "Add torrent from URL"
+msgstr "Innles torrent frá leinkju"
+
+#: ../src/trg-torrent-graph.c:415
+msgid "Total Uploading"
+msgstr "Uppsendiferð tilsamans"
+
+#: ../src/trg-torrent-graph.c:423
+msgid "Total Downloading"
+msgstr "Niðurtøkuferð tilsamans"
+
+#: ../src/trg-torrent-model.c:407
+msgid "Default"
+msgstr "Forsett"
+
+#: ../src/trg-torrent-move-dialog.c:119 ../src/trg-torrent-props-dialog.c:255
+msgid "Location:"
+msgstr "Stað:"
+
+#: ../src/trg-torrent-move-dialog.c:166
+#, c-format
+msgid "Move %s"
+msgstr "Flyt %s"
+
+#: ../src/trg-torrent-move-dialog.c:168
+#, c-format
+msgid "Move %d torrents"
+msgstr "Flyt %d torrentir"
+
+#: ../src/trg-torrent-props-dialog.c:201
+msgid "Activity"
+msgstr "Virksemi"
+
+#: ../src/trg-torrent-props-dialog.c:206
+msgid "Torrent size:"
+msgstr "Torrent-stødd:"
+
+#: ../src/trg-torrent-props-dialog.c:211
+msgid "Have:"
+msgstr ""
+
+#: ../src/trg-torrent-props-dialog.c:216
+msgid "Downloaded:"
+msgstr "Niðurtikið:"
+
+#: ../src/trg-torrent-props-dialog.c:221
+msgid "Uploaded:"
+msgstr "Uppsent:"
+
+#: ../src/trg-torrent-props-dialog.c:226
+msgid "State:"
+msgstr "Støða:"
+
+#: ../src/trg-torrent-props-dialog.c:231
+msgid "Running time:"
+msgstr "Tíð virkin:"
+
+#: ../src/trg-torrent-props-dialog.c:236
+msgid "Remaining time:"
+msgstr "Tíð eftir:"
+
+#: ../src/trg-torrent-props-dialog.c:241
+msgid "Last activity:"
+msgstr "Seinast virkið:"
+
+#: ../src/trg-torrent-props-dialog.c:246
+msgid "Error:"
+msgstr "Villa:"
+
+#: ../src/trg-torrent-props-dialog.c:250
+msgid "Details"
+msgstr "Staklutir"
+
+#: ../src/trg-torrent-props-dialog.c:261
+msgid "Hash:"
+msgstr ""
+
+#: ../src/trg-torrent-props-dialog.c:267
+msgid "Privacy:"
+msgstr ""
+
+#: ../src/trg-torrent-props-dialog.c:273
+msgid "Origin:"
+msgstr "Uppruni:"
+
+#: ../src/trg-torrent-props-dialog.c:290
+msgid "Comment:"
+msgstr "Viðmerking:"
+
+#: ../src/trg-torrent-props-dialog.c:325
+msgid "Private to this tracker -- DHT and PEX disabled"
+msgstr "Privat til hendan rekjaran -- DHT og PEX er óvirkt"
+
+#: ../src/trg-torrent-props-dialog.c:327
+msgid "Public torrent"
+msgstr "Alment torrent"
+
+#: ../src/trg-torrent-props-dialog.c:337
+#, c-format
+msgid "Created by %1$s on %2$s"
+msgstr "%1$s framleiddi tann %2$s"
+
+#: ../src/trg-torrent-props-dialog.c:340
+#, c-format
+msgid "Created on %1$s"
+msgstr "Framleitt tann %1$s"
+
+#: ../src/trg-torrent-props-dialog.c:342
+#, c-format
+msgid "Created by %1$s"
+msgstr "Framleitt hevur %1$s"
+
+#: ../src/trg-torrent-props-dialog.c:375
+msgid "No errors"
+msgstr "Ongar villur"
+
+#: ../src/trg-torrent-props-dialog.c:379
+msgid "Active now"
+msgstr "Virkið nú"
+
+#: ../src/trg-torrent-props-dialog.c:412
+msgid "Honor global limits"
+msgstr "Bundið av heiltøkum mørkum"
+
+#: ../src/trg-torrent-props-dialog.c:422
+msgid "Torrent priority:"
+msgstr "Torrent raðfesti:"
+
+#: ../src/trg-torrent-props-dialog.c:428
+msgid "Queue Position:"
+msgstr "Pláss í bíðirøð:"
+
+#: ../src/trg-torrent-props-dialog.c:433
+msgid "Limit download speed (KiB/s)"
+msgstr "Avmarka niðurtøkuferð (KiB/s)"
+
+#: ../src/trg-torrent-props-dialog.c:441
+msgid "Limit upload speed (KiB/s)"
+msgstr "Avmarka uppsendiferð (KiB/s)"
+
+#: ../src/trg-torrent-props-dialog.c:449
+msgid "Use global settings"
+msgstr "Nýt heiltøka stilling"
+
+#: ../src/trg-torrent-props-dialog.c:450
+msgid "Stop seeding at ratio"
+msgstr "Steðga uppsending á lutfalli"
+
+#: ../src/trg-torrent-props-dialog.c:451
+msgid "Seed regardless of ratio"
+msgstr "Deil óansæð lutfall"
+
+#: ../src/trg-torrent-props-dialog.c:454
+msgid "Seed ratio mode:"
+msgstr "Deililutfalsstilling:"
+
+#: ../src/trg-torrent-props-dialog.c:462
+msgid "Seed ratio limit:"
+msgstr "Delilutfalsmark:"
+
+#: ../src/trg-torrent-props-dialog.c:468
+msgid "Peer limit:"
+msgstr "Javningamark:"
+
+#: ../src/trg-torrent-props-dialog.c:541
+#, c-format
+msgid "Multiple (%d) torrent properties"
+msgstr "Eginleikar torrentanna (%d)"
+
+#: ../src/trg-torrent-props-dialog.c:573
+msgid "Information"
+msgstr "Upplýsingar"
+
+#: ../src/trg-torrent-tree-view.c:64
+msgid "Done"
+msgstr "Liðið"
+
+#: ../src/trg-torrent-tree-view.c:69
+msgid "Seeds"
+msgstr "Deilarir"
+
+#: ../src/trg-torrent-tree-view.c:71
+msgid "Sending"
+msgstr "Uppsendarar"
+
+#: ../src/trg-torrent-tree-view.c:77
+msgid "Downloads"
+msgstr "Niðurtøkur"
+
+#: ../src/trg-torrent-tree-view.c:80
+msgid "Receiving"
+msgstr "Sambundnir niðurtakarar"
+
+#: ../src/trg-torrent-tree-view.c:84
+msgid "Connected"
+msgstr "Sambundnir javningar"
+
+#: ../src/trg-torrent-tree-view.c:86
+msgid "PEX Peers"
+msgstr "PEX javningar"
+
+#: ../src/trg-torrent-tree-view.c:91
+msgid "DHT Peers"
+msgstr "DHT javningar"
+
+#: ../src/trg-torrent-tree-view.c:97
+msgid "Tracker Peers"
+msgstr "Rekjarajavningar"
+
+#: ../src/trg-torrent-tree-view.c:101
+msgid "LTEP Peers"
+msgstr "LTEP javningar"
+
+#: ../src/trg-torrent-tree-view.c:106
+msgid "Resumed Peers"
+msgstr "Uppafturtiknir javningar"
+
+#: ../src/trg-torrent-tree-view.c:112
+msgid "Incoming Peers"
+msgstr "Inngangandi javningasambond"
+
+#: ../src/trg-torrent-tree-view.c:117
+msgid "Peers T/I/E/H/X/L/R"
+msgstr "Javningar T/I/E/H/X/L/R"
+
+#: ../src/trg-torrent-tree-view.c:137
+msgid "Added"
+msgstr "Innlagt"
+
+#: ../src/trg-torrent-tree-view.c:140
+msgid "First Tracker"
+msgstr "Fyrsti rekjari"
+
+#: ../src/trg-torrent-tree-view.c:146
+msgid "ID"
+msgstr "Eyðmerkingarnummar"
+
+#: ../src/trg-torrent-tree-view.c:152
+msgid "Queue Position"
+msgstr "Pláss í bíðirøð"
+
+#: ../src/trg-torrent-tree-view.c:158
+msgid "Last Active"
+msgstr "Seinast virkið"
+
+#: ../src/trg-trackers-tree-view.c:172
+msgid "Tier"
+msgstr "Lag"
+
+#: ../src/trg-trackers-tree-view.c:178
+msgid "Announce URL"
+msgstr "Fráboðanarleinkja"
+
+#: ../src/trg-trackers-tree-view.c:196
+msgid "Seeder Count"
+msgstr "Deilarir"
+
+#: ../src/trg-trackers-tree-view.c:199
+msgid "Leecher Count"
+msgstr "Niðurtakarar"
+
+#: ../src/trg-trackers-tree-view.c:203
+msgid "Last Announce"
+msgstr "Fráboðað seinast"
+
+#: ../src/trg-trackers-tree-view.c:206
+msgid "Last Result"
+msgstr "Seinasta úrslit"
+
+#: ../src/trg-trackers-tree-view.c:208
+msgid "Scrape URL"
+msgstr "Skavileinkja"
+
+#: ../src/trg-trackers-tree-view.c:210
+msgid "Last Scrape"
+msgstr "Seinast skavaður"
+
+#: ../src/trg-trackers-tree-view.c:309
+msgid "Delete"
+msgstr "Strika"
+
+#: ../src/trg-tree-view.c:281
+msgid "Ascending"
+msgstr "Hækkandi"
+
+#: ../src/trg-tree-view.c:291
+msgid "Descending"
+msgstr "Lækkandi"
+
+#: src/trg-files-tree-view-common.c:57
+msgid "Rename..."
+msgstr "Nýnevn…"
+
+#: ../src/trg-files-tree-view-common.c:80
+msgid "Expand All"
+msgstr "Lat fíluskrá upp"
+
+#: ../src/trg-files-tree-view-common.c:85
+msgid "Collapse All"
+msgstr "Loka fíluskrá"
+
+#: src/util.c:341
+#, c-format
+msgid "Request failed with HTTP code: %d"
+msgstr "Umbøn miseydnaðist. HTTP-kotu: %d"
+
+#: ../src/util.c:46
+msgid "KiB"
+msgstr "KiB"
+
+#: ../src/util.c:47
+msgid "MiB"
+msgstr "MiB"
+
+#: ../src/util.c:48
+msgid "GiB"
+msgstr "GiB"
+
+#: ../src/util.c:49
+msgid "TiB"
+msgstr "TiB"
+
+#: ../src/util.c:52
+msgid "KiB/s"
+msgstr "KiB/s"
+
+#: ../src/util.c:53
+msgid "MiB/s"
+msgstr "MiB/s"
+
+#: ../src/util.c:54
+msgid "GiB/s"
+msgstr "GiB/s"
+
+#: ../src/util.c:55
+msgid "TiB/s"
+msgstr "TiB/s"
+
+#: ../src/util.c:342
+msgid "JSON decoding error."
+msgstr "JSON greiningarvilla."
+
+#: ../src/util.c:347
+msgid "Server responded, but with no result."
+msgstr "Ambætarin svaraði, men uttan úrslit."
+
+#: ../src/util.c:385 ../src/util.c:531
+msgid "None"
+msgstr "Einki"
+
+#: ../src/util.c:431
+#, c-format
+msgid "%d day"
+msgid_plural "%d days"
+msgstr[0] "%d dagur"
+msgstr[1] "%d dagar"
+
+#: ../src/util.c:432
+#, c-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] "%d tími"
+msgstr[1] "%d tímar"
+
+#: ../src/util.c:434
+#, c-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] "%d minuttur"
+msgstr[1] "%d minuttir"
+
+#: ../src/util.c:437
+#, c-format
+msgid "%ld second"
+msgid_plural "%ld seconds"
+msgstr[0] "%ld sekund"
+msgstr[1] "%ld sekund"

--- a/po/fo.po
+++ b/po/fo.po
@@ -39,7 +39,7 @@ msgstr ""
 "Við Transmission Remote GTK kanst tú fjarumsita Transmission BitTorrent "
 "viðskiftaran umvegis RPC markamót hansara. Innles torrent fílur, byrja, "
 "steðga, strika, vátta og endurfráboða torrentir. Transmission Remote GTK "
-" virkar sum ein handfari fyri .torrent fílar (t.d. frá einum vevkaga)."
+" virkar sum ein handfari fyri .torrent fílur (t.d. frá einum vevkaga)."
 
 #: ../data/transmission-remote-gtk.appdata.xml.in.h:3
 msgid "Features:"
@@ -814,7 +814,7 @@ msgstr "Vís í stýrikervistøðuteiginum."
 
 #: src/trg-preferences-dialog.c:637
 msgid "System tray not supported."
-msgstr "Stýrikevistøðuteigafunka er ikki virkja í ritbúnaði."
+msgstr "Stýrikervistøðuteigafunka er ikki virkja í ritbúnaði."
 
 #: ../src/trg-preferences-dialog.c:776
 msgid "Minimise to system tray"
@@ -985,7 +985,7 @@ msgstr ""
 
 #: ../src/trg-remote-prefs-dialog.c:441
 msgid "Port is <span font_weight=\"bold\" fgcolor=\"red\">closed</span>"
-msgstr "Portrið er <span font_weight=\"bold\" fgcolor=\"red\">læst</span>"
+msgstr "Portrið er <span font_weight=\"bold\" fgcolor=\"red\">stongt</span>"
 
 #: ../src/trg-remote-prefs-dialog.c:457 ../src/trg-remote-prefs-dialog.c:526
 msgid "Port test"
@@ -1093,7 +1093,7 @@ msgstr "Atburður"
 
 #: ../src/trg-remote-prefs-dialog.c:639
 msgid "Rename partial files"
-msgstr "Navnaeftirfesti á ólidnar fílar"
+msgstr "Navnaeftirfest ólidnar fílur"
 
 #: ../src/trg-remote-prefs-dialog.c:644
 msgid "Trash original torrent files"

--- a/po/fo.po
+++ b/po/fo.po
@@ -394,12 +394,12 @@ msgstr "<big><b>Ynskir tú at strika %d torrentir?</b></big>"
 #: ../src/trg-main-window.c:925
 #, c-format
 msgid "<big><b>Remove and delete torrent \"%s\"?</b></big>"
-msgstr "<big><b>Ynskir tú at strika torrentið og dáturnar \"%s\"?</b></big>"
+msgstr "<big><b>Ynskir tú at strika torrentið \"%s\" og dáturnar?</b></big>"
 
-#: ../src/trg-main-window.c:927
+#: src/trg-main-window.c:698
 #, c-format
-msgid "<big><b>Remove and delete %d torrents?</b></big>"
-msgstr "<big><b>Ynskir tú at strika %d torrentir og teirra dátur?</b></big>"
+msgid "<big><b>%s %d torrents?</b></big>"
+msgstr "<big><b>%s %d torrentir og dátur teirra?</b></big>"
 
 #: src/trg-main-window.c:704 src/trg-torrent-add-dialog.c:487
 #: src/trg-torrent-add-dialog.c:592
@@ -412,7 +412,7 @@ msgstr "Strika t_orrent"
 
 #: src/trg-main-window.c:760
 msgid "Remove and delete"
-msgstr "Strika torrent og dátur"
+msgstr "Strika"
 
 #: src/trg-main-window.c:760
 msgid "_Delete"

--- a/po/fo.po
+++ b/po/fo.po
@@ -335,7 +335,7 @@ msgstr "Deililutfalsmark"
 
 #: ../src/trg-general-panel.c:344
 msgid "Corrupted"
-msgstr "Lýtt"
+msgstr "Avskeplað"
 
 #: ../src/trg-general-panel.c:347 ../src/trg-torrent-tree-view.c:67
 msgid "Status"
@@ -466,7 +466,7 @@ msgstr "Umbøn %d/%d miseydnaðist: %s"
 
 #: ../src/trg-main-window.c:2123
 msgid "No Limit"
-msgstr "Einki mark"
+msgstr "Óavmarkað"
 
 #: ../src/trg-main-window.c:2224 ../src/trg-menu-bar.c:712
 #: ../src/trg-toolbar.c:228

--- a/po/fo.po
+++ b/po/fo.po
@@ -741,7 +741,7 @@ msgstr "Innles einans virkin torrentir"
 
 #: ../src/trg-preferences-dialog.c:418
 msgid "Full update every (?) updates"
-msgstr "Innles øll fyri (?). hvørja innlesing"
+msgstr "Fulla innlesing (?). hvørja innlesing"
 
 #: ../src/trg-preferences-dialog.c:432
 msgid "Update interval:"

--- a/po/fo.po
+++ b/po/fo.po
@@ -890,7 +890,7 @@ msgstr "Vátta SSL-sertifikat"
 
 #: ../src/trg-preferences-dialog.c:885
 msgid "Timeout:"
-msgstr "Bíðitíð:"
+msgstr "Svarfreist:"
 
 #: ../src/trg-preferences-dialog.c:889
 msgid "Retries:"
@@ -1478,7 +1478,7 @@ msgstr "Nýt heiltøka stilling"
 
 #: ../src/trg-torrent-props-dialog.c:450
 msgid "Stop seeding at ratio"
-msgstr "Steðga uppsending á lutfalli"
+msgstr "Steðga deiling á lutfalli"
 
 #: ../src/trg-torrent-props-dialog.c:451
 msgid "Seed regardless of ratio"

--- a/po/fo.po
+++ b/po/fo.po
@@ -410,6 +410,14 @@ msgstr "_Angra"
 msgid "_Remove"
 msgstr "Strika t_orrent"
 
+#: src/trg-main-window.c:760
+msgid "Remove and delete"
+msgstr "Strika torrent og dátur"
+
+#: src/trg-main-window.c:760
+msgid "_Delete"
+msgstr "_Strika"
+
 #: ../src/trg-main-window.c:1026 ../src/trg-preferences-dialog.c:947
 #: ../src/trg-remote-prefs-dialog.c:697
 msgid "General"

--- a/po/fo.po
+++ b/po/fo.po
@@ -399,7 +399,7 @@ msgstr "<big><b>Ynskir tú at strika torrentið \"%s\" og dáturnar?</b></big>"
 #: src/trg-main-window.c:698
 #, c-format
 msgid "<big><b>%s %d torrents?</b></big>"
-msgstr "<big><b>%s %d torrentir og dátur teirra?</b></big>"
+msgstr "<big><b>%s %d torrentir?</b></big>"
 
 #: src/trg-main-window.c:704 src/trg-torrent-add-dialog.c:487
 #: src/trg-torrent-add-dialog.c:592
@@ -408,11 +408,11 @@ msgstr "_Angra"
 
 #: src/trg-main-window.c:740
 msgid "_Remove"
-msgstr "Strika t_orrent"
+msgstr "_Strika"
 
 #: src/trg-main-window.c:760
 msgid "Remove and delete"
-msgstr "Strika"
+msgstr "Strika dátur fyri"
 
 #: src/trg-main-window.c:760
 msgid "_Delete"
@@ -501,7 +501,7 @@ msgstr "Flyt"
 #: ../src/trg-main-window.c:2242 ../src/trg-menu-bar.c:743
 #: ../src/trg-toolbar.c:232
 msgid "Remove"
-msgstr "Strika torrent"
+msgstr "Strika"
 
 #: ../src/trg-main-window.c:2245 ../src/trg-menu-bar.c:749
 #: ../src/trg-toolbar.c:236

--- a/po/fo.po
+++ b/po/fo.po
@@ -6,7 +6,7 @@ msgstr ""
 "Project-Id-Version: transmission-remote-gtk\n"
 "Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
 "POT-Creation-Date: 2016-10-03 07:31+0000\n"
-"PO-Revision-Date: 2026-06-15 15:00+0000\n"
+"PO-Revision-Date: 2026-06-20 15:00+0000\n"
 "Last-Translator: krvi <Unknown>\n"
 "Language-Team: Faroese <fo@li.org>\n"
 "MIME-Version: 1.0\n"
@@ -1089,7 +1089,7 @@ msgstr "Skjátta til ólidnar niðurtøkur"
 
 #: ../src/trg-remote-prefs-dialog.c:623
 msgid "Torrent done script"
-msgstr "Skeljarrit at koyra tá torrentir eru liðug"
+msgstr "Koyr skeljarrit tá torrentir eru liðug"
 
 #: ../src/trg-remote-prefs-dialog.c:632
 msgid "Cache size (MiB)"
@@ -1246,8 +1246,8 @@ msgid ""
 "Unable to parse torrent file. File preferences unavailable, but you can "
 "still try uploading it."
 msgstr ""
-"Bar ikki til at greina torrent fíluna. Tú kanst tó gera eina roynd at "
-"uppsenda hana hóast fílugreiningin ikki er tøk."
+"Bar ikki til at greina torrent fíluna. Tú kanst tó royna at uppsenda hana"
+"hóast fílugreiningin ikki er tøk."
 
 #: ../src/trg-torrent-add-dialog.c:445
 #, c-format

--- a/po/fo.po
+++ b/po/fo.po
@@ -777,7 +777,7 @@ msgstr "Stýriboð"
 
 #: ../src/trg-preferences-dialog.c:617 ../src/trg-preferences-dialog.c:691
 msgid "Label"
-msgstr "Frámerki"
+msgstr "Spjaldur"
 
 #: ../src/trg-preferences-dialog.c:620
 msgid "Command"

--- a/po/fo.po
+++ b/po/fo.po
@@ -834,7 +834,7 @@ msgstr "Fráboðanir"
 
 #: ../src/trg-preferences-dialog.c:788
 msgid "Torrent added notifications"
-msgstr "Fráboða um innlagt torrent"
+msgstr "Fráboða um innløgd torrentir"
 
 #: ../src/trg-preferences-dialog.c:792
 msgid "Torrent complete notifications"

--- a/po/fo.po
+++ b/po/fo.po
@@ -6,7 +6,7 @@ msgstr ""
 "Project-Id-Version: transmission-remote-gtk\n"
 "Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
 "POT-Creation-Date: 2016-10-03 07:31+0000\n"
-"PO-Revision-Date: 2026-06-13 18:00+0000\n"
+"PO-Revision-Date: 2026-06-15 15:00+0000\n"
 "Last-Translator: krvi <Unknown>\n"
 "Language-Team: Faroese <fo@li.org>\n"
 "MIME-Version: 1.0\n"
@@ -834,11 +834,11 @@ msgstr "Fráboðanir"
 
 #: ../src/trg-preferences-dialog.c:788
 msgid "Torrent added notifications"
-msgstr "Fráboða um innløgd torrentir"
+msgstr "Fráboða um nýinnløgd torrentir"
 
 #: ../src/trg-preferences-dialog.c:792
 msgid "Torrent complete notifications"
-msgstr "Fráboða um liðug torrentir"
+msgstr "Fráboða um nýliga liðug torrentir"
 
 #: ../src/trg-preferences-dialog.c:819
 msgid "Profile: "


### PR DESCRIPTION
Over the past few weeks I've worked on this translation over on [Launchpad](https://translations.launchpad.net/transmission-remote-gtk/) but since the translations have not been syncronized with Launchpad since the end of 2022 added them via my own fork. Since they have not been in sync for so long I've also added the new strings and made further corrections.