### PR TITLE
Fix UI blocklist string construction for translation

### DIFF
--- a/po/fo.po
+++ b/po/fo.po
@@ -1008,8 +1008,8 @@ msgid "Update"
 msgstr "Dagfør"
 
 #: ../src/trg-remote-prefs-dialog.c:478 ../src/trg-remote-prefs-dialog.c:572
-msgid "Blocklist (%"
-msgstr "Svartalisti (%"
+msgid "Blocklist (%lld entries)"
+msgstr "Svartalisti (%lld skrásetingar)"
 
 #: ../src/trg-remote-prefs-dialog.c:520 ../src/trg-remote-prefs-dialog.c:702
 msgid "Connections"

--- a/src/trg-remote-prefs-dialog.c
+++ b/src/trg-remote-prefs-dialog.c
@@ -528,8 +528,8 @@ static GtkWidget *trg_rprefs_connPage(TrgRemotePrefsDialog *win, JsonObject *s)
 
     hig_workarea_add_section_title(t, &row, _("Blocklist"));
 
-    stringValue = g_strdup_printf(_("Blocklist (%lld entries)"),
-                                  (long long)session_get_blocklist_size(s));
+    stringValue
+        = g_strdup_printf(_("Blocklist (%lld entries)"), (long long)session_get_blocklist_size(s));
     tb = win->blocklist_check
         = trg_json_widget_check_new(&win->widgets, s, SGET_BLOCKLIST_ENABLED, stringValue, NULL);
     g_free((gchar *)stringValue);

--- a/src/trg-remote-prefs-dialog.c
+++ b/src/trg-remote-prefs-dialog.c
@@ -445,8 +445,8 @@ static gboolean on_blocklist_updated(gpointer data)
         if (response->status == SOUP_STATUS_OK) {
             JsonObject *args = get_arguments(response->obj);
             gchar *labelText
-                = g_strdup_printf(_("Blocklist (%" G_GINT64_FORMAT " entries)"),
-                                  json_object_get_int_member(args, SGET_BLOCKLIST_SIZE));
+                = g_strdup_printf(_("Blocklist (%lld entries)"),
+                                  (long long)json_object_get_int_member(args, SGET_BLOCKLIST_SIZE));
             gtk_button_set_label(GTK_BUTTON(self->blocklist_check), labelText);
             g_free(labelText);
         } else {
@@ -528,8 +528,8 @@ static GtkWidget *trg_rprefs_connPage(TrgRemotePrefsDialog *win, JsonObject *s)
 
     hig_workarea_add_section_title(t, &row, _("Blocklist"));
 
-    stringValue = g_strdup_printf(_("Blocklist (%" G_GINT64_FORMAT " entries)"),
-                                  session_get_blocklist_size(s));
+    stringValue = g_strdup_printf(_("Blocklist (%lld entries)"),
+                                  (long long)session_get_blocklist_size(s));
     tb = win->blocklist_check
         = trg_json_widget_check_new(&win->widgets, s, SGET_BLOCKLIST_ENABLED, stringValue, NULL);
     g_free((gchar *)stringValue);


### PR DESCRIPTION
The label text `Blocklist (n entries)` in the remote preferences dialog was not being translated due to the way the string was constructed prior to translation. This PR makes the string a translatable format string literal, and adjusts the translation for a language I know.