### PR TITLE
Set prgname to application ID

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -50,6 +50,7 @@ static void bindtext_wrapper(void)
 int main(int argc, char *argv[])
 {
     g_set_application_name(PACKAGE_NAME);
+    g_set_prgname(APPLICATION_ID);
     bindtext_wrapper();
 
     g_autoptr(TrgClient) client = trg_client_new();


### PR DESCRIPTION
Using the application ID ensures that Wayland compositors could match the window with the application and show the appropriate icon for them.

References:
- https://honk.sigxcpu.org/con/GTK__and_the_application_id.html
- https://docs.gtk.org/gtk4/migrating-3to4.html#set-a-proper-application-id